### PR TITLE
Ethereum test fixtures provide storage values as hex literals

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -385,16 +385,16 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + JDfromStorageDynamicJump0_AfterJumpdest.json                    OK
 + JDfromStorageDynamicJump0_AfterJumpdest3.json                   OK
 + JDfromStorageDynamicJump0_foreverOutOfGas.json                  OK
-- JDfromStorageDynamicJump0_jumpdest0.json                        Fail
-- JDfromStorageDynamicJump0_jumpdest2.json                        Fail
++ JDfromStorageDynamicJump0_jumpdest0.json                        OK
++ JDfromStorageDynamicJump0_jumpdest2.json                        OK
 + JDfromStorageDynamicJump0_withoutJumpdest.json                  OK
 + JDfromStorageDynamicJump1.json                                  OK
 + JDfromStorageDynamicJumpInsidePushWithJumpDest.json             OK
 + JDfromStorageDynamicJumpInsidePushWithoutJumpDest.json          OK
 + JDfromStorageDynamicJumpi0.json                                 OK
-- JDfromStorageDynamicJumpi1.json                                 Fail
++ JDfromStorageDynamicJumpi1.json                                 OK
 + JDfromStorageDynamicJumpi1_jumpdest.json                        OK
-- JDfromStorageDynamicJumpiAfterStop.json                         Fail
++ JDfromStorageDynamicJumpiAfterStop.json                         OK
 + JDfromStorageDynamicJumpiOutsideBoundary.json                   OK
 + JDfromStorageDynamicJumpifInsidePushWithJumpDest.json           OK
 + JDfromStorageDynamicJumpifInsidePushWithoutJumpDest.json        OK
@@ -483,7 +483,7 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + swapAt52becameMstore.json                                       OK
 + when.json                                                       OK
 ```
-OK: 138/145 Fail: 6/145 Skip: 1/145
+OK: 142/145 Fail: 2/145 Skip: 1/145
 ## vmLogTest
 ```diff
 + log0_emptyMem.json                                              OK

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -92,7 +92,7 @@ proc setupStateDB*(wantedState: JsonNode, stateDB: var AccountStateDB) =
   for ac, accountData in wantedState:
     let account = ethAddressFromHex(ac)
     for slot, value in accountData{"storage"}:
-      stateDB.setStorage(account, slot.parseHexInt.u256, value.getInt.u256)
+      stateDB.setStorage(account, slot.parseHexInt.u256, value.getStr.parseHexInt.u256)
 
     let nonce = accountData{"nonce"}.getInt.u256
     let code = hexToSeqByte(accountData{"code"}.getStr).toRange


### PR DESCRIPTION
4 indirect jump test cases (jump to inline push1'd constant + storage[0]) was jumping 4 bytes too early in 4 test cases because the storage was being incorrectly initialized to storage[0] = 0, not storage[0] = 4.

These were partly manifesting as gas discreptancies by ~20k due to sstore costs, but this was root cause.

There don't appear to be any decimal (vs hex) value specifiers in the test cases, so it was reasonable to switch parsing to hex-only.