### PR TITLE
[WIP] Gas & Memory ops refactoring - uses native integer instead of uint256

### DIFF
--- a/src/constants.nim
+++ b/src/constants.nim
@@ -46,13 +46,13 @@ proc `==`*(a: UInt256, b: int): bool =
 proc `!=`*(a: UInt256, b: int): bool =
   a != b.u256
 
-proc `^`*(base: int; exp: int): UInt256 =
-  let base = base.u256
-  var ex = exp
-  result = 1.u256
-  while ex > 0:
-    result = result * base
-    dec(ex)
+# proc `^`*(base: int; exp: int): UInt256 =
+#   let base = base.u256
+#   var ex = exp
+#   result = 1.u256
+#   while ex > 0:
+#     result = result * base
+#     dec(ex)
 
 proc `^`*(left: Int256, right: int): Int256 =
   var value = right.i256
@@ -123,7 +123,7 @@ let
   INT_256_MAX_AS_UINT256* =       cast[Uint256](high(Int256))
   NULLBYTE* =                     "\x00"
   EMPTYWORD* =                    repeat(NULLBYTE, 32)
-  UINT160CEILING*: UInt256 =      2 ^ 160
+  UINT160CEILING*: UInt256 =      2.u256 ^ 160
   CREATE_CONTRACT_ADDRESS* =      ""
   ZERO_ADDRESS* =                 repeat("\x00", 20)
   ZERO_HASH32* =                  repeat("\x00", 20)
@@ -147,34 +147,34 @@ let
   # GAS_SLOAD_COST* =               20.u256
   # GAS_SELF_DESTRUCT_COST* =       0.u256
   # GAS_IN_HANDLER* =               0.u256 # to be calculated in handler
-  REFUND_SCLEAR* =                15_000.u256
+  REFUND_SCLEAR* =                15_000
 
   # GAS_SELF_DESTRUCT* =            0.u256
   # GAS_SELF_DESTRUCT_NEW_ACCOUNT* = 25_000.u256
   GAS_CREATE* =                   32_000.u256
   # GAS_CALL* =                     40.u256
-  GAS_CALL_VALUE* =               9_000.u256
-  GAS_CALL_STIPEND* =             2_300.u256
-  GAS_NEW_ACCOUNT* =              25_000.u256
+  GAS_CALL_VALUE* =               9_000
+  GAS_CALL_STIPEND* =             2_300
+  GAS_NEW_ACCOUNT* =              25_000
 
   # GAS_COST_BALANCE* =             400.u256 # TODO: this is post-eip150, see also GAS_BALANCE
 
   # GAS_EXP* =                      10.u256
   # GAS_EXP_BYTE* =                 10.u256
-  GAS_MEMORY* =                   3.u256
+  GAS_MEMORY* =                   3
   GAS_TX_CREATE* =                32_000.u256
   GAS_TX_DATA_ZERO* =             4.u256
   GAS_TX_DATA_NON_ZERO* =         68.u256
   GAS_TX* =                       21_000.u256
   GAS_LOG* =                      375.u256
-  GAS_LOG_DATA* =                 8.u256
-  GAS_LOG_TOPIC* =                375.u256
+  GAS_LOG_DATA* =                 8
+  GAS_LOG_TOPIC* =                375
   # GAS_SHA3* =                     30.u256
-  GAS_SHA3_WORD* =                6.u256
-  GAS_COPY* =                     3.u256
+  GAS_SHA3_WORD* =                6
+  GAS_COPY* =                     3
   GAS_BLOCK_HASH* =               20.u256
   GAS_CODE_DEPOSIT* =             200.u256
-  GAS_MEMORY_QUADRATIC_DENOMINATOR* = 512.u256
+  GAS_MEMORY_QUADRATIC_DENOMINATOR* = 512
   GAS_SHA256* =                   60.u256
   GAS_SHA256WORD* =               12.u256
   GAS_RIP_EMD160* =               600.u256
@@ -188,7 +188,7 @@ let
   GAS_ECPAIRING_PER_POINT* =      80_000.u256
   GAS_LIMIT_EMA_DENOMINATOR* =    1_024.u256
   GAS_LIMIT_ADJUSTMENT_FACTOR* =  1_024.u256
