### PR TITLE
accessing memory can't cost less than nothing

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -406,8 +406,8 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + deadCode_1.json                                                 OK
 + dupAt51becameMload.json                                         OK
 - extcodecopyMemExp.json                                          Fail
-- for_loop1.json                                                  Fail
-- for_loop2.json                                                  Fail
++ for_loop1.json                                                  OK
++ for_loop2.json                                                  OK
 + gas0.json                                                       OK
 + gas1.json                                                       OK
 + gasOverFlow.json                                                OK
@@ -451,7 +451,7 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + loop_stacklimit_1021.json                                       OK
 + memory1.json                                                    OK
 + mloadError0.json                                                OK
-- mloadError1.json                                                Fail
++ mloadError1.json                                                OK
 + mloadMemExp.json                                                OK
 + mloadOutOfGasError2.json                                        OK
 + msize0.json                                                     OK
@@ -472,7 +472,7 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + pop0.json                                                       OK
 + pop1.json                                                       OK
 + return1.json                                                    OK
-- return2.json                                                    Fail
++ return2.json                                                    OK
 + sha3MemExp.json                                                 OK
 + sstore_load_0.json                                              OK
 + sstore_load_1.json                                              OK
@@ -483,7 +483,7 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + swapAt52becameMstore.json                                       OK
 + when.json                                                       OK
 ```
-OK: 134/145 Fail: 10/145 Skip: 1/145
+OK: 138/145 Fail: 6/145 Skip: 1/145
 ## vmLogTest
 ```diff
 + log0_emptyMem.json                                              OK


### PR DESCRIPTION
The general pattern here was that test cases allocating sufficient memory, then repeatedly accessing lower addresses, effectively got credit for "negative" memory gas costs. This needed sufficient (e.g., sometimes beyond-32-byte/1-word boundaries, etc) conditions in which to manifest. Bigger gas discreptancies were observed where e.g., the for loop tests did this, well, in loops.

See https://github.com/ethereum/go-ethereum/blob/2433349c808fad601419d1f06275bec5b6a93ec8/core/vm/gas_table.go#L25 for how geth handles this. Same idea as used here.