### PR TITLE
Stack underflow

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -132,7 +132,7 @@ VMTests
 + mul5.json                                                       OK
 + mul6.json                                                       OK
 + mul7.json                                                       OK
-- mulUnderFlow.json                                               Fail
++ mulUnderFlow.json                                               OK
 + mulmod0.json                                                    OK
 + mulmod1.json                                                    OK
 + mulmod1_overflow.json                                           OK
@@ -163,7 +163,7 @@ VMTests
 + sdivByZero0.json                                                OK
 + sdivByZero1.json                                                OK
 + sdivByZero2.json                                                OK
-- sdiv_dejavu.json                                                Fail
++ sdiv_dejavu.json                                                OK
 + sdiv_i256min.json                                               OK
 + sdiv_i256min2.json                                              OK
 + sdiv_i256min3.json                                              OK
@@ -198,7 +198,7 @@ VMTests
 + sub3.json                                                       OK
 + sub4.json                                                       OK
 ```
-OK: 186/195 Fail: 8/195 Skip: 1/195
+OK: 188/195 Fail: 6/195 Skip: 1/195
 ## vmBitwiseLogicOperation
 ```diff
 + and0.json                                                       OK

--- a/src/vm/stack.nim
+++ b/src/vm/stack.nim
@@ -75,6 +75,7 @@ proc push*(stack: var Stack, value: Bytes) =
   stack.values.add(value.toType(UInt256))
 
 proc internalPop(stack: var Stack, numItems: int): seq[UInt256] =
+  # TODO: it is very inefficient to allocate a seq
   if len(stack) < numItems:
     result = @[]
   else:
@@ -82,6 +83,7 @@ proc internalPop(stack: var Stack, numItems: int): seq[UInt256] =
     stack.values = stack.values[0 ..< ^numItems]
 
 proc internalPop(stack: var Stack, numItems: int, T: typedesc): seq[T] =
+  # TODO: it is very inefficient to allocate a seq
   result = @[]
   if len(stack) < numItems:
     return
@@ -90,9 +92,12 @@ proc internalPop(stack: var Stack, numItems: int, T: typedesc): seq[T] =
     var value = stack.values.pop()
     result.add(toType(value, T))
 
-template ensurePop(elements: untyped, a: untyped): untyped =
-  if len(`elements`) < `a`:
-    raise newException(InsufficientStack, "No stack items")
+proc ensurePop(elements: seq, a: int) =
+  let num = elements.len
+  let expected = a
+  if num < expected:
+    raise newException(InsufficientStack,
+      &"Stack underflow: expected {expected} elements, got {num} instead.")
 
 proc popInt*(stack: var Stack): UInt256 =
   var elements = stack.internalPop(1, UInt256)

--- a/tests/test_stack.nim
+++ b/tests/test_stack.nim
@@ -93,3 +93,12 @@ suite "stack":
     var stack = newStack()
     expect(InsufficientStack):
       stack.dup(0)
+
+  test "binary operations raises InsufficientStack appropriately":
+    # https://github.com/status-im/nimbus/issues/31
+    # ./tests/fixtures/VMTests/vmArithmeticTest/mulUnderFlow.json
+
+    var stack = newStack()
+    stack.push(123)
+    expect(InsufficientStack):
+      discard stack.popInt(2)


### PR DESCRIPTION
Stack underflows are now properly catched at the EVM level (raises InsufficientStack exception) instead of at the Nim level (raised IndexError).

I tried to add `expect(EVMError)` to this part of the Ethereum JSON tests:
https://github.com/status-im/nimbus/blob/74a558f187443d91dbaeccd24d1f2dad856b36b5/tests/test_vm_json.nim#L110-L113
but all the tests failed afterward 🤷‍♂️ 

##### Results

- 2 new tests passed, only 6 tests failing left in the official arithmetic test suite out of 194 tested (1 skipped).

##### Future considerations:
As mentioned in the yellow paper and in #31, the EVM is supposed to consume gas but roll back to the previous state in case of underflows. But we just threw an Exception so what is supposed to happen next with the contract is a mystery. This is necessary if we want to play/replay a contract or Ethereum history I think.