### PR TITLE
ExtCodeCopy is a memory expansion operation for gas computation purposes

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -323,10 +323,10 @@ OK: 11/12 Fail: 1/12 Skip: 0/12
 - codecopy_DataIndexTooHigh.json                                  Fail
 + codesize.json                                                   OK
 - env1.json                                                       Fail
-- extcodecopy0.json                                               Fail
-- extcodecopy0AddressTooBigLeft.json                              Fail
-- extcodecopy0AddressTooBigRight.json                             Fail
-- extcodecopyZeroMemExpansion.json                                Fail
++ extcodecopy0.json                                               OK
++ extcodecopy0AddressTooBigLeft.json                              OK
++ extcodecopy0AddressTooBigRight.json                             OK
++ extcodecopyZeroMemExpansion.json                                OK
 - extcodecopy_DataIndexTooHigh.json                               Fail
 + extcodesize0.json                                               OK
 + extcodesize1.json                                               OK
@@ -334,7 +334,7 @@ OK: 11/12 Fail: 1/12 Skip: 0/12
 + gasprice.json                                                   OK
 + origin.json                                                     OK
 ```
-OK: 29/52 Fail: 8/52 Skip: 15/52
+OK: 33/52 Fail: 4/52 Skip: 15/52
 ## vmIOandFlowOperations
 ```diff
 + BlockNumberDynamicJump0_AfterJumpdest.json                      OK

--- a/nimbus/vm/interpreter/gas_costs.nim
+++ b/nimbus/vm/interpreter/gas_costs.nim
@@ -163,11 +163,10 @@ template gasCosts(FeeSchedule: GasFeeSchedule, prefix, ResultGasCostsName: untyp
       static(FeeSchedule[GasCopy]) * memLength.wordCount
     result += `prefix gasMemoryExpansion`(currentMemSize, memOffset, memLength)
 
-  func `prefix gasExtCodeCopy`(value: Uint256): GasInt {.nimcall.} =
-    ## Value is the size of the input to the CallDataCopy/CodeCopy/ReturnDataCopy function
-
-    result = static(FeeSchedule[GasVeryLow]) +
-      static(FeeSchedule[GasCopy]) * value.toInt.wordCount
+  func `prefix gasExtCodeCopy`(currentMemSize, memOffset, memLength: Natural): GasInt {.nimcall.} =
+    result = static(FeeSchedule[GasExtCode]) +
+      static(FeeSchedule[GasCopy]) * memLength.wordCount
+    result += `prefix gasMemoryExpansion`(currentMemSize, memOffset, memLength)
 
   func `prefix gasLoadStore`(currentMemSize, memOffset, memLength: Natural): GasInt {.nimcall.} =
     result = static(FeeSchedule[GasVeryLow])
@@ -375,7 +374,7 @@ template gasCosts(FeeSchedule: GasFeeSchedule, prefix, ResultGasCostsName: untyp
           CodeCopy:        memExpansion `prefix gasCopy`,
           GasPrice:        fixed GasBase,
           ExtCodeSize:     fixed GasExtcode,
-          ExtCodeCopy:     dynamic `prefix gasExtCodeCopy`,
+          ExtCodeCopy:     memExpansion `prefix gasExtCodeCopy`,
           ReturnDataSize:  fixed GasBase,
           ReturnDataCopy:  memExpansion `prefix gasCopy`,
 

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -319,7 +319,7 @@ op extCodeCopy, inline = true:
   let (memPos, codePos, len) = (memStartPos.toInt, codeStartPos.toInt, size.toInt)
 
   computation.gasMeter.consumeGas(
-    computation.gasCosts[CodeCopy].m_handler(memPos, codePos, len),
+    computation.gasCosts[ExtCodeCopy].m_handler(memPos, codePos, len),
     reason="ExtCodeCopy fee")
 
   let codeBytes = computation.vmState.readOnlyStateDB.getCode(account)


### PR DESCRIPTION
The existing code seemed to be stubbed, essentially. The gas cost function wasn't even running; it could be filled with random garbage with no change in test output.

There's a lot of boilerplate around this memory expansion opcode type -- it seems to be a whole class of bugs which one might automate away.