### PR TITLE
travis: use ccache

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,7 +54,7 @@ install:
   - koch nimble
 build_script:
   - cd C:\projects\%APPVEYOR_PROJECT_SLUG%
-  - nimble install -y
+  - nimble install -dy
 test_script:
   - nimble test
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,13 +43,8 @@ install:
   - 7z x -y "%ROCKSDB_ARCHIVE%" > nul
   - IF "%PLATFORM%" == "x64" ( copy %CD%\x64\librocksdb.dll %CD%\bin\librocksdb.dll ) ELSE ( copy %CD%\x86\librocksdb.dll %CD%\bin\librocksdb.dll )
   - SET PATH=%CD%\%MINGW_DIR%\bin;%CD%\bin;%CD%\Nim\bin;%PATH%
-  - git clone https://github.com/nim-lang/Nim.git
+  - git clone https://github.com/status-im/Nim.git
   - cd %CD%\Nim
-  - git remote add statusim https://github.com/status-im/Nim.git
-  - git fetch statusim
-  - git config --global user.email "you@example.com"
-  - git config --global user.name "Your Name"
-  - for /f "tokens=*" %%G IN ('git branch -a --list ^"statusim/status-autopatch-*^"') DO (git merge %%G)
   - git clone --depth 1 https://github.com/nim-lang/csources
   - cd csources
   - IF "%PLATFORM%" == "x64" ( build64.bat ) else ( build.bat )

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - nim
 
 install:
