### PR TITLE
Fix arithmetic implementation issues

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -135,7 +135,7 @@ VMTests
 - mulUnderFlow.json                                               Fail
 + mulmod0.json                                                    OK
 + mulmod1.json                                                    OK
-- mulmod1_overflow.json                                           Fail
++ mulmod1_overflow.json                                           OK
 + mulmod1_overflow2.json                                          OK
 + mulmod1_overflow3.json                                          OK
 + mulmod1_overflow4.json                                          OK
@@ -155,7 +155,7 @@ VMTests
 + sdiv2.json                                                      OK
 + sdiv3.json                                                      OK
 + sdiv4.json                                                      OK
-+ sdiv5.json                                                      OK
+- sdiv5.json                                                      Fail
 + sdiv6.json                                                      OK
 + sdiv7.json                                                      OK
 + sdiv8.json                                                      OK
@@ -165,7 +165,7 @@ VMTests
 + sdivByZero2.json                                                OK
 - sdiv_dejavu.json                                                Fail
 + sdiv_i256min.json                                               OK
-+ sdiv_i256min2.json                                              OK
+- sdiv_i256min2.json                                              Fail
 + sdiv_i256min3.json                                              OK
 + signextendInvalidByteNumber.json                                OK
 + signextend_00.json                                              OK
@@ -185,12 +185,12 @@ VMTests
 + smod2.json                                                      OK
 + smod3.json                                                      OK
 + smod4.json                                                      OK
-+ smod5.json                                                      OK
+- smod5.json                                                      Fail
 + smod6.json                                                      OK
-+ smod7.json                                                      OK
+- smod7.json                                                      Fail
 + smod8_byZero.json                                               OK
-+ smod_i256min1.json                                              OK
-+ smod_i256min2.json                                              OK
+- smod_i256min1.json                                              Fail
+- smod_i256min2.json                                              Fail
 + stop.json                                                       OK
 + sub0.json                                                       OK
 + sub1.json                                                       OK
@@ -198,7 +198,7 @@ VMTests
 + sub3.json                                                       OK
 + sub4.json                                                       OK
 ```
-OK: 187/195 Fail: 7/195 Skip: 1/195
+OK: 182/195 Fail: 12/195 Skip: 1/195
 ## vmBitwiseLogicOperation
 ```diff
 + and0.json                                                       OK

--- a/VMTests.md
+++ b/VMTests.md
@@ -155,7 +155,7 @@ VMTests
 + sdiv2.json                                                      OK
 + sdiv3.json                                                      OK
 + sdiv4.json                                                      OK
-- sdiv5.json                                                      Fail
++ sdiv5.json                                                      OK
 + sdiv6.json                                                      OK
 + sdiv7.json                                                      OK
 + sdiv8.json                                                      OK
@@ -165,7 +165,7 @@ VMTests
 + sdivByZero2.json                                                OK
 - sdiv_dejavu.json                                                Fail
 + sdiv_i256min.json                                               OK
-- sdiv_i256min2.json                                              Fail
++ sdiv_i256min2.json                                              OK
 + sdiv_i256min3.json                                              OK
 + signextendInvalidByteNumber.json                                OK
 + signextend_00.json                                              OK
@@ -189,8 +189,8 @@ VMTests
 + smod6.json                                                      OK
 - smod7.json                                                      Fail
 + smod8_byZero.json                                               OK
-- smod_i256min1.json                                              Fail
-- smod_i256min2.json                                              Fail
++ smod_i256min1.json                                              OK
++ smod_i256min2.json                                              OK
 + stop.json                                                       OK
 + sub0.json                                                       OK
 + sub1.json                                                       OK
@@ -198,7 +198,7 @@ VMTests
 + sub3.json                                                       OK
 + sub4.json                                                       OK
 ```
-OK: 182/195 Fail: 12/195 Skip: 1/195
+OK: 186/195 Fail: 8/195 Skip: 1/195
 ## vmBitwiseLogicOperation
 ```diff
 + and0.json                                                       OK

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -120,13 +120,7 @@ mapOp(`xor`)
 
 let
   UINT_256_MAX*: UInt256 =        high(UInt256)
