### PR TITLE
Change import from eth-rpc to json_rpc

### DIFF
--- a/nimbus/rpc/common.nim
+++ b/nimbus/rpc/common.nim
@@ -6,7 +6,7 @@
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
-import eth-rpc/server, nimcrypto
+import json_rpc/server, nimcrypto
 import ../config
 
 proc setupCommonRPC*(server: RpcServer) =

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -6,7 +6,7 @@
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
-import nimcrypto, eth-rpc/server, eth_p2p
+import nimcrypto, json_rpc/server, eth_p2p
 import ../config
 
 proc setupP2PRPC*(server: EthereumNode, rpcsrv: RpcServer) =


### PR DESCRIPTION
A tiny PR to change the name of the imports for RPC from `eth-rpc` to `json_rpc`.