### PR TITLE
Try to fix Appveyor appending string from time to time

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,5 @@
 version: '{build}'
 
-# clone directory - avoids Appveyor appending a unique string: https://ci.appveyor.com/project/jarradh/nimbus-on2qu/build/59
-clone_folder: c:\projects\nimbus
-
 cache:
 - x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
 - i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
@@ -43,7 +40,7 @@ install:
   - koch boot -d:release
   - koch nimble
 build_script:
-  - cd C:\projects\nimbus
+  - cd C:\projects\%APPVEYOR_PROJECT_SLUG%
   - nimble install -y
 test_script:
   - nimble test


### PR DESCRIPTION
Instead of forcing the clone directory (which doesn't work) we use the project slug environment variable to cd into the proper one