### PR TITLE
first approach to detecting addition overflow for copy opcodes

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -320,21 +320,21 @@ OK: 11/12 Fail: 1/12 Skip: 0/12
 + callvalue.json                                                  OK
 + codecopy0.json                                                  OK
 + codecopyZeroMemExpansion.json                                   OK
-- codecopy_DataIndexTooHigh.json                                  Fail
++ codecopy_DataIndexTooHigh.json                                  OK
 + codesize.json                                                   OK
 - env1.json                                                       Fail
 + extcodecopy0.json                                               OK
 + extcodecopy0AddressTooBigLeft.json                              OK
 + extcodecopy0AddressTooBigRight.json                             OK
 + extcodecopyZeroMemExpansion.json                                OK
-- extcodecopy_DataIndexTooHigh.json                               Fail
++ extcodecopy_DataIndexTooHigh.json                               OK
 + extcodesize0.json                                               OK
 + extcodesize1.json                                               OK
 + extcodesizeUnderFlow.json                                       OK
 + gasprice.json                                                   OK
 + origin.json                                                     OK
 ```
-OK: 33/52 Fail: 4/52 Skip: 15/52
+OK: 35/52 Fail: 2/52 Skip: 15/52
 ## vmIOandFlowOperations
 ```diff
 + BlockNumberDynamicJump0_AfterJumpdest.json                      OK


### PR DESCRIPTION
Two test cases position the copy offset start at what, in signed representations, is -6, and ask for 8 bytes. This caused problems with the gas calculation -- fixed by casting to uint64 in each of copycode/extcopycode opcode implementations, so that the gas calculation didn't get confused -- and actual memory copying of this absurdity.

The tests only currently hit copyStartPos/codeStartPos, but negative values on basically any input here aren't well-handled (i.e. coerced in a lossless attempt to a Natural, which fail).

Only fixed the immediately relevant param, pending a structural fix with less boilerplate and repetition than a full fix would need. Lots of approaches but staying to minimal, proximate changes to start with.

Better coordinating types across stint <-> {ext,}codecopy <-> gas cost calculations to enable no/fewer casts would help; both C++ and Go official EF clients rely on C-style unsigned arithmetic, so this is baked into the standard.

Regarding the approach to overflow and/or wraparound detection (depending on signed/unsigned perspective), it's possible to detect addition wraparound using the signed arithmetic the rules of which Natural keeps reverting to by going case by case depending on four combinations of (+/-) signed across the two operands, but that seems contrived, so the code is very insistent about working on uint64's.