### PR TITLE
Initial EVMC message type API matching

### DIFF
--- a/nimbus/vm/message.nim
+++ b/nimbus/vm/message.nim
@@ -23,16 +23,14 @@ proc newMessageOptions*(
     depth: int = 0,
     createAddress = ZERO_ADDRESS,
     codeAddress = ZERO_ADDRESS,
-    shouldTransferValue: bool = true,
-    isStatic: bool = false): MessageOptions =
+    flags: MsgFlags = static(emvcNoFlags)): MessageOptions =
 
   result = MessageOptions(
     origin: origin,
     depth: depth,
     createAddress: createAddress,
     codeAddress: codeAddress,
-    shouldTransferValue: shouldTransferValue,
-    isStatic: isStatic)
+    flags: flags)
 
 proc newMessage*(
     gas: GasInt,
@@ -49,15 +47,14 @@ proc newMessage*(
   new(result)
   result.gas = gas
   result.gasPrice = gasPrice
-  result.to = to
+  result.destination = to
   result.sender = sender
   result.value = value
   result.data = data
   result.depth = options.depth
   result.storageAddress = options.createAddress
   result.codeAddress = options.codeAddress
-  result.shouldTransferValue = options.shouldTransferValue
-  result.isStatic = options.isStatic
+  result.flags = options.flags
   result.code = code
 
   if options.origin != ZERO_ADDRESS:
@@ -78,13 +75,13 @@ proc codeAddress*(message: Message): EthAddress =
   if message.internalCodeAddress != ZERO_ADDRESS:
     message.internalCodeAddress
   else:
-    message.to
+    message.destination
 
 proc `storageAddress`*(message: Message): EthAddress =
   if message.internalStorageAddress != ZERO_ADDRESS:
     message.internalStorageAddress
   else:
-    message.to
+    message.destination
 
 proc isCreate(message: Message): bool =
-  message.to == CREATE_CONTRACT_ADDRESS
+  message.destination == CREATE_CONTRACT_ADDRESS

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -51,8 +51,20 @@ type
     startGas*: GasInt
     gasRemaining*: GasInt
 
+  CallKind* = enum
+    evmcCall         = 0, # CALL
+    evmcDelegateCall = 1, # DELEGATECALL
+    evmcCallCode     = 2, # CALLCODE
+    evmcCreate       = 3, # CREATE
+    evmcCreate2      = 4  # CREATE2
+
+  MsgFlags* = enum
+    emvcNoFlags  = 0
+    emvcStatic   = 1
+
   Message* = ref object
     # A message for VM computation
+    # https://github.com/ethereum/evmc/blob/master/include/evmc/evmc.h
 
     # depth = None
 
@@ -61,30 +73,33 @@ type
 
     # createAddress = None
 
-    # shouldTransferValue = None
-    # isStatic = None
-
     # logger = logging.getLogger("evm.vm.message.Message")
 
-    gas*:                     GasInt
-    gasPrice*:                GasInt
-    to*:                      EthAddress
+    destination*:             EthAddress
     sender*:                  EthAddress
     value*:                   UInt256
     data*:                    seq[byte]
+    # size_t input_size;
+    codeHash*:                UInt256
+    create2Salt*:             Uint256
+    gas*:                     GasInt
+    gasPrice*:                GasInt
+    depth*:                   int
+    kind*:                    CallKind
+    flags*:                   MsgFlags
+
+    # Not in EVMC API
+
+    # TODO: Done via callback function (v)table in EVMC
     code*:                    string    # TODO: seq[byte] is probably a better representation
+
     internalOrigin*:          EthAddress
     internalCodeAddress*:     EthAddress
-    depth*:                   int
     internalStorageAddress*:  EthAddress
-    shouldTransferValue*:     bool
-    isStatic*:                bool
-    isCreate*:                bool
 
   MessageOptions* = ref object
     origin*:                  EthAddress
     depth*:                   int
     createAddress*:           EthAddress
     codeAddress*:             EthAddress
-    shouldTransferValue*:     bool
-    isStatic*:                bool
+    flags*:                   MsgFlags


### PR DESCRIPTION
https://github.com/status-im/nimbus/issues/61

-reorder overlapping fields to match EMVC;
-rename "to" to destination;
-replace isStatic (not in EVMC) with more general flags (with only one non-zero value);
-remove superfluous-seeming shouldTransferValue (not in EVMC);
-keep internalFoo fields, which aren't in PyEVM either, so weren't per se, it looks like, part of PyEVM matching

It appears to have been all plumbing, no real implementation of the modified fields (e.g., isStatic was never checked), so it doesn't change much executionwise at the moment.

I tried to balance specificity of names/types (e.g., "MsgFlags") with matching EMVC more verbatim.