### PR TITLE
Few steps forward vm_tests

### DIFF
--- a/src/block_types.nim
+++ b/src/block_types.nim
@@ -15,6 +15,6 @@ type
     elements: seq[T] # TODO
 
   Block* = ref object of RootObj
-    header*: Header
-    uncles*: CountableList[Header]
+    header*: BlockHeader
+    uncles*: CountableList[BlockHeader]
     blockNumber*: UInt256

--- a/src/block_types.nim
+++ b/src/block_types.nim
@@ -6,7 +6,9 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  logging, constants, utils / header, ttmath
+  ttmath,
+  ./logging, ./constants,
+  ./utils/header
 
 type
   CountableList*[T] = ref object

--- a/src/chain.nim
+++ b/src/chain.nim
@@ -19,7 +19,7 @@ type
     header*: BlockHeader
     logger*: Logger
     networkId*: string
-    vmsByRange*: seq[tuple[blockNumber: Int256, vmk: VMkind]] # TODO: VM should actually be a runtime typedesc(VM)
+    vmsByRange*: seq[tuple[blockNumber: UInt256, vmk: VMkind]] # TODO: VM should actually be a runtime typedesc(VM)
     importBlock*: bool
     validateBlock*: bool
     db*: BaseChainDB
@@ -45,7 +45,7 @@ type
     code*: string
 
 
-proc configureChain*(name: string, blockNumber: Int256, vmk: VMKind, importBlock: bool = true, validateBlock: bool = true): Chain =
+proc configureChain*(name: string, blockNumber: UInt256, vmk: VMKind, importBlock: bool = true, validateBlock: bool = true): Chain =
   new(result)
   result.vmsByRange = @[(blockNumber: blockNumber, vmk: vmk)]
   result.importBlock = importBlock
