### PR TITLE
Alternative form of getSender that raises and returns address

### DIFF
--- a/nimbus/transaction.nim
+++ b/nimbus/transaction.nim
@@ -58,3 +58,7 @@ proc getSender*(transaction: Transaction, output: var EthAddress): bool =
     output = pubKey.toCanonicalAddress()
     result = true
 
+proc getSender*(transaction: Transaction): EthAddress =
+  ## Raises error on failure to recover public key
+  if not transaction.getSender(result):
+    raise newException(ValidationError, "Could not derive sender address from transaction")


### PR DESCRIPTION
Just an extra form for getSender that raises.
Makes it easier to use in `let` statements, for example, and/or where you intend to raise an error on a validation fail anyway.