-  UINT_256_CEILING*: UInt256 =    2 ^ 256      # TODO, this won't work
-  UINT_255_MAX*: UInt256 =        2 ^ (255 - 1) - 1.u256
-  UINT_255_CEILING*: UInt256 =    2 ^ 255      # TODO, this won't work
-  UINT_256_CEILING_INT*: Int256 = high(Int256)
-  UINT_255_MAX_INT*: Int256 =     2.i256 ^ (255 - 1) - 1.i256
-  UINT_256_MAX_INT*: Int256 =     2.i256 ^ 256 - 1.i256 # TODO, this won't work
-  UINT_255_CEILING_INT*: Int256 = 2.i256 ^ 255 - 1.i256
+  INT_256_MAX_AS_UINT256* =       cast[Uint256](high(Int256))
   NULLBYTE* =                     "\x00"
   EMPTYWORD* =                    repeat(NULLBYTE, 32)
   UINT160CEILING*: UInt256 =      2 ^ 160

--- a/src/logic/arithmetic.nim
+++ b/src/logic/arithmetic.nim
@@ -46,7 +46,9 @@ proc smod*(computation: var BaseComputation) =
   let (value, modulus) = computation.stack.popInt(2)
 
   let res = if modulus.isZero: zero(Uint256)
-            else: cast[UInt256](cast[Int256](value) mod cast[Int256](modulo))
+            else: pseudoSignedToUnsigned(
+              unsignedToPseudoSigned(value) mod unsignedToPseudoSigned(modulus)
+              )
   pushRes()
 
 proc mul*(computation: var BaseComputation) =
@@ -74,10 +76,12 @@ proc divide*(computation: var BaseComputation) =
 
 proc sdiv*(computation: var BaseComputation) =
   # Signed Division
-  let (value, modulus) = computation.stack.popInt(2)
+  let (value, divisor) = computation.stack.popInt(2)
 
-  let res = if modulus.isZero: zero(Uint256)
-            else: cast[UInt256](cast[Int256](value) div cast[Int256](modulo))
+  let res = if divisor.isZero: zero(Uint256)
+            else: pseudoSignedToUnsigned(
+              unsignedToPseudoSigned(value) div unsignedToPseudoSigned(divisor)
+              )
   pushRes()
 
 # no curry

--- a/src/logic/arithmetic.nim
+++ b/src/logic/arithmetic.nim
@@ -12,74 +12,72 @@ import
 
 proc add*(computation: var BaseComputation) =
   # Addition
-  var (left, right) = computation.stack.popInt(2)
+  let (left, right) = computation.stack.popInt(2)
 
-  var res = (left + right) and UINT_256_MAX
+  let res = left + right
   pushRes()
 
 proc addmod*(computation: var BaseComputation) =
   # Modulo Addition
-  var (left, right, arg) = computation.stack.popInt(3)
+  let (left, right, modulus) = computation.stack.popInt(3)
 
-  var res = if arg == 0: 0.u256 else: (left + right) mod arg
+  let res = if modulus.isZero: zero(Uint256) # EVM special casing of div by 0
+            else: addmod(left, right, modulus)
   pushRes()
 
 proc sub*(computation: var BaseComputation) =
   # Subtraction
-  var (left, right) = computation.stack.popInt(2)
+  let (left, right) = computation.stack.popInt(2)
 
-  var res = (left - right) and UINT_256_MAX
+  let res = left - right
   pushRes()
 
 
 proc modulo*(computation: var BaseComputation) =
   # Modulo
-  var (value, arg) = computation.stack.popInt(2)
+  let (value, modulus) = computation.stack.popInt(2)
 
-  var res = if arg == 0: 0.u256 else: value mod arg
+  let res = if modulus.isZero: zero(Uint256) # EVM special casing of div by 0
+            else: value mod modulus
   pushRes()
 
 proc smod*(computation: var BaseComputation) =
   # Signed Modulo
-  var (value, arg) = computation.stack.popInt(2)
-  let signedValue = unsignedToSigned(value)
-  let signedArg = unsignedToSigned(arg)
+  let (value, modulus) = computation.stack.popInt(2)
 
-  var posOrNeg = if signedValue < 0: -1.i256 else: 1.i256
-  var signedRes = if signedArg == 0: 0.i256 else: ((signedValue.abs mod signedArg.abs) * posOrNeg) and UINT_256_MAX_INT
-  var res = signedToUnsigned(signedRes)
+  let res = if modulus.isZero: zero(Uint256)
+            else: cast[UInt256](cast[Int256](value) mod cast[Int256](modulo))
   pushRes()
 
 proc mul*(computation: var BaseComputation) =
   # Multiplication
