### PR TITLE
add subcase of yellow paper equation (297) for zero-length memory ranges

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -669,14 +669,14 @@ OK: 0/17 Fail: 0/17 Skip: 17/17
 + sha3_bigSize.json                                               OK
 + sha3_memSizeNoQuadraticCost31.json                              OK
 + sha3_memSizeQuadraticCost32.json                                OK
-- sha3_memSizeQuadraticCost32_zeroSize.json                       Fail
++ sha3_memSizeQuadraticCost32_zeroSize.json                       OK
 + sha3_memSizeQuadraticCost33.json                                OK
 + sha3_memSizeQuadraticCost63.json                                OK
 + sha3_memSizeQuadraticCost64.json                                OK
 + sha3_memSizeQuadraticCost64_2.json                              OK
 + sha3_memSizeQuadraticCost65.json                                OK
 ```
-OK: 17/18 Fail: 1/18 Skip: 0/18
+OK: 18/18 Fail: 0/18 Skip: 0/18
 ## vmSystemOperations
 ```diff
   ABAcalls0.json                                                  Skip

--- a/nimbus/vm/interpreter/gas_costs.nim
+++ b/nimbus/vm/interpreter/gas_costs.nim
@@ -120,6 +120,17 @@ template gasCosts(FeeSchedule: GasFeeSchedule, prefix, ResultGasCostsName: untyp
     #   μ'i is the memory size after opcode execution
 
     #   Cmem(a) ≡ Gmemory · a + a² / 512
+    #
+    #   Except when memLength = 0, where per eq (297),
+    #   M(currentMemSize, f, l) = currentMemSize
+
+    if memLength == 0:
+      # Special subcase of memory-expansion cost
+      # currentMemSize - currentMemSize = 0
+      # "Referencing a zero length range ... does not require memory to be extended
+      #  to the beginning of the range."
+      return 0
+
     let
       prev_words = currentMemSize.wordCount
       prev_cost = prev_words * static(FeeSchedule[GasMemory]) +


### PR DESCRIPTION
This short-circuits some computations that would all cancel out to 0.