-  GAS_LIMIT_MAXIMUM*: UInt256 =   2 ^ 63 - 1.u256
+  GAS_LIMIT_MAXIMUM* =            high(int64)
   GAS_LIMIT_USAGE_ADJUSTMENT_NUMERATOR* = 3.u256
   GAS_LIMIT_USAGE_ADJUSTMENT_DENOMINATOR* = 2.u256
 
@@ -206,7 +206,7 @@ let
   MAX_UNCLE_DEPTH* =              6.u256
   MAX_UNCLES* =                   2.u256
 
-  SECPK1_P*: UInt256 =            2 ^ 256 - 2 ^ 32 - 977.u256
+  SECPK1_P*: UInt256 =            2.u256 ^ 256 - 2.u256 ^ 32 - 977.u256
   SECPK1_N*: UInt256 =            "115792089237316195423570985008687907852837564279074904382605163141518161494337".u256
   SECPK1_A* =                     0.u256
   SECPK1_B* =                     7.u256

--- a/src/logic/arithmetic.nim
+++ b/src/logic/arithmetic.nim
@@ -92,7 +92,7 @@ proc exp*(computation: var BaseComputation) =
 
   var gasCost = computation.gasCosts[GasExp]
   if not exponent.isZero:
-    gasCost += gasCost * (one(Uint256) + log256(exponent))
+    gasCost += gasCost * (1 + log256(exponent))
   computation.gasMeter.consumeGas(gasCost, reason="EXP: exponent bytes")
 
   let res = if base.isZero: 0.u256 # 0^0 is 0 in py-evm

--- a/src/logic/flow.nim
+++ b/src/logic/flow.nim
@@ -55,4 +55,4 @@ proc pc*(computation) =
 
 proc gas*(computation) =
   let gasRemaining = gasMeter.gasRemaining
-  stack.push(gasRemaining)
+  stack.push(gasRemaining.u256)

--- a/src/logic/memory_ops.nim
+++ b/src/logic/memory_ops.nim
@@ -6,7 +6,8 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  ../constants, ../computation, ../types, .. / vm / [stack, memory], .. / utils / [padding, bytes]
+  ../constants, ../computation, ../types, .. / vm / [stack, memory], .. / utils / [padding, bytes],
+  stint
 
 
 {.this: computation.}
@@ -16,14 +17,14 @@ using
   computation: var BaseComputation
 
 proc mstoreX(computation; x: int) =
-  let start = stack.popInt()
+  let start = stack.popInt().toInt
   let value = stack.popBinary()
 
   let paddedValue = padLeft(value, x, 0.byte)
   let normalizedValue = paddedValue[^x .. ^1]
 
-  extendMemory(start, x.u256)
-  memory.write(start, 32.u256, normalizedValue)
+  extendMemory(start, x)
+  memory.write(start, 32, normalizedValue)
 
 # TODO template handler
 
@@ -34,11 +35,11 @@ proc mstore8*(computation) =
   mstoreX(1)
 
 proc mload*(computation) =
-  let start = stack.popInt()
+  let start = stack.popInt().toInt
 
-  extendMemory(start, 32.u256)
+  extendMemory(start, 32)
 
-  let value = memory.read(start, 32.u256)
+  let value = memory.read(start, 32)
   stack.push(value)
 
 proc msize*(computation) =

--- a/src/logic/sha3.nim
+++ b/src/logic/sha3.nim
@@ -10,9 +10,10 @@ import
 
 proc sha3op*(computation: var BaseComputation) =
   let (startPosition, size) = computation.stack.popInt(2)
-  computation.extendMemory(startPosition, size)
-  let sha3Bytes = computation.memory.read(startPosition, size)
-  let wordCount = sha3Bytes.len.u256.ceil32 div 32
+  let (pos, len) = (startPosition.toInt, size.toInt)
+  computation.extendMemory(pos, len)
+  let sha3Bytes = computation.memory.read(pos, len)
+  let wordCount = sha3Bytes.len.ceil32 div 32 # TODO, can't we just shr instead of rounding + div
   let gasCost = constants.GAS_SHA3_WORD * wordCount
   computation.gasMeter.consumeGas(gasCost, reason="SHA3: word gas cost")
   var res = keccak("")