-  var (left, right) = computation.stack.popInt(2)
+  let (left, right) = computation.stack.popInt(2)
 
-  var res = (left * right) and UINT_256_MAX
+  let res = left * right
   pushRes()
 
 proc mulmod*(computation: var BaseComputation) =
   #  Modulo Multiplication
-  var (left, right, arg) = computation.stack.popInt(3)
+  let (left, right, modulus) = computation.stack.popInt(3)
 
-  var res = if arg == 0: 0.u256 else: (left * right) mod arg
+  let res = if modulus.isZero: zero(Uint256)
+            else: mulmod(left, right, modulus)
   pushRes()
 
 proc divide*(computation: var BaseComputation) =
   # Division
-  var (numerator, denominator) = computation.stack.popInt(2)
+  let (numerator, denominator) = computation.stack.popInt(2)
 
-  var res = if denominator == 0: 0.u256 else: (numerator div denominator) and UINT_256_MAX
+  let res = if denominator.isZero: zero(Uint256)
+            else: numerator div denominator
   pushRes()
 
 proc sdiv*(computation: var BaseComputation) =
   # Signed Division
-  var (numerator, denominator) = computation.stack.popInt(2)
-  let signedNumerator = unsignedToSigned(numerator)
-  let signedDenominator = unsignedToSigned(denominator)
+  let (value, modulus) = computation.stack.popInt(2)
 
-  var posOrNeg = if signedNumerator * signedDenominator < 0: -1.i256 else: 1.i256
-  var signedRes = if signedDenominator == 0: 0.i256 else: (posOrNeg * (signedNumerator.abs div signedDenominator.abs))
-  var res = signedToUnsigned(signedRes)
+  let res = if modulus.isZero: zero(Uint256)
+            else: cast[UInt256](cast[Int256](value) div cast[Int256](modulo))
   pushRes()
 
 # no curry
@@ -93,18 +91,23 @@ proc exp*(computation: var BaseComputation) =
     gasCost += GAS_EXP_BYTE * (one(Uint256) + log256(exponent))
   computation.gasMeter.consumeGas(gasCost, reason="EXP: exponent bytes")
 
-  var res = if base == 0: 0.u256 else: base.pow(exponent)
+  let res = if base.isZero: 0.u256 # 0^0 is 0 in py-evm
+            else: base.pow(exponent)
   pushRes()
 
 proc signextend*(computation: var BaseComputation) =
   # Signed Extend
-  var (bits, value) = computation.stack.popInt(2)
+  let (bits, value) = computation.stack.popInt(2)
 
   var res: UInt256
   if bits <= 31.u256:
-    var testBit = bits.toInt * 8 + 7
-    var signBit = (1 shl testBit)
-    res = if value != 0 and signBit != 0: value or (UINT_256_CEILING - signBit.u256) else: value and (signBit.u256 - 1.u256)
+    let testBit = bits.toInt * 8 + 7
+    let bitPos = (1 shl testBit)
+    let mask = bitPos - 1
+    if not (value and bitPos).isZero:
+      res = value or (not mask)
+    else:
+      res = value and mask
   else:
     res = value
   pushRes()

--- a/src/utils_numeric.nim
+++ b/src/utils_numeric.nim
@@ -48,19 +48,21 @@ proc log256*(value: UInt256): UInt256 =
 
 proc unsignedToSigned*(value: UInt256): Int256 =
   0.i256
-  # TODO
-  # if value <= UINT_255_MAX_INT:
-  #   return value
-  # else:
-  #   return value - UINT_256_CEILING_INT
+  # TODO Remove stub (used in quasiBoolean for signed comparison)
 
 proc signedToUnsigned*(value: Int256): UInt256 =
   0.u256
