### PR TITLE
memory expansion boilerplate usage wasn't 100% consistent

### DIFF
--- a/VMTests.md
+++ b/VMTests.md
@@ -402,10 +402,10 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + bad_indirect_jump2.json                                         OK
 + byte1.json                                                      OK
   calldatacopyMemExp.json                                         Skip
-- codecopyMemExp.json                                             Fail
++ codecopyMemExp.json                                             OK
 + deadCode_1.json                                                 OK
 + dupAt51becameMload.json                                         OK
-- extcodecopyMemExp.json                                          Fail
++ extcodecopyMemExp.json                                          OK
 + for_loop1.json                                                  OK
 + for_loop2.json                                                  OK
 + gas0.json                                                       OK
@@ -483,7 +483,7 @@ OK: 33/52 Fail: 4/52 Skip: 15/52
 + swapAt52becameMstore.json                                       OK
 + when.json                                                       OK
 ```
-OK: 142/145 Fail: 2/145 Skip: 1/145
+OK: 144/145 Fail: 0/145 Skip: 1/145
 ## vmLogTest
 ```diff
 + log0_emptyMem.json                                              OK

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -297,7 +297,7 @@ op codecopy, inline = false, memStartPos, copyStartPos, size:
   let (memPos, copyPos, len) = (memStartPos.toInt, copyStartPos.toInt, size.toInt)
 
   computation.gasMeter.consumeGas(
-    computation.gasCosts[CodeCopy].m_handler(memPos, copyPos, len),
+    computation.gasCosts[CodeCopy].m_handler(computation.memory.len, memPos, len),
     reason="CodeCopy fee")
 
   computation.memory.writePaddedResult(computation.code.bytes, memPos, copyPos, len)
@@ -319,7 +319,7 @@ op extCodeCopy, inline = true:
   let (memPos, codePos, len) = (memStartPos.toInt, codeStartPos.toInt, size.toInt)
 
   computation.gasMeter.consumeGas(
-    computation.gasCosts[ExtCodeCopy].m_handler(memPos, codePos, len),
+    computation.gasCosts[ExtCodeCopy].m_handler(computation.memory.len, memPos, len),
     reason="ExtCodeCopy fee")
 
   let codeBytes = computation.vmState.readOnlyStateDB.getCode(account)


### PR DESCRIPTION
My only comment here is that if all the m_handler cases need computation.memory.len as their first parameter, that's evidently potentially buggy boilerplate/repetition to allow to be specified anew each time.

Reading the yellow paper sections, it's not clear to me it should be anything else.