--- a/src/logic/storage.nim
+++ b/src/logic/storage.nim
@@ -29,7 +29,7 @@ proc sstore*(computation) =
   let isCurrentlyEmpty = not existing # currentValue == 0
   let isGoingToBeEmpty = value == 0
 
-  let gasRefund = if isCurrentlyEmpty or not isGoingToBeEmpty: 0.u256 else: REFUND_SCLEAR
+  let gasRefund = if isCurrentlyEmpty or not isGoingToBeEmpty: 0 else: REFUND_SCLEAR
   let gasCost = if isCurrentlyEmpty and not isGoingToBeEmpty: GAS_SSET else: GAS_SRESET
 
   computation.gasMeter.consumeGas(computation.gasCosts[gasCost], &"SSTORE: {computation.msg.storageAddress}[slot] -> {value} ({currentValue})")

--- a/src/types.nim
+++ b/src/types.nim
@@ -9,7 +9,8 @@ import
   tables,
   constants, vm_state,
   opcode_values, stint,
-  vm / [code_stream, gas_meter, memory, message, stack]
+  vm / [code_stream, memory, stack],
+  ./logging
 
 type
   BaseComputation* = ref object of RootObj
@@ -49,6 +50,16 @@ type
     gasCostKind*: GasCostKind
     runLogic*:  proc(computation: var BaseComputation)
 
+  GasInt* = int64
+    ## Type alias used for gas computation
+    # For reference - https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
+
+  GasMeter* = ref object
+    logger*: Logger
+    gasRefunded*: GasInt
+    startGas*: GasInt
+    gasRemaining*: GasInt
+
   GasCostKind* = enum
     GasZero
     GasBase
@@ -71,4 +82,42 @@ type
     GasExp
     GasSHA3
 
-  GasCosts* = array[GasCostKind, UInt256]
+  GasCosts* = array[GasCostKind, GasInt]
+
+  Message* = ref object
+    # A message for VM computation
+
+    # depth = None
+
+    # code = None
+    # codeAddress = None
+
+    # createAddress = None
+
+    # shouldTransferValue = None
+    # isStatic = None
+
+    # logger = logging.getLogger("evm.vm.message.Message")
+
+    gas*:                     GasInt
+    gasPrice*:                GasInt
+    to*:                      string
+    sender*:                  string
+    value*:                   UInt256
+    data*:                    seq[byte]
+    code*:                    string
+    internalOrigin*:          string
+    internalCodeAddress*:     string
+    depth*:                   int
+    internalStorageAddress*:  string
+    shouldTransferValue*:     bool
+    isStatic*:                bool
+    isCreate*:                bool
+
+  MessageOptions* = ref object
+    origin*:                  string
+    depth*:                   int
+    createAddress*:           string
+    codeAddress*:             string
+    shouldTransferValue*:     bool
+    isStatic*:                bool

--- a/src/utils_numeric.nim
+++ b/src/utils_numeric.nim
@@ -36,8 +36,8 @@ proc bigEndianToInt*(value: Bytes): UInt256 =
 # proc bitLength*(value: UInt256): int =
 #   255 - value.countLeadingZeroBits
 
-proc log256*(value: UInt256): UInt256 =
-  ((255 - value.countLeadingZeroBits) div 8).u256
+proc log256*(value: UInt256): Natural =
+  (255 - value.countLeadingZeroBits) div 8 # Compilers optimize to `shr 3`
 
 # proc ceil8*(value: int): int =
 #   let remainder = value mod 8
@@ -68,12 +68,12 @@ proc pseudoSignedToUnsigned*(value: UInt256): UInt256 =
 macro ceilXX(ceiling: static[int]): untyped =
   var name = ident(&"ceil{ceiling}")
   result = quote:
-    proc `name`*(value: UInt256): UInt256 =
-      var remainder = value mod `ceiling`.u256
+    proc `name`*(value: Natural): Natural =
+      var remainder = value mod `ceiling`
       if remainder == 0:
         return value
       else:
-        return value + `ceiling`.u256 - remainder
+        return value + `ceiling` - remainder
 
 
 ceilXX(32)