-  # TODO
-  # if value < 0:
-  #   return value + UINT_256_CEILING_INT
-  # else:
-  #   return value
+  # TODO Remove stub (used in quasiBoolean for signed comparison)
+
+proc unsignedToPseudoSigned*(value: UInt256): UInt256 =
+  result = value
+  if value > INT_256_MAX_AS_UINT256:
+    result -= INT_256_MAX_AS_UINT256
+
+proc pseudoSignedToUnsigned*(value: UInt256): UInt256 =
+  result = value
+  if value > INT_256_MAX_AS_UINT256:
+    result += INT_256_MAX_AS_UINT256
 
 # it's deasible to map nameXX methods like that (originally decorator)
 macro ceilXX(ceiling: static[int]): untyped =

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -63,6 +63,8 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
   if not fixture{"post"}.isNil:
     # Success checks
     check(not computation.isError)
+    if computation.isError:
+      echo "Computation error: ", computation.error.info
 
     let logEntries = computation.getLogEntries()
     if not fixture{"logs"}.isNil:


### PR DESCRIPTION
- This uses proper `addmod`, `submod`, `mulmod`. Previously, they would fail if a + b or a * b overflowed uint256 was the modulo as only taken after the operation.
- Signextend now uses the same clearer implementation as Cpp-ethereum.
- Several unused UINT256 constants are removed.
- It also introduces `unsignedToPseudoSigned` and `signedToPseudoSigned` to replace `unsignedToSigned` and `signedToUnsigned` stub procs. They will be removed with a further refactoring of [signed comparisons](https://github.com/status-im/nimbus/blob/0f56bdec26db39e986b44f42e8341815ce732b7e/src/logic/comparison.nim) and removal of the [quasi-boolean macro](https://github.com/status-im/nimbus/blob/5a3202f4d3ef023cd600ae0125f1ced916a31313/src/logic/helpers.nim).

### Unfixed arithmetic tests

The following are not covered by this PR

#### smod5 and smod7

Unfortunately, tests `smod5` and `smod7` are now failing due to gas issue. I do not know why it didn't fail before:
```
vmArithmeticTestsmod5.json
    test_vm_json.nim(65, 10): Check failed: not computation.isError
    computation.isError was true
Computation error: Out of gas: Needed 20000 - Remaining 9980 - Reason: SSTORE: 0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6[slot] -> 2 (0)
    9980 4980
    test_vm_json.nim(86, 53): Check failed: actualGasRemaining == expectedGasRemaining or
    computation.code.hasSStore() and
    (actualGasRemaining > expectedGasRemaining and
    (actualGasRemaining - expectedGasRemaining) mod 15000 == 0 or
    expectedGasRemaining > actualGasRemaining and
    (expectedGasRemaining - actualGasRemaining) mod 15000 == 0)
  [FAILED] tests/fixtures/VMTests/vmArithmeticTest/smod5.json
```
```
vmArithmeticTestsmod7.json
    test_vm_json.nim(65, 10): Check failed: not computation.isError
    computation.isError was true
Computation error: Out of gas: Needed 20000 - Remaining 9980 - Reason: SSTORE: 0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6[slot] -> 2 (0)
    9980 4980
    test_vm_json.nim(86, 53): Check failed: actualGasRemaining == expectedGasRemaining or
    computation.code.hasSStore() and
    (actualGasRemaining > expectedGasRemaining and
    (actualGasRemaining - expectedGasRemaining) mod 15000 == 0 or
    expectedGasRemaining > actualGasRemaining and
    (expectedGasRemaining - actualGasRemaining) mod 15000 == 0)
```

#### mulUnderflow and sdiv_dejavu

The issue is not related to the implementation but the stack. Edit: tracked in #31.

```
vmArithmeticTestmulUnderFlow.json
test_helpers.nim(48)     test_vm_json
computation.nim(278)     testFixture
computation.nim(272)     :anonymous
stack.nim(135)           mul
stack.nim(116)           internalPopTuple2
system.nim(2445)         pop
system.nim(2843)         sysFatal

    Unhandled exception: index out of bounds
  [FAILED] tests/fixtures/VMTests/vmArithmeticTest/mulUnderFlow.json
```
```
vmArithmeticTestsdiv_dejavu.json
test_helpers.nim(48)     test_vm_json
computation.nim(278)     testFixture
computation.nim(272)     :anonymous
stack.nim(135)           sdiv
stack.nim(116)           internalPopTuple2
system.nim(2445)         pop
system.nim(2843)         sysFatal

    Unhandled exception: index out of bounds
  [FAILED] tests/fixtures/VMTests/vmArithmeticTest/sdiv_dejavu.json
```