### PR TITLE
Reenable core json tests

### DIFF
--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, strformat, strutils, sequtils, tables, stint, json, ospaths,
+  unittest, strformat, strutils, sequtils, tables, stint, json, ospaths, times,
   ./test_helpers,
   ../src/[constants, errors, logging],
   ../src/[chain, vm_state, computation, opcode, types, opcode_table],
@@ -29,8 +29,8 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     coinbase: fixture{"env"}{"currentCoinbase"}.getStr,
     difficulty: fixture{"env"}{"currentDifficulty"}.getHexadecimalInt.u256,
     blockNumber: fixture{"env"}{"currentNumber"}.getHexadecimalInt.u256,
-    gasLimit: fixture{"env"}{"currentGasLimit"}.getHexadecimalInt.u256,
-    timestamp: fixture{"env"}{"currentTimestamp"}.getHexadecimalInt)
+    # gasLimit: fixture{"env"}{"currentGasLimit"}.getHexadecimalInt.u256,
+    timestamp: fixture{"env"}{"currentTimestamp"}.getHexadecimalInt.int64.fromUnix)
 
   var code = ""
   vm.state.db(readOnly=false):

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -6,10 +6,13 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, strformat, strutils, sequtils, tables, stint, json,
-  test_helpers, constants, errors, logging, ospaths,
-  chain, vm_state, computation, opcode, types, opcode_table, utils / [header, padding], vm / [gas_meter, message, code_stream, stack], vm / forks / frontier / vm, db / [db_chain, state_db], db / backends / memory_backend
-
+  unittest, strformat, strutils, sequtils, tables, stint, json, ospaths,
+  ./test_helpers,
+  ../src/[constants, errors, logging],
+  ../src/[chain, vm_state, computation, opcode, types, opcode_table],
+  ../src/utils/[header, padding],
+  ../src/vm/[gas_meter, message, code_stream, stack],
+  ../src/vm/forks/frontier/vm, ../src/db/[db_chain, state_db, backends/memory_backend]
 
 proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus)
 


### PR DESCRIPTION
This only change the JSON fixtures enough so that it compiles with the latest Nim and Nimbus changes:

- Support the new "Time" format introduced by https://github.com/nim-lang/Nim/commit/f6df2d9956a79eda0486391
- Follow the tests refacting changes https://github.com/nim-lang/Nim/commit/f6df2d9956a79eda0486391