--- a/src/vm/forks/gas_costs.nim
+++ b/src/vm/forks/gas_costs.nim
@@ -10,36 +10,36 @@ import
 
 # TODO: Make that computation at compile-time.
 #       Go-Ethereum uses pure uint64 for gas computation
-let BaseGasCosts*: GasCosts = [
-  GasZero:                     0.u256,
-  GasBase:                     2.u256,
-  GasVeryLow:                  3.u256,
-  GasLow:                      5.u256,
-  GasMid:                      8.u256,
-  GasHigh:                     10.u256,
-  GasSload:                    50.u256,     # Changed to 200 in Tangerine (EIP150)
-  GasJumpDest:                 1.u256,
-  GasSset:                     20_000.u256,
-  GasSreset:                   5_000.u256,
-  GasExtCode:                  20.u256,
-  GasCoinbase:                 20.u256,
-  GasSelfDestruct:             0.u256,      # Changed to 5000 in Tangerine (EIP150)
-  GasInHandler:                0.u256,      # to be calculated in handler
-  GasRefundSclear:             15000.u256,
+const BaseGasCosts*: GasCosts = [
+  GasZero:                     0'i64,
+  GasBase:                     2,
+  GasVeryLow:                  3,
+  GasLow:                      5,
+  GasMid:                      8,
+  GasHigh:                     10,
+  GasSload:                    50,     # Changed to 200 in Tangerine (EIP150)
+  GasJumpDest:                 1,
+  GasSset:                     20_000,
+  GasSreset:                   5_000,
+  GasExtCode:                  20,
+  GasCoinbase:                 20,
+  GasSelfDestruct:             0,      # Changed to 5000 in Tangerine (EIP150)
+  GasInHandler:                0,      # to be calculated in handler
+  GasRefundSclear:             15000,
 
-  GasBalance:                  20.u256,     # Changed to 400 in Tangerine (EIP150)
-  GasCall:                     40.u256,     # Changed to 700 in Tangerine (EIP150)
-  GasExp:                      10.u256,
-  GasSHA3:                     30.u256
+  GasBalance:                  20,     # Changed to 400 in Tangerine (EIP150)
+  GasCall:                     40,     # Changed to 700 in Tangerine (EIP150)
+  GasExp:                      10,
+  GasSHA3:                     30
 ]
 
 proc tangerineGasCosts(baseCosts: GasCosts): GasCosts =
 
   # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md
   result = baseCosts
-  result[GasSload]        = 200.u256
-  result[GasSelfDestruct] = 5000.u256
-  result[GasBalance]      = 400.u256
-  result[GasCall]         = 40.u256
+  result[GasSload]        = 200
+  result[GasSelfDestruct] = 5000
+  result[GasBalance]      = 400
+  result[GasCall]         = 40
 
-let TangerineGasCosts* = BaseGasCosts.tangerineGasCosts
+const TangerineGasCosts* = BaseGasCosts.tangerineGasCosts

--- a/src/vm/gas_meter.nim
+++ b/src/vm/gas_meter.nim
@@ -7,25 +7,20 @@
 
 import
   strformat,
-  ../logging, ../errors, ../constants, stint
+  ../logging, ../errors, ../types
 
-type
-  GasMeter* = ref object
-    logger*: Logger
-    gasRefunded*: UInt256
-    startGas*: UInt256
-    gasRemaining*: UInt256
-
-proc newGasMeter*(startGas: UInt256): GasMeter =
+proc newGasMeter*(startGas: GasInt): GasMeter =
   new(result)
   result.startGas = startGas
   result.gasRemaining = result.startGas
-  result.gasRefunded = 0.u256
+  result.gasRefunded = 0
   result.logger = logging.getLogger("gas")
 
-proc consumeGas*(gasMeter: var GasMeter; amount: UInt256; reason: string) =
+proc consumeGas*(gasMeter: var GasMeter; amount: GasInt; reason: string) =
   #if amount < 0.u256:
   #  raise newException(ValidationError, "Gas consumption amount must be positive")
+  # Alternatively: use a range type `range[0'i64 .. high(int64)]`
+  #   https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
   if amount > gasMeter.gasRemaining:
     raise newException(OutOfGas,
       &"Out of gas: Needed {amount} - Remaining {gasMeter.gasRemaining} - Reason: {reason}")
@@ -33,16 +28,20 @@ proc consumeGas*(gasMeter: var GasMeter; amount: UInt256; reason: string) =
   gasMeter.logger.trace(
     &"GAS CONSUMPTION: {gasMeter.gasRemaining + amount} - {amount} -> {gasMeter.gasRemaining} ({reason})")
 
-proc returnGas*(gasMeter: var GasMeter; amount: UInt256) =
+proc returnGas*(gasMeter: var GasMeter; amount: GasInt) =
   #if amount < 0.int256:
   #  raise newException(ValidationError, "Gas return amount must be positive")
+  # Alternatively: use a range type `range[0'i64 .. high(int64)]`
+  #   https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
   gasMeter.gasRemaining += amount
   gasMeter.logger.trace(
     &"GAS RETURNED: {gasMeter.gasRemaining - amount} + {amount} -> {gasMeter.gasRemaining}")
 
-proc refundGas*(gasMeter: var GasMeter; amount: UInt256) =
+proc refundGas*(gasMeter: var GasMeter; amount: GasInt) =
   #if amount < 0.int256:
   #  raise newException(ValidationError, "Gas refund amount must be positive")
+  # Alternatively: use a range type `range[0'i64 .. high(int64)]`
+  #   https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
   gasMeter.gasRefunded += amount
   gasMeter.logger.trace(
     &"GAS REFUND: {gasMeter.gasRemaining - amount} + {amount} -> {gasMeter.gasRefunded}")

--- a/src/vm/memory.nim
+++ b/src/vm/memory.nim
@@ -24,39 +24,39 @@ proc len*(memory: Memory): int =
 
 
 # TODO: why is the size passed as a UInt256?
-proc extend*(memory: var Memory; startPosition: UInt256; size: UInt256) =
+proc extend*(memory: var Memory; startPosition: Natural; size: Natural) =
   if size == 0:
     return
   var newSize = ceil32(startPosition + size)
-  if newSize <= len(memory).u256:
+  if newSize <= len(memory):
     return
-  var sizeToExtend = newSize - len(memory).u256
-  memory.bytes = memory.bytes.concat(repeat(0.byte, sizeToExtend.toInt))
+  var sizeToExtend = newSize - len(memory)
+  memory.bytes = memory.bytes.concat(repeat(0.byte, sizeToExtend))
 
-proc newMemory*(size: UInt256): Memory =
+proc newMemory*(size: Natural): Memory =
   result = newMemory()
-  result.extend(0.u256, size)
+  result.extend(0, size)
 
 # TODO: why is the size passed as a UInt256?
-proc read*(memory: var Memory, startPosition: UInt256, size: UInt256): seq[byte] =
-  result = memory.bytes[startPosition.toInt ..< (startPosition + size).toInt]
+proc read*(memory: var Memory, startPosition: Natural, size: Natural): seq[byte] =
+  result = memory.bytes[startPosition ..< (startPosition + size)]
 
 # TODO: why is the size passed as a UInt256?
-proc write*(memory: var Memory, startPosition: UInt256, size: UInt256, value: seq[byte]) =
+proc write*(memory: var Memory, startPosition: Natural, size: Natural, value: seq[byte]) =
   if size == 0:
     return
   #echo size
   #echo startPosition
   #validateGte(startPosition, 0)
   #validateGte(size, 0)
-  validateLength(value, size.toInt)
+  validateLength(value, size)
   validateLte(startPosition + size, memory.len)
   let index = memory.len
-  if memory.len.u256 < startPosition + size:
-    memory.bytes = memory.bytes.concat(repeat(0.byte, memory.len - (startPosition + size).toInt)) # TODO: better logarithmic scaling?
+  if memory.len < startPosition + size:
+    memory.bytes = memory.bytes.concat(repeat(0.byte, memory.len - (startPosition + size))) # TODO: better logarithmic scaling?
 
   for z, b in value:
-    memory.bytes[z + startPosition.toInt] = b
+    memory.bytes[z + startPosition] = b
 
-template write*(memory: var Memory, startPosition: UInt256, size: UInt256, value: cstring) =
+template write*(memory: var Memory, startPosition: Natural, size: Natural, value: cstring) =
   memory.write(startPosition, size, value.toBytes)

--- a/src/vm/message.nim
+++ b/src/vm/message.nim
@@ -6,46 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-    ../logging, ../constants, ../validation, stint
-
-type
-  Message* = ref object
-    # A message for VM computation
-
-    # depth = None
-
-    # code = None
-    # codeAddress = None
-
-    # createAddress = None
-
-    # shouldTransferValue = None
-    # isStatic = None
-
-    # logger = logging.getLogger("evm.vm.message.Message")
-
-    gas*:                     UInt256
-    gasPrice*:                UInt256
-    to*:                      string
-    sender*:                  string
-    value*:                   UInt256
-    data*:                    seq[byte]
-    code*:                    string
-    internalOrigin:           string
-    internalCodeAddress:      string
-    depth*:                   int
-    internalStorageAddress:   string
-    shouldTransferValue*:     bool
-    isStatic*:                bool
-    isCreate*:                bool
-
-  MessageOptions* = ref object
-    origin*:                  string
-    depth*:                   int
-    createAddress*:           string
-    codeAddress*:             string
-    shouldTransferValue*:     bool
-    isStatic*:                bool
+    ../logging, ../constants, ../validation, stint, ../types
 
 proc `origin=`*(message: var Message, value: string) =
   message.internalOrigin = value
@@ -73,8 +34,8 @@ proc newMessageOptions*(
     isStatic: isStatic)
 
 proc newMessage*(
-    gas: UInt256,
-    gasPrice: UInt256,
+    gas: GasInt,
+    gasPrice: GasInt,
     to: string,
     sender: string,
     value: UInt256,

--- a/tests/test_gas_meter.nim
+++ b/tests/test_gas_meter.nim
@@ -7,7 +7,7 @@
 
 import  unittest, macros, strformat, strutils, sequtils,
         stint,
-        ../src/[constants, opcode_values, errors, logging, vm/gas_meter]
+        ../src/[constants, opcode_values, errors, logging, types, vm/gas_meter]
 
 # TODO: quicktest
 # PS: parametrize can be easily immitated, but still quicktests would be even more useful
@@ -15,7 +15,7 @@ import  unittest, macros, strformat, strutils, sequtils,
 disableLogging()
 
 proc gasMeters: seq[GasMeter] =
-  @[newGasMeter(10.u256), newGasMeter(100.u256), newGasMeter(999.u256)]
+  @[newGasMeter(10), newGasMeter(100), newGasMeter(999)]
 
 macro all(element: untyped, handler: untyped): untyped =
   let name = ident(&"{element.repr}s")
@@ -84,15 +84,15 @@ suite "gasMeter":
     all(gasMeter):
       check(gasMeter.gasRemaining == gasMeter.startGas)
       expect(OutOfGas):
-        gasMeter.consumeGas(gasMeter.startGas + 1.u256, "")
+        gasMeter.consumeGas(gasMeter.startGas + 1, "")
 
   test "return refund works correctly":
     all(gasMeter):
       check(gasMeter.gasRemaining == gasMeter.startGas)
       check(gasMeter.gasRefunded == 0)
-      gasMeter.consumeGas(5.u256, "")
-      check(gasMeter.gasRemaining == gasMeter.startGas - 5.u256)
-      gasMeter.returnGas(5.u256)
+      gasMeter.consumeGas(5, "")
+      check(gasMeter.gasRemaining == gasMeter.startGas - 5)
+      gasMeter.returnGas(5)
       check(gasMeter.gasRemaining == gasMeter.startGas)
-      gasMeter.refundGas(5.u256)
-      check(gasMeter.gasRefunded == 5.u256)
+      gasMeter.refundGas(5)
+      check(gasMeter.gasRefunded == 5)

--- a/tests/test_memory.nim
+++ b/tests/test_memory.nim
@@ -11,17 +11,17 @@ import  unittest, macros, strformat, strutils, sequtils,
 
 proc memory32: Memory =
   result = newMemory()
-  result.extend(0.u256, 32.u256)
+  result.extend(0, 32)
 
 proc memory128: Memory =
   result = newMemory()
-  result.extend(0.u256, 128.u256)
+  result.extend(0, 128)
 
 suite "memory":
   test "write":
     var mem = memory32()
     # Test that write creates 32byte string == value padded with zeros
-    mem.write(startPosition = 0.u256, size = 4.u256, value = @[1.byte, 0.byte, 1.byte, 0.byte])
+    mem.write(startPosition = 0, size = 4, value = @[1.byte, 0.byte, 1.byte, 0.byte])
     check(mem.bytes == @[1.byte, 0.byte, 1.byte, 0.byte].concat(repeat(0.byte, 28)))
 
   # test "write rejects invalid position":
@@ -47,28 +47,28 @@ suite "memory":
   test "write rejects invalid value":
     expect(ValidationError):
       var mem = memory32()
-      mem.write(startPosition = 0.u256, size = 4.u256, value = @[1.byte, 0.byte])
+      mem.write(startPosition = 0, size = 4, value = @[1.byte, 0.byte])
 
   test "write rejects valyes beyond memory size":
     expect(ValidationError):
       var mem = memory128()
-      mem.write(startPosition = 128.u256, size = 4.u256, value = @[1.byte, 0.byte, 1.byte, 0.byte])
+      mem.write(startPosition = 128, size = 4, value = @[1.byte, 0.byte, 1.byte, 0.byte])
 
   test "extends appropriately extends memory":
     var mem = newMemory()
     # Test extends to 32 byte array: 0 < (start_position + size) <= 32
-    mem.extend(startPosition = 0.u256, size = 10.u256)
+    mem.extend(startPosition = 0, size = 10)
     check(mem.bytes == repeat(0.byte, 32))
     # Test will extend past length if params require: 32 < (start_position + size) <= 64
-    mem.extend(startPosition = 28.u256, size = 32.u256)
+    mem.extend(startPosition = 28, size = 32)
     check(mem.bytes == repeat(0.byte, 64))
     # Test won't extend past length unless params require: 32 < (start_position + size) <= 64
-    mem.extend(startPosition = 48.u256, size = 10.u256)
+    mem.extend(startPosition = 48, size = 10)
     check(mem.bytes == repeat(0.byte, 64))
 
   test "read returns correct bytes":
     var mem = memory32()
-    mem.write(startPosition = 5.u256, size = 4.u256, value = @[1.byte, 0.byte, 1.byte, 0.byte])
-    check(mem.read(startPosition = 5.u256, size = 4.u256) == @[1.byte, 0.byte, 1.byte, 0.byte])
-    check(mem.read(startPosition = 6.u256, size = 4.u256) == @[0.byte, 1.byte, 0.byte, 0.byte])
-    check(mem.read(startPosition = 1.u256, size = 3.u256) == @[0.byte, 0.byte, 0.byte])
+    mem.write(startPosition = 5, size = 4, value = @[1.byte, 0.byte, 1.byte, 0.byte])
+    check(mem.read(startPosition = 5, size = 4) == @[1.byte, 0.byte, 1.byte, 0.byte])
+    check(mem.read(startPosition = 6, size = 4) == @[0.byte, 1.byte, 0.byte, 0.byte])
+    check(mem.read(startPosition = 1, size = 3) == @[0.byte, 0.byte, 0.byte])

--- a/tests/test_opcode.nim
+++ b/tests/test_opcode.nim
@@ -16,7 +16,7 @@ import
   test_helpers
 
 
-proc testCode(code: string, initialGas: UInt256, blockNum: UInt256): BaseComputation =
+proc testCode(code: string, initialGas: GasInt, blockNum: UInt256): BaseComputation =
   let header = BlockHeader(blockNumber: blockNum)
   var vm = newNimbusVM(header, newBaseChainDB(newMemoryDB()))
     # coinbase: "",
@@ -32,7 +32,7 @@ proc testCode(code: string, initialGas: UInt256, blockNum: UInt256): BaseComputa
     data = @[],
     code=code,
     gas=initial_gas,
-    gasPrice=1.u256) # What is this used for?
+    gasPrice=1) # What is this used for?
     # gasPrice=fixture{"exec"}{"gasPrice"}.getHexadecimalInt.u256,
     #options=newMessageOptions(origin=fixture{"exec"}{"origin"}.getStr))
 
