### PR TITLE
Dirty fix #46 (test_vm_json segfaults from #45), incidentally fix #32

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -144,7 +144,7 @@ VMTests
 + mulmod2_1.json                                                  OK
 + mulmod3.json                                                    OK
 + mulmod3_0.json                                                  OK
-- mulmod4.json                                                    Fail
++ mulmod4.json                                                    OK
 + mulmoddivByZero.json                                            OK
 + mulmoddivByZero1.json                                           OK
 + mulmoddivByZero2.json                                           OK
@@ -198,7 +198,7 @@ VMTests
 + sub3.json                                                       OK
 + sub4.json                                                       OK
 ```
-OK: 189/195 Fail: 5/195 Skip: 1/195
+OK: 190/195 Fail: 4/195 Skip: 1/195
 ## vmBitwiseLogicOperation
 ```diff
 + and0.json                                                       OK
@@ -720,8 +720,8 @@ OK: 0/36 Fail: 0/36 Skip: 36/36
 ## vmTests
 ```diff
   arith.json                                                      Skip
-- boolean.json                                                    Fail
-- mktx.json                                                       Fail
-- suicide.json                                                    Fail
++ boolean.json                                                    OK
++ mktx.json                                                       OK
++ suicide.json                                                    OK
 ```
-OK: 0/4 Fail: 3/4 Skip: 1/4
+OK: 3/4 Fail: 0/4 Skip: 1/4

--- a/nimbus/logic/call.nim
+++ b/nimbus/logic/call.nim
@@ -7,7 +7,7 @@
 
 import
   strformat, eth_common,
-  ../constants, ../vm_types, ../errors, ../computation, ../opcode, ../opcode_values, ../logging,
+  ../constants, ../vm_types, ../errors, ../computation, ../opcode_values, ../logging,
   .. / vm / [stack, memory, gas_meter, message],
   .. / utils / [address, bytes],
   stint
@@ -52,7 +52,7 @@ method callParams*(call: BaseCall, computation): (UInt256, UInt256, EthAddress, 
   raise newException(NotImplementedError, "Must be implemented subclasses")
 
 method runLogic*(call: BaseCall, computation) =
-  computation.gasMeter.consumeGas(computation.gasCosts[call.gasCost(computation)], reason = $call.kind) # TODO: Refactoring call gas costs
+  computation.gasMeter.consumeGas(computation.gasCosts[call.gasCostKind], reason = $call.kind) # TODO: Refactoring call gas costs
   let (gas, value, to, sender,
        codeAddress,
        memoryInputStartPosition, memoryInputSize,
@@ -87,7 +87,7 @@ method runLogic*(call: BaseCall, computation) =
     else:
       raise newException(VMError, "Invariant: Unreachable code path")
 
-    call.logger.debug(&"{call.kind} failure: {errMessage}")
+    computation.logger.debug(&"{call.kind} failure: {errMessage}")
     computation.gasMeter.returnGas(childMsgGas)
     computation.stack.push(0.u256)
   else:

--- a/nimbus/opcode.nim
+++ b/nimbus/opcode.nim
@@ -10,11 +10,22 @@ import
   constants, logging, errors, opcode_values, computation, vm/stack, stint,
   ./vm_types
 
+
+# Super dirty fix for https://github.com/status-im/nimbus/issues/46
+# Pending https://github.com/status-im/nimbus/issues/36
+# Disentangle opcode logic
+from logic.call import runLogic, BaseCall
+
+
 template run*(opcode: Opcode, computation: var BaseComputation) =
   # Hook for performing the actual VM execution
   # opcode.consumeGas(computation)
   computation.gasMeter.consumeGas(computation.gasCosts[opcode.gasCost(computation)], reason = $opcode.kind) # TODO: further refactoring of gas costs
-  opcode.runLogic(computation)
+
+  if opcode.kind == Op.Call: # Super dirty fix for https://github.com/status-im/nimbus/issues/46
+    runLogic(BaseCall(opcode), computation)
+  else:
+    opcode.runLogic(computation)
 
 method logger*(opcode: Opcode): Logger =
   logging.getLogger(&"vm.opcode.{opcode.kind}")


### PR DESCRIPTION
Fix #46 regression (from #45)

This is super ugly and in my opinion shows that the current opcode logic is flawed.
`DelegateCall`, `CallCode` and `Create` opcodes require the same treatment.

This will be addressed in #36 but for the moment it does the job and even has the luxury of fixing:

- mulmod4 test
- boolean, mktx and suicide test from #32