### PR TITLE
remove callcreates-handling code in VMTests harness

### DIFF
--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -105,26 +105,6 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
             (actualGasRemaining > expectedGasRemaining and (actualGasRemaining - expectedGasRemaining) mod 15_000 == 0 or
              expectedGasRemaining > actualGasRemaining and (expectedGasRemaining - actualGasRemaining) mod 15_000 == 0))
 
-    let callCreatesJson = fixture{"callcreates"}
-    var callCreates: seq[JsonNode] = @[]
-    if not callCreatesJson.isNil:
-      for next in callCreatesJson:
-        callCreates.add(next)
-
-    check(computation.children.len == callCreates.len)
-    for child in zip(computation.children, callCreates):
-      var (childComputation, createdCall) = child
-      let toAddress = createdCall{"destination"}.getStr.parseAddress
-      let data = createdCall{"data"}.getStr.hexToSeqByte
-      let gasLimit = createdCall{"gasLimit"}.getHexadecimalInt
-      let value = createdCall{"value"}.getHexadecimalInt.u256
-
-      check(childComputation.msg.to == toAddress)
-      check(data == childComputation.msg.data or childComputation.msg.code.len > 0)
-      check(gasLimit == childComputation.msg.gas)
-      check(value == childComputation.msg.value)
-      # TODO postState = fixture{"post"}
-
     if not fixture{"post"}.isNil:
       verifyStateDb(fixture{"post"}, computation.vmState.readOnlyStateDB)
   else:


### PR DESCRIPTION
1. callcreates, empirically, is always missing or empty in VMTests;
2. by policy, callcreates will not be in new VMTests
3. the code was broken, regardless, as a couple of since-removed VMTests which had non-empty callcreates had demonstated. It was not creating `computation.children`.