@@ -74,7 +74,7 @@ proc fromGenesis*(
   # TODO
   # chainDB.persistBlockToDB(result.getBlock)
 
-proc getVMClassForBlockNumber*(chain: Chain, blockNumber: Int256): VMKind =
+proc getVMClassForBlockNumber*(chain: Chain, blockNumber: UInt256): VMKind =
   ## Returns the VM class for the given block number
   # TODO should the return value be a typedesc?
 
@@ -93,4 +93,7 @@ proc getVM*(chain: Chain, header: BlockHeader = nil): VM =
     let header = chain.header # shadowing input param
 
 
-  # let vm_class = chain.getVMClassForBlockNumber(header.blockNumber)
+  let vm_class = chain.getVMClassForBlockNumber(header.blockNumber)
+
+  # case vm_class:
+  # of vmkFrontier: result =

--- a/src/chain.nim
+++ b/src/chain.nim
@@ -7,12 +7,10 @@
 
 import
   tables, ttmath,
-  logging, constants, errors, validation, utils / hexadecimal, vm / base, db / db_chain
+  ./logging, ./constants, ./errors, ./validation, ./utils/hexadecimal, ./vm/base, ./db/db_chain,
+  ./utils/header
 
 type
-  BlockHeader* = ref object
-    # Placeholder TODO
-
   Chain* = ref object
     ## An Chain is a combination of one or more VM classes.  Each VM is associated
     ## with a range of blocks.  The Chain class acts as a wrapper around these other
@@ -95,3 +93,4 @@ proc getVM*(chain: Chain, header: BlockHeader = nil): VM =
     let header = chain.header # shadowing input param
 
 
+  # let vm_class = chain.getVMClassForBlockNumber(header.blockNumber)

--- a/src/chain.nim
+++ b/src/chain.nim
@@ -81,7 +81,7 @@ proc getVMClassForBlockNumber*(chain: Chain, blockNumber: UInt256): VMKind =
   # TODO: validate_block_number
   for idx in countdown(chain.vmsByRange.high, chain.vmsByRange.low):
     let (n, vmk) = chain.vmsByRange[idx]
-    if blockNumber > n:
+    if blockNumber >= n:
       return vmk
 
   raise newException(ValueError, "VM not found for block #" & $blockNumber) # TODO: VMNotFound exception

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -233,9 +233,9 @@ let
 
   EMPTY_UNCLE_HASH* =             "\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a\xd3\x12E\x1b\x94\x8at\x13\xf0\xa1B\xfd@\xd4\x93G"
 
-  GENESIS_BLOCK_NUMBER* =         0.u256
-  GENESIS_DIFFICULTY* =           131_072.u256
-  GENESIS_GAS_LIMIT* =            3_141_592.u256
+  GENESIS_BLOCK_NUMBER* =         0.i256
+  GENESIS_DIFFICULTY* =           131_072.i256
+  GENESIS_GAS_LIMIT* =            3_141_592.i256
   GENESIS_PARENT_HASH* =          ZERO_HASH32
   GENESIS_COINBASE* =             ZERO_ADDRESS
   GENESIS_NONCE* =                "\x00\x00\x00\x00\x00\x00\x00B"

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -233,9 +233,9 @@ let
 
   EMPTY_UNCLE_HASH* =             "\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a\xd3\x12E\x1b\x94\x8at\x13\xf0\xa1B\xfd@\xd4\x93G"
 
-  GENESIS_BLOCK_NUMBER* =         0.i256
-  GENESIS_DIFFICULTY* =           131_072.i256
-  GENESIS_GAS_LIMIT* =            3_141_592.i256
+  GENESIS_BLOCK_NUMBER* =         0.u256
+  GENESIS_DIFFICULTY* =           131_072.u256
+  GENESIS_GAS_LIMIT* =            3_141_592.u256
   GENESIS_PARENT_HASH* =          ZERO_HASH32
   GENESIS_COINBASE* =             ZERO_ADDRESS
   GENESIS_NONCE* =                "\x00\x00\x00\x00\x00\x00\x00B"

--- a/src/runner.nim
+++ b/src/runner.nim
@@ -33,7 +33,7 @@ var c = BaseComputation(
   vmState: BaseVMState(
     prevHeaders: @[],
     chaindb: BaseChainDB(),
-    blockHeader: Header(),
+    blockHeader: BlockHeader(),
     name: "zero"),
   msg: msg,
   memory: mem,

--- a/src/utils/header.nim
+++ b/src/utils/header.nim
@@ -10,6 +10,7 @@ import ../constants, ttmath, strformat, times, ../validation
 
 type
   Header* = ref object
+    # Note: this is defined in evm/rlp/headers in the original repo
     timestamp*: EthTime
     difficulty*: UInt256
     blockNumber*: UInt256
@@ -17,8 +18,7 @@ type
     unclesHash*: string
     coinbase*: string
     stateRoot*: string
-
-  # TODO
+    # TODO: incomplete
 
 proc hasUncles*(header: Header): bool = header.uncles_hash != EMPTY_UNCLE_HASH
 

--- a/src/vm/base.nim
+++ b/src/vm/base.nim
@@ -25,7 +25,7 @@ type
     state*: BaseVMState
     `block`*: Block
 
-proc newVM*(header: Header, chainDB: BaseChainDB): VM =
+proc newVM*(header: BlockHeader, chainDB: BaseChainDB): VM =
   new(result)
   result.chainDB = chainDB
 

--- a/src/vm/base.nim
+++ b/src/vm/base.nim
@@ -9,6 +9,11 @@ import
   ../logging, ../constants, ../errors, ../transaction, ../types, ../computation, ../block_obj, ../vm_state, ../vm_state_transactions, ../db/db_chain, ../utils/header
 
 type
+  VMkind* = enum
+    ## List of VMs forks (py-evm vm_class) of the Ethereum network
+    # TODO: used in Chain.vmsByRange: can we store the runtimetime in a seq/tuple instead?
+    vmkFrontier, vmkHomestead, vmkTangerineWhistle, vmkSpuriousDragon, vmkByzantium
+
   VM* = ref object of RootObj
     # The VM class represents the Chain rules for a specific protocol definition
     # such as the Frontier or Homestead network.  Defining an Chain  defining

--- a/src/vm/base.nim
+++ b/src/vm/base.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  ../logging, ../constants, ../errors, ../transaction, ../types, ../computation, ../block_obj, ../vm_state, ../vm_state_transactions, ../db/db_chain, ../utils/header
+  ../logging, ../constants, ../errors, ../transaction, ../types, ../computation, ../block_types, ../vm_state, ../vm_state_transactions, ../db/db_chain, ../utils/header
 
 type
   VMkind* = enum

--- a/src/vm/forks/frontier/frontier_block.nim
+++ b/src/vm/forks/frontier/frontier_block.nim
@@ -7,7 +7,7 @@
 
 import
   ../../../logging, ../../../constants, ../../../errors, ../../../transaction,
-  ../../../block_obj,
+  ../../../block_types,
   ../../../utils/header
 
 type

--- a/src/vm/forks/frontier/frontier_block.nim
+++ b/src/vm/forks/frontier/frontier_block.nim
@@ -11,7 +11,7 @@ import
   ../../../utils/header
 
 type
-  FrontierBlock* = object of Block
+  FrontierBlock* = ref object of Block
     # bloomFilter*: BloomFilter
     # header*: BlockHeader
     transactions*: seq[BaseTransaction]
@@ -25,13 +25,13 @@ type
 #   rlp, rlp.sedes, eth_bloom, evm.constants, evm.rlp.receipts, evm.rlp.blocks,
 #   evm.rlp.headers, evm.utils.keccak, transactions
 
-# method makeFrontierBlock*(header: auto; transactions: auto; uncles: void): auto =
-#   if transactions is None:
-#     transactions = @[]
-#   if uncles is None:
-#     uncles = @[]
-#   result.bloomFilter = BloomFilter(header.bloom)
-#   super(FrontierBlock, result).__init__()
+proc makeFrontierBlock*(header: BlockHeader; transactions: seq[BaseTransaction]; uncles: void): FrontierBlock =
+  new result
+  if transactions.len == 0:
+    result.transactions = @[]
+  # if uncles is None:
+  #   uncles = @[]
+  # result.bloomFilter = BloomFilter(header.bloom)
 
 # method number*(self: FrontierBlock): int =
 #   return self.header.blockNumber

--- a/src/vm/forks/frontier/frontier_headers.nim
+++ b/src/vm/forks/frontier/frontier_headers.nim
@@ -8,21 +8,21 @@
 import
   logging, constants, errors, validation, utils/header, vm / forks / frontier / vm
 
-method computeDifficulty*(parentHeader: Header, timestamp: int): Int256 =
-  validateGt(timestamp, parentHeader.timestamp, title="Header timestamp")
+method computeDifficulty*(parentHeader: BlockHeader, timestamp: int): Int256 =
+  validateGt(timestamp, parentHeader.timestamp, title="BlockHeader timestamp")
   let offset = parentHeader.difficulty div DIFFICULTY_ADJUSTMENT_DENOMINATOR
   # We set the minimum to the lowest of the protocol minimum and the parent
   # minimum to allow for the initial frontier *warming* period during which
   # the difficulty begins lower than the protocol minimum
   let difficultyMinimum = min(parentHeader.difficulty, DIFFICULTY_MINIMUM)
   # let test = (timestamp - parentHeader.timestamp).Int256 < FRONTIER_DIFFICULTY_ADJUSTMENT_CUTOFF
-  # let baseDifficulty = max(parent.Header.difficulty + (if test: offset else: -offset), difficultyMinimum)
+  # let baseDifficulty = max(parent.BlockHeader.difficulty + (if test: offset else: -offset), difficultyMinimum)
   # # Adjust for difficulty bomb
   # let numBombPeriods = ((parentHeader.blockNumber + 1) div BOMB_EXPONENTIAL_PERIOD) - BOMB_EXPONENTIAL_FREE_PERIODS
   # result = if numBombPeriods >= 0: max(baseDifficulty + 2.Int256 ^ numBombPeriods, DIFFICULTY_MINIMUM) else: baseDifficulty
   result = 0.Int256
 
-method createHeaderFromParent*(parentHeader: Header): Header =
+method createHeaderFromParent*(parentHeader: BlockHeader): BlockHeader =
   # TODO
-  result = Header()
+  result = BlockHeader()
 

--- a/src/vm/forks/frontier/frontier_vm_state.nim
+++ b/src/vm/forks/frontier/frontier_vm_state.nim
@@ -20,7 +20,7 @@ proc newFrontierVMState*: FrontierVMState =
   result.prevHeaders = @[]
   result.name = "FrontierVM"
   result.accessLogs = newAccessLogs()
-  result.blockHeader = Header(hash: "TODO", coinbase: "TODO", stateRoot: "TODO")
+  result.blockHeader = BlockHeader(hash: "TODO", coinbase: "TODO", stateRoot: "TODO")
 
 # import
 #   py2nim_helpers, __future__, rlp, evm, evm.constants, evm.exceptions, evm.rlp.logs,

--- a/src/vm/forks/frontier/vm.nim
+++ b/src/vm/forks/frontier/vm.nim
@@ -8,7 +8,7 @@
 import
   ../../../logging, ../../../constants, ../../../errors,
   ttmath,
-  ../../../block_obj,
+  ../../../block_types,
   ../../../vm/[base, stack], ../../../db/db_chain,  ../../../utils/header,
   ./frontier_block, ./frontier_vm_state, ./frontier_validation
 

--- a/src/vm/forks/frontier/vm.nim
+++ b/src/vm/forks/frontier/vm.nim
@@ -29,7 +29,7 @@ method getUncleReward(vm: FrontierVM, blockNumber: UInt256, uncle: Block): UInt2
 method getNephewReward(vm: FrontierVM): UInt256 =
   vm.getBlockReward() div 32
 
-proc newFrontierVM*(header: Header, chainDB: BaseChainDB): FrontierVM =
+proc newFrontierVM*(header: BlockHeader, chainDB: BaseChainDB): FrontierVM =
   new(result)
   result.chainDB = chainDB
   result.isStateless = true

--- a/src/vm/forks/frontier/vm.nim
+++ b/src/vm/forks/frontier/vm.nim
@@ -34,3 +34,4 @@ proc newFrontierVM*(header: BlockHeader, chainDB: BaseChainDB): FrontierVM =
   result.chainDB = chainDB
   result.isStateless = true
   result.state = newFrontierVMState()
+  result.`block` = makeFrontierBlock(header, @[])

--- a/src/vm_state.nim
+++ b/src/vm_state.nim
@@ -8,7 +8,7 @@
 import
   macros, strformat, tables,
   ttmath,
-  ./logging, ./constants, ./errors, ./transaction, ./db/db_chain, ./utils/state, ./utils/header
+  ./logging, ./constants, ./errors, ./transaction, ./db/[db_chain, state_db], ./utils/state, ./utils/header
 
 type
   BaseVMState* = ref object of RootObj
@@ -98,3 +98,6 @@ macro db*(vmState: untyped, readOnly: untyped, handler: untyped): untyped =
       # leaving the context.
       # TODO `db`.db = nil
       # state._trie = None
+
+proc readOnlyStateDB*(vmState: BaseVMState): AccountStateDB {.inline.}=
+  vmState.chaindb.getStateDb("", readOnly = true)

--- a/src/vm_state.nim
+++ b/src/vm_state.nim
@@ -7,7 +7,8 @@
 
 import
   macros, strformat, tables,
-  logging, constants, ttmath, errors, transaction, db/db_chain, utils/state, utils/header
+  ttmath,
+  ./logging, ./constants, ./errors, ./transaction, ./db/db_chain, ./utils/state, ./utils/header
 
 type
   BaseVMState* = ref object of RootObj

--- a/src/vm_state.nim
+++ b/src/vm_state.nim
@@ -12,11 +12,11 @@ import
 
 type
   BaseVMState* = ref object of RootObj
-    prevHeaders*: seq[Header]
+    prevHeaders*: seq[BlockHeader]
     # receipts*:
     chaindb*: BaseChainDB
     accessLogs*: AccessLogs
-    blockHeader*: Header
+    blockHeader*: BlockHeader
     name*: string
 
   AccessLogs* = ref object
@@ -41,7 +41,7 @@ proc newBaseVMState*: BaseVMState =
   result.prevHeaders = @[]
   result.name = "BaseVM"
   result.accessLogs = newAccessLogs()
-  result.blockHeader = Header(hash: "TODO", coinbase: "TODO", stateRoot: "TODO")
+  result.blockHeader = BlockHeader(hash: "TODO", coinbase: "TODO", stateRoot: "TODO")
 
 method logger*(vmState: BaseVMState): Logger =
   logging.getLogger(&"evm.vmState.{vmState.name}")

--- a/src/vm_state_transactions.nim
+++ b/src/vm_state_transactions.nim
@@ -9,7 +9,7 @@ import
   strformat, tables,
   logging, constants, errors, computation, transaction, types, vm_state, block_types, db / db_chain, utils / [state, header]
 
-method executeTransaction(vmState: var BaseVMState, transaction: BaseTransaction): (BaseComputation, Header) =
+method executeTransaction(vmState: var BaseVMState, transaction: BaseTransaction): (BaseComputation, BlockHeader) =
   # Execute the transaction in the vm
   raise newException(ValueError, "Must be implemented by subclasses")
 

--- a/src/vm_state_transactions.nim
+++ b/src/vm_state_transactions.nim
@@ -9,8 +9,11 @@ import
   strformat, tables,
   logging, constants, errors, computation, transaction, types, vm_state, block_types, db / db_chain, utils / [state, header]
 
-method executeTransaction(vmState: var BaseVMState, transaction: BaseTransaction): (BaseComputation, BlockHeader) =
+method executeTransaction(vmState: var BaseVMState, transaction: BaseTransaction): (BaseComputation, BlockHeader) {.base.}=
   # Execute the transaction in the vm
+  # TODO: introduced here: https://github.com/ethereum/py-evm/commit/21c57f2d56ab91bb62723c3f9ebe291d0b132dde
+  # Refactored/Removed here: https://github.com/ethereum/py-evm/commit/cc991bf
+  # Deleted here: https://github.com/ethereum/py-evm/commit/746defb6f8e83cee2c352a0ab8690e1281c4227c
   raise newException(ValueError, "Must be implemented by subclasses")
 
 

--- a/src/vm_state_transactions.nim
+++ b/src/vm_state_transactions.nim
@@ -7,7 +7,7 @@
 
 import
   strformat, tables,
-  logging, constants, errors, computation, transaction, types, vm_state, block_obj, db / db_chain, utils / [state, header]
+  logging, constants, errors, computation, transaction, types, vm_state, block_types, db / db_chain, utils / [state, header]
 
 method executeTransaction(vmState: var BaseVMState, transaction: BaseTransaction): (BaseComputation, Header) =
   # Execute the transaction in the vm

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -9,7 +9,7 @@ import  ./test_code_stream,
         ./test_gas_meter,
         ./test_memory,
         ./test_stack,
-        ./test_opcode,
-        ./test_vm
+        ./test_opcode
+        # ./test_vm
 
 

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -9,6 +9,7 @@ import  ./test_code_stream,
         ./test_gas_meter,
         ./test_memory,
         ./test_stack,
-        ./test_opcode
+        ./test_opcode,
+        ./test_vm
 
 

--- a/tests/fixtures.nim
+++ b/tests/fixtures.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, strformat, tables,
+  unittest, strformat, tables, times,
   ttmath,
   ../src/[constants, chain, vm/forks/frontier/vm, utils/header, utils/address, db/db_chain, db/backends/memory_backend]
 
@@ -24,7 +24,7 @@ proc chainWithoutBlockValidation*: Chain =
     nonce: GENESIS_NONCE,
     mixHash: GENESIS_MIX_HASH,
     extraData: GENESIS_EXTRA_DATA,
-    timestamp: 1501851927,
+    timestamp: fromUnix 1501851927,
     stateRoot: "0x9d354f9b5ba851a35eced279ef377111387197581429cfcc7f744ef89a30b5d4") #.decodeHex)
   let genesisState = {"fundedAddr": FundedAddress(balance: initialBalance.int256, nonce: 0, code: "")}.toTable()
   result = fromGenesis(

--- a/tests/fixtures.nim
+++ b/tests/fixtures.nim
@@ -5,9 +5,12 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import unittest, strformat, tables, constants, chain, ttmath, vm / forks / frontier / vm, utils / [header, address], db / db_chain, db / backends / memory_backend
+import
+  unittest, strformat, tables,
+  ttmath,
+  ../src/[constants, chain, vm/forks/frontier/vm, utils/header, utils/address, db/db_chain, db/backends/memory_backend]
 
-proc chainWithoutBlockValidation: Chain =
+proc chainWithoutBlockValidation*: Chain =
   result = configureChain("TestChain", GENESIS_BLOCK_NUMBER, newFrontierVM(Header(), newBaseChainDB(newMemoryDB())), false, false)
   let privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" # TODO privateKey(decodeHex("0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"))
   let fundedAddr = privateKey # privateKey.publicKey.toCanonicalAddress

--- a/tests/fixtures.nim
+++ b/tests/fixtures.nim
@@ -8,10 +8,10 @@
 import
   unittest, strformat, tables, times,
   ttmath,
-  ../src/[constants, chain, vm/forks/frontier/vm, utils/header, utils/address, db/db_chain, db/backends/memory_backend]
+  ../src/[constants, chain, vm/base, vm/forks/frontier/vm, utils/header, utils/address, db/db_chain, db/backends/memory_backend]
 
 proc chainWithoutBlockValidation*: Chain =
-  result = configureChain("TestChain", GENESIS_BLOCK_NUMBER, newFrontierVM(Header(), newBaseChainDB(newMemoryDB())), false, false)
+  result = configureChain("TestChain", GENESIS_BLOCK_NUMBER, vmkFrontier, false, false)
   let privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" # TODO privateKey(decodeHex("0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"))
   let fundedAddr = privateKey # privateKey.publicKey.toCanonicalAddress
   let initialBalance = 100_000_000

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -95,16 +95,18 @@ proc getHexadecimalInt*(j: JsonNode): int =
 
 method newTransaction*(
   vm: VM, addr_from, addr_to: string,
-  amount: Int256,
+  amount: UInt256,
   private_key: string,
-  gas_price = 10.i256,
-  gas = 100000.i256,
+  gas_price = 10.u256,
+  gas = 100000.u256,
   data: seq[byte] = @[]
 ): BaseTransaction =
-  # TODO
+  # TODO: amount should be an Int to deal with negatives
+  new result
 
   # Todo getStateDB is incomplete
-  let nonce = vm.state.chaindb.getStateDb("", readOnly = true).getNonce(addr_from)
+  let nonce = vm.state.readOnlyStateDB.getNonce(addr_from)
 
+  # TODO
   # if !private key: create_unsigned_transaction
   # else: create_signed_transaction

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -10,7 +10,8 @@ import
   ttmath,
   ../src/utils/[hexadecimal, address, padding],
   ../src/[chain, vm_state, constants],
-  ../src/db/[db_chain, state_db], ../src/vm/forks/frontier/vm
+  ../src/db/[db_chain, state_db], ../src/vm/forks/frontier/vm,
+  ../src/vm/base, ../src/transaction
 
 type
   Status* {.pure.} = enum OK, Fail, Skip
@@ -91,3 +92,19 @@ proc setupStateDB*(desiredState: JsonNode, stateDB: var AccountStateDB) =
 
 proc getHexadecimalInt*(j: JsonNode): int =
   discard parseHex(j.getStr, result)
+
+method newTransaction*(
+  vm: VM, addr_from, addr_to: string,
+  amount: Int256,
+  private_key: string,
+  gas_price = 10.i256,
+  gas = 100000.i256,
+  data: seq[byte] = @[]
+): BaseTransaction =
+  # TODO
+
+  # Todo getStateDB is incomplete
+  let nonce = vm.state.chaindb.getStateDb("", readOnly = true).getNonce(addr_from)
+
+  # if !private key: create_unsigned_transaction
+  # else: create_signed_transaction

--- a/tests/test_opcode.nim
+++ b/tests/test_opcode.nim
@@ -17,8 +17,8 @@ import
 
 
 proc testCode(code: string, gas: UInt256): BaseComputation =
-  var vm = newFrontierVM(Header(), newBaseChainDB(newMemoryDB()))
-  let header = Header()
+  var vm = newFrontierVM(BlockHeader(), newBaseChainDB(newMemoryDB()))
+  let header = BlockHeader()
     # coinbase: "",
     # difficulty: fixture{"env"}{"currentDifficulty"}.getHexadecimalInt.u256,
     # blockNumber: fixture{"env"}{"currentNumber"}.getHexadecimalInt.u256,

--- a/tests/test_vm.nim
+++ b/tests/test_vm.nim
@@ -6,18 +6,19 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest,
+  unittest, ttmath,
   ./test_helpers, ./fixtures,
-  ../src/[db/backends/memory_backend, chain, constants, utils/hexadecimal]
+  ../src/[db/backends/memory_backend, chain, constants, utils/hexadecimal],
+  ../src/[vm/base, computation]
 
 suite "VM":
-  test "Sanity check with no validation":
+  test "Apply transaction with no validation":
     var
       chain = chainWithoutBlockValidation()
       vm = chain.getVM()
-      txIdx = len(vm.`block`.transactions)
+      # txIdx = len(vm.`block`.transactions) # Can't take len of a runtime field
       recipient = decodeHex("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c")
-      amount = 100.Int256
+      amount = 100.i256
 
     var ethaddr_from = chain.fundedAddress
     var tx = newTransaction(vm, ethaddr_from, recipient, amount, chain.fundedAddressPrivateKey)
@@ -27,10 +28,10 @@ suite "VM":
     check(not computation.isError)
 
     var txGas = tx.gasPrice * constants.GAS_TX
-    inDb(vm.state.stateDb(readOnly=true)):
-      check(db.getBalance(ethaddr_from) == chain.fundedAddressInitialBalance - amount - txGas)
-      check(db.getBalance(recipient) == amount)
-    var b = vm.`block`
-    check(b.transactions[txIdx] == tx)
-    check(b.header.gasUsed == constants.GAS_TX)
+    # inDb(vm.state.stateDb(readOnly=true)):
+    #   check(db.getBalance(ethaddr_from) == chain.fundedAddressInitialBalance - amount - txGas)
+    #   check(db.getBalance(recipient) == amount)
+    # var b = vm.`block`
+    # check(b.transactions[txIdx] == tx)
+    # check(b.header.gasUsed == constants.GAS_TX)
 

--- a/tests/test_vm.nim
+++ b/tests/test_vm.nim
@@ -7,19 +7,20 @@
 
 import
   unittest,
-  test_helpers, .. / src / [db / backends / memory, db / chain, constants, utils / hexadecimal]
+  ./test_helpers, ./fixtures,
+  ../src/[db/backends/memory_backend, chain, constants, utils/hexadecimal]
 
-suite "vm":
-  test "apply no validation":
+suite "VM":
+  test "Sanity check with no validation":
     var
-      chain = testChain()
+      chain = chainWithoutBlockValidation()
       vm = chain.getVM()
-      txIdx = len(vm.`block`.transactions)
+      txIdx = len(vm.block.transactions)
       recipient = decodeHex("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c")
       amount = 100.Int256
 
-    var from = chain.fundedAddress
-    var tx = newTransaction(vm, from, recipient, amount, chain.fundedAddressPrivateKey)
+    var ethaddr_from = chain.fundedAddress
+    var tx = newTransaction(vm, ethaddr_from, recipient, amount, chain.fundedAddressPrivateKey)
     var (computation, _) = vm.applyTransaction(tx)
     var accessLogs = computation.vmState.accessLogs
 
@@ -27,7 +28,7 @@ suite "vm":
 
     var txGas = tx.gasPrice * constants.GAS_TX
     inDb(vm.state.stateDb(readOnly=true)):
-      check(db.getBalance(from) == chain.fundedAddressInitialBalance - amount - txGas)
+      check(db.getBalance(ethaddr_from) == chain.fundedAddressInitialBalance - amount - txGas)
       check(db.getBalance(recipient) == amount)
     var b = vm.`block`
     check(b.transactions[txIdx] == tx)

--- a/tests/test_vm.nim
+++ b/tests/test_vm.nim
@@ -8,8 +8,10 @@
 import
   unittest, ttmath,
   ./test_helpers, ./fixtures,
-  ../src/[db/backends/memory_backend, chain, constants, utils/hexadecimal],
+  ../src/[db/backends/memory_backend, db/state_db, chain, constants, utils/hexadecimal, vm_state],
   ../src/[vm/base, computation]
+
+import typetraits
 
 suite "VM":
   test "Apply transaction with no validation":
@@ -17,21 +19,26 @@ suite "VM":
       chain = chainWithoutBlockValidation()
       vm = chain.getVM()
       # txIdx = len(vm.`block`.transactions) # Can't take len of a runtime field
+    let
       recipient = decodeHex("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c")
-      amount = 100.i256
+      amount = 100.u256
+      ethaddr_from = chain.fundedAddress
+      tx = newTransaction(vm, ethaddr_from, recipient, amount, chain.fundedAddressPrivateKey)
+      # (computation, _) = vm.applyTransaction(tx)
+      # accessLogs = computation.vmState.accessLogs
 
-    var ethaddr_from = chain.fundedAddress
-    var tx = newTransaction(vm, ethaddr_from, recipient, amount, chain.fundedAddressPrivateKey)
-    var (computation, _) = vm.applyTransaction(tx)
-    var accessLogs = computation.vmState.accessLogs
+    # check(not computation.isError)
 
-    check(not computation.isError)
+    let
+      txGas = tx.gasPrice * constants.GAS_TX
+      state_db = vm.state.readOnlyStateDB
+      b = vm.`block`
 
-    var txGas = tx.gasPrice * constants.GAS_TX
-    # inDb(vm.state.stateDb(readOnly=true)):
-    #   check(db.getBalance(ethaddr_from) == chain.fundedAddressInitialBalance - amount - txGas)
-    #   check(db.getBalance(recipient) == amount)
-    # var b = vm.`block`
-    # check(b.transactions[txIdx] == tx)
-    # check(b.header.gasUsed == constants.GAS_TX)
+    echo state_db.getBalance(ethaddr_from).type.name
+
+    # check:
+    #   state_db.getBalance(ethaddr_from) == chain.fundedAddressInitialBalance - amount - txGas # TODO: this really should be i256
+    #   state_db.getBalance(recipient) == amount
+    #   b.transactions[txIdx] == tx
+    #   b.header.gasUsed == constants.GAS_TX
 

--- a/tests/test_vm.nim
+++ b/tests/test_vm.nim
@@ -15,7 +15,7 @@ suite "VM":
     var
       chain = chainWithoutBlockValidation()
       vm = chain.getVM()
-      txIdx = len(vm.block.transactions)
+      txIdx = len(vm.`block`.transactions)
       recipient = decodeHex("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c")
       amount = 100.Int256
 

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -21,8 +21,8 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
   for label, child in fixtures:
     fixture = child
     break
-  var vm = newFrontierVM(Header(), newBaseChainDB(newMemoryDB()))
-  let header = Header(
+  var vm = newFrontierVM(BlockHeader(), newBaseChainDB(newMemoryDB()))
+  let header = BlockHeader(
     coinbase: fixture{"env"}{"currentCoinbase"}.getStr,
     difficulty: fixture{"env"}{"currentDifficulty"}.getHexadecimalInt.u256,
     blockNumber: fixture{"env"}{"currentNumber"}.getHexadecimalInt.u256,


### PR DESCRIPTION
This was an attempt to enable the following tests: https://github.com/status-im/nimbus/blob/4da71f76b9c1e9939539291fb7af2a7e914c11d2/tests/test_vm.nim

However this is clearly too early and it's better in my opinion to target "intermediate tests" before this one. Here are the few changes added on the way here:

- `Header` renamed to `BlockHeader` similar to the py-evm repo
- Chain stores a new `VMKind` instead of the whole `VM`. Ideally it should store the runtime type (py-evm VMclass) but I don't think it's possible. Py-evm delays the VM creation to `getVM` time while before this PR Nim initialized it during the chain construction. See [get_vm](https://github.com/ethereum/py-evm/blob/96e4b400b06946c8713bf101ba696063d49688a8/evm/chains/base.py#L381-L400) and [vm initialization](https://github.com/ethereum/py-evm/blob/96e4b400b06946c8713bf101ba696063d49688a8/evm/vm/base.py#L61-L64).
- Type fixing of consts that were not tested (UInt vs Int). This will be completely overhauled by @coffeepots 

In this attempt I've noticed that several refactoring happened to VM, VMState and transaction execution:
  - `executeTransaction` [base](https://github.com/status-im/nimbus/blob/5a3202f4d3ef023cd600ae0125f1ced916a31313/src/vm_state_transactions.nim#L12) and [frontier](https://github.com/status-im/nimbus/blob/5a3202f4d3ef023cd600ae0125f1ced916a31313/src/vm/forks/frontier/frontier_vm_state.nim#L119) methods were introduced upstream here: https://github.com/ethereum/py-evm/commit/21c57f2d56ab91bb62723c3f9ebe291d0b132dde
  - Refactored/removed here: https://github.com/ethereum/py-evm/commit/cc991bf
  - to be finally deleted: https://github.com/ethereum/py-evm/commit/746defb6f8e83cee2c352a0ab8690e1281c4227c