### PR TITLE
Fix nimble warning

### DIFF
--- a/nimbus.nimble
+++ b/nimbus.nimble
@@ -5,7 +5,7 @@ version       = "0.1.0"
 author        = "Status Research & Development GmbH"
 description   = "An Ethereum 2.0 Sharding Client for Resource-Restricted Devices"
 license       = "Apache License 2.0"
-skipDirs      = @["tests"]
+skipDirs      = @["tests", "examples"]
 
 requires "nim >= 0.18.1",
          "nimcrypto",


### PR DESCRIPTION
Nimble warns about .nim files that are outside of the 'nimbus' directory
when they are not mentioned in the skipDirs.