### PR TITLE
Use AccountNonce

### DIFF
--- a/nimbus/account.nim
+++ b/nimbus/account.nim
@@ -10,14 +10,13 @@ import
 
 type
   Account* = object
-    nonce*:             UInt256
+    nonce*:             AccountNonce
     balance*:           UInt256
     storageRoot*:       Hash256
     codeHash*:          Hash256
 
-proc newAccount*(nonce: UInt256 = 0.u256, balance: UInt256 = 0.u256): Account =
+proc newAccount*(nonce: AccountNonce = 0, balance: UInt256 = 0.u256): Account =
   result.nonce = nonce
   result.balance = balance
   result.storageRoot = BLANK_ROOT_HASH
   result.codeHash = EMPTY_SHA3
-

--- a/nimbus/db/state_db.nim
+++ b/nimbus/db/state_db.nim
@@ -105,13 +105,13 @@ proc getStorage*(db: AccountStateDB, address: EthAddress, slot: UInt256): (UInt2
   else:
     result = (0.u256, false)
 
-proc setNonce*(db: var AccountStateDB, address: EthAddress, newNonce: UInt256) =
+proc setNonce*(db: var AccountStateDB, address: EthAddress, newNonce: AccountNonce) =
   var account = db.getAccount(address)
   if newNonce != account.nonce:
     account.nonce = newNonce
     db.setAccount(address, account)
 
-proc getNonce*(db: AccountStateDB, address: EthAddress): UInt256 =
+proc getNonce*(db: AccountStateDB, address: EthAddress): AccountNonce =
   let account = db.getAccount(address)
   account.nonce
 

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -136,7 +136,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
     if storage[1]:
       result = storage[0]
 
-  rpcsrv.rpc("eth_getTransactionCount") do(data: EthAddressStr, quantityTag: string) -> UInt256:
+  rpcsrv.rpc("eth_getTransactionCount") do(data: EthAddressStr, quantityTag: string) -> AccountNonce:
     ## Returns the number of transactions sent from an address.
     ##
     ## data: address.

--- a/nimbus/rpc/rpc_types.nim
+++ b/nimbus/rpc/rpc_types.nim
@@ -64,7 +64,7 @@ type
   TransactionObject* = object       # A transaction object, or null when no transaction was found:
     # Returned to user
     hash*: Hash256                    # hash of the transaction.
-    nonce*: UInt256                   # the number of transactions made by the sender prior to this one.
+    nonce*: AccountNonce              # the number of transactions made by the sender prior to this one.
     blockHash*: Option[Hash256]       # hash of the block where this transaction was in. null when its pending.
     blockNumber*: Option[BlockNumber] # block number where this transaction was in. null when its pending.
     transactionIndex*: Option[int64]  # integer of the transactions index position in the block. null when its pending.

--- a/nimbus/transaction.nim
+++ b/nimbus/transaction.nim
@@ -25,7 +25,7 @@ func hash*(transaction: Transaction): Hash256 =
   # Hash transaction without signature
   type
     TransHashObj = object
-      accountNonce:  uint64
+      accountNonce:  AccountNonce
       gasPrice:      GasInt
       gasLimit:      GasInt
       to:            EthAddress


### PR DESCRIPTION
*Note that this PR changes `Account.nonce` to be `uint64` from `UInt256`!*

For `Transaction`, however, this is simply an update to use a shared type.

Account nonces are the number of transactions so this shouldn't impact VM operation, and unifies the account nonces to be a single type, allowing us to change it in one place.

Note that this requires the associated PR in https://github.com/status-im/nim-eth-common/pull/13