-  - export NIMVER=$(git ls-remote  git@github.com:status-im/nimbus.git HEAD | cut -f 1)
+  - export NIMVER=$(git ls-remote https://github.com/status-im/nim.git HEAD | cut -f 1)
   - "[ -f nim/$NIMVER/bin/nim ] || { mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }"
   - export PATH=$PWD/nim/$NIMVER/bin:$PATH
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 install:
   - export NIMVER=$(git ls-remote  git@github.com:status-im/nimbus.git HEAD | cut -f 1)
-  - [ -f nim/$NIMVER/bin/nim ] || { mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }
+  - "[ -f nim/$NIMVER/bin/nim ] || { mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }"
   - export PATH=$PWD/nim/$NIMVER/bin:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       sudo: required
       before_install:
         - sudo apt-get install -y libssl-dev libgflags-dev libsnappy-dev
-        - "[ -d rocksdb-5.14.2 ] || { wget https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz && tar xvf v5.14.2.tar.gz; }"
+        - "[ -f rocksdb-5.14.2/Makefile ] || { wget https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz && tar xvf v5.14.2.tar.gz; }"
         # rocksdb not present on trusty - on a newer ubuntu you can apt-get install -y librocksdb-dev
         - cd rocksdb-5.14.2 && make shared_lib -j$(nproc) && sudo make INSTALL_PATH=/usr install-shared && cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ matrix:
       cache: ccache
       sudo: required
       before_install:
-        - sudo apt-get install -y libssl-dev librocksdb-dev
+        - sudo apt-get install -y libssl-dev libgflags-dev libsnappy-dev
+        - git clone https://github.com/facebook/rocksdb.git
+        - cd rocksdb && make shared_lib && sudo make install && cd ..
         - git clone https://github.com/status-im/nim.git
         - cd nim
         - sh build_all.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ matrix:
       sudo: required
       before_install:
         - sudo apt-get install -y libssl-dev libgflags-dev libsnappy-dev
-        - git clone https://github.com/facebook/rocksdb.git
+        - wget https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz
+        - tar xvf v5.14.2.tar.gz
         # rocksdb not present on trusty - on a newer ubuntu you can apt-get install -y librocksdb-dev
-        - cd rocksdb && git checkout v5.14.2 && make shared_lib -j$(nproc) && sudo make INSTALL_PATH=/usr install-shared && cd ..
+        - cd rocksdb-5.14.2 && make shared_lib -j$(nproc) && sudo make INSTALL_PATH=/usr install-shared && cd ..
 
     - os: osx
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
       before_install:
         - sudo apt-get install -y libssl-dev libgflags-dev libsnappy-dev
         - git clone https://github.com/facebook/rocksdb.git
-        - cd rocksdb && make shared_lib && sudo make install && cd ..
+        # rocksdb not present on trusty - on a newer ubuntu you can apt-get install -y librocksdb-dev
+        - cd rocksdb && git checkout v5.14.2 && make shared_lib -j$(nproc) && sudo make INSTALL_PATH=/usr install-shared && cd ..
         - git clone https://github.com/status-im/nim.git
         - cd nim
         - sh build_all.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,38 @@
+language: c # or other C/C++ variants
+
+cache: ccache
+
 matrix:
   # allow_failures:
   #   - os: osx
 
   include:
     - os: linux
+      cache: ccache
       sudo: required
-      services:
-        - docker
       before_install:
-        - docker pull statusteam/nim-base
+        - sudo apt-get install -y libssl-dev librocksdb-dev
+        - git clone https://github.com/status-im/nim.git
+        - cd nim
+        - sh build_all.sh
+        - cd ..
+        - export PATH=$PWD/nim/bin:$PATH
       script:
-        - docker run statusteam/nim-base nim --version
-        - docker run -v "$(pwd):/project" -w /project statusteam/nim-base sh -c "nimble install -dy && nimble test"
+        - nimble install -dy && nimble test
 
     - os: osx
       before_install:
         - brew update
-        - brew install rocksdb
+        - brew install rocksdb ccache
+        - export PATH="/usr/local/opt/ccache/libexec:$PATH"
         # - brew install gcc
 
-        - git clone https://github.com/nim-lang/nim.git
+        - git clone https://github.com/status-im/nim.git
         - cd nim
-        - git remote add statusim https://github.com/status-im/nim.git
-        - git fetch statusim
-        - git config --global user.email "you@example.com"
-        - git config --global user.name "Your Name"
-        - for b in $(git branch -a --list 'statusim/status-autopatch-*'); do git merge $b; done
-        - git clone --depth 1 https://github.com/nim-lang/csources.git
-        - cd csources
-        - sh build.sh
+        - sh build_all.sh
         - cd ..
-        - export PATH=$PWD/bin:$PATH
-        - nim c koch
-        - ./koch boot -d:release
-        - ./koch nimble
-        - cd ..
+        - export PATH=$PWD/nim/bin:$PATH
+
 
       script:
         - nimble install -dy && nimble test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 install:
   - export NIMVER=$(git ls-remote https://github.com/status-im/nim.git HEAD | cut -f 1)
-  - "[ -f nim/$NIMVER/bin/nim ] || { mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }"
+  - "[ -f nim/$NIMVER/bin/nim ] || { rm -rf nim ; mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }"
   - export PATH=$PWD/nim/$NIMVER/bin:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: c # or other C/C++ variants
 
+# https://docs.travis-ci.com/user/caching/#ccache-cache
 cache: ccache
+
+install:
+  - git clone https://github.com/status-im/nim.git
+  - cd nim
+  - sh build_all.sh
+  - cd ..
+  - export PATH=$PWD/nim/bin:$PATH
+
+script:
+  - nimble install -dy && nimble test
 
 matrix:
   # allow_failures:
@@ -8,20 +19,12 @@ matrix:
 
   include:
     - os: linux
-      cache: ccache
       sudo: required
       before_install:
         - sudo apt-get install -y libssl-dev libgflags-dev libsnappy-dev
         - git clone https://github.com/facebook/rocksdb.git
         # rocksdb not present on trusty - on a newer ubuntu you can apt-get install -y librocksdb-dev
         - cd rocksdb && git checkout v5.14.2 && make shared_lib -j$(nproc) && sudo make INSTALL_PATH=/usr install-shared && cd ..
-        - git clone https://github.com/status-im/nim.git
-        - cd nim
-        - sh build_all.sh
-        - cd ..
-        - export PATH=$PWD/nim/bin:$PATH
-      script:
-        - nimble install -dy && nimble test
 
     - os: osx
       before_install:
@@ -29,13 +32,3 @@ matrix:
         - brew install rocksdb ccache
         - export PATH="/usr/local/opt/ccache/libexec:$PATH"
         # - brew install gcc
-
-        - git clone https://github.com/status-im/nim.git
-        - cd nim
-        - sh build_all.sh
-        - cd ..
-        - export PATH=$PWD/nim/bin:$PATH
-
-
-      script:
-        - nimble install -dy && nimble test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 install:
   - export NIMVER=$(git ls-remote https://github.com/status-im/nim.git HEAD | cut -f 1)
-  - "[ -f nim/$NIMVER/bin/nim ] || { rm -rf nim ; mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }"
+  - "{ [ -f nim/$NIMVER/bin/nim ] && [ -f nim/$NIMVER/bin/nimble ] ; } || { rm -rf nim ; mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }"
   - export PATH=$PWD/nim/$NIMVER/bin:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ cache:
   ccache: true
   directories:
     - rocksdb-5.14.2
+    - nim
 
 install:
-  - git clone https://github.com/status-im/nim.git
-  - cd nim
-  - sh build_all.sh
-  - cd ..
-  - export PATH=$PWD/nim/bin:$PATH
+  - export NIMVER=$(git ls-remote  git@github.com:status-im/nimbus.git HEAD | cut -f 1)
+  - [ -f nim/$NIMVER/bin/nim ] || { mkdir -p nim; git clone https://github.com/status-im/nim.git nim/$NIMVER; cd nim/$NIMVER; sh build_all.sh; cd ../.. ; }
+  - export PATH=$PWD/nim/$NIMVER/bin:$PATH
 
 script:
   - nimble install -dy && nimble test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: c # or other C/C++ variants
 
 # https://docs.travis-ci.com/user/caching/#ccache-cache
-cache: ccache
+cache:
+  ccache: true
+  directories:
+    - rocksdb-5.14.2
 
 install:
   - git clone https://github.com/status-im/nim.git
@@ -22,8 +25,7 @@ matrix:
       sudo: required
       before_install:
         - sudo apt-get install -y libssl-dev libgflags-dev libsnappy-dev
-        - wget https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz
-        - tar xvf v5.14.2.tar.gz
+        - "[ -d rocksdb-5.14.2 ] || { wget https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz && tar xvf v5.14.2.tar.gz; }"
         # rocksdb not present on trusty - on a newer ubuntu you can apt-get install -y librocksdb-dev
         - cd rocksdb-5.14.2 && make shared_lib -j$(nproc) && sudo make INSTALL_PATH=/usr install-shared && cd ..
 


### PR DESCRIPTION
Changes the travis and appveyor build to:
* use HEAD from https://github.com/status-im/Nim - the idea is that we keep it locked at a working nim version
* use ccache to build dependencies
* doesn't use Docker any more - this means the build on OSX and linux builds work the same way

Downsides:
* docker image contained a single source of truth of how to set up a "nimbus" build env.. with many repos, this needs to be replicated somehow
  * ideally, build stuff such as the rocksdb build in the linux env would be handled by the wrapper and transitively applied by nimble to everything that uses rocksdb - this would allow nimble to become the single source of truth. we're not there yet I think - an alternative might be to do some script hackery, but that's going to be fragile..