@@ -53,10 +53,10 @@ suite "opcodes":
   test "add":
     var c = testCode(
       "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01",
-      100_000.u256,
+      100_000,
       0.u256
       )
-    check(c.gasMeter.gasRemaining == 99_991.u256)
+    check(c.gasMeter.gasRemaining == 99_991)
     check(c.stack.peek == "115792089237316195423570985008687907853269984665640564039457584007913129639934".u256)
 #     let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
 #   let code = "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055".from_hex().unwrap();
@@ -80,33 +80,33 @@ suite "opcodes":
     block: # Using Balance (0x31)
       var c = testCode(
         "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff31",
-        100_000.u256,
+        100_000,
         0.u256
         )
-      check: c.gasMeter.gasRemaining == 100000.u256 - 3.u256 - 20.u256 # Starting gas - push32 (verylow) - balance
+      check: c.gasMeter.gasRemaining == 100000 - 3 - 20 # Starting gas - push32 (verylow) - balance
 
     block: # Using SLOAD (0x54)
       var c = testCode(
         "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff54",
-        100_000.u256,
+        100_000,
         0.u256
         )
-      check: c.gasMeter.gasRemaining == 100000.u256 - 3.u256 - 50.u256 # Starting gas - push32 (verylow) - SLOAD
+      check: c.gasMeter.gasRemaining == 100000 - 3 - 50 # Starting gas - push32 (verylow) - SLOAD
 
 
   test "Tangerine VM computation - post-EIP150 gas cost properly applied":
     block: # Using Balance (0x31)
       var c = testCode(
         "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff31",
-        100_000.u256,
+        100_000,
         2_463_000.u256 # Tangerine block
         )
-      check: c.gasMeter.gasRemaining == 100000.u256 - 3.u256 - 400.u256 # Starting gas - push32 (verylow) - balance
+      check: c.gasMeter.gasRemaining == 100000 - 3 - 400 # Starting gas - push32 (verylow) - balance
 
     block: # Using SLOAD (0x54)
       var c = testCode(
         "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff54",
-        100_000.u256,
+        100_000,
         2_463_000.u256
         )
-      check: c.gasMeter.gasRemaining == 100000.u256 - 3.u256 - 200.u256 # Starting gas - push32 (verylow) - SLOAD
+      check: c.gasMeter.gasRemaining == 100000 - 3 - 200 # Starting gas - push32 (verylow) - SLOAD


### PR DESCRIPTION
This refactoring is according to #35, see full rationale there.

Other implementations:
  - Go-Ethereum uses [uint64 with explicit overflow checks](https://github.com/ethereum/go-ethereum/blob/8771c3061f340451d0966adcc547338a25f2231f/common/math/integer.go#L81-L99)
  - Py-EVM uses Python arbitrary size integer but has an [explicit gas limit](https://github.com/ethereum/py-evm/blob/7f33392e92d1bd0a56b24fdec210d077449d3533/evm/constants.py#L104) of 2^63 - 1
  - Parity uses [uint256 but tries to drop down to uint64](https://github.com/paritytech/parity/blob/e346f3058ef806ae397571beef5901f8723116d9/ethcore/evm/src/evm.rs#L58-L76) as much as possible.

Details:
  - An alias `GasInt` has been introduced to easily switch from int64 to what we want in the future, for example `range[0'i64 .. high(int64)]`.
  - Int64 will throw exceptions on gas overflow if compiled with --overflowChecks. I'm pretty sure the EVM does it as well, but to be confirmed.
  - I solved #39 as well, i.e. overloading `^`(int, int): Uint256
  - I moved `Message` and `GasMeter` types in `types.nim` to avoid recursive imports
  - EVM memory operations (pointer + length) were changed to use `Natural` instead of `uint256` as well

Pending:
  - I didn't try to compile vm_tests_json today, so don't merge yet.

What did I learn:
  - `call.nim` code is 80% about dealing with the various gas costs depending on the block number and vm fork and not about `CALL` opcode logic. This will be addressed by #36 .