### PR TITLE
Assorted fixes towards GeneralStateTests working

### DIFF
--- a/nimbus/db/state_db.nim
+++ b/nimbus/db/state_db.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  sequtils, tables,
+  sequtils, strformat, tables,
   chronicles, eth_common, nimcrypto, rlp, eth_trie/[hexary, memdb],
   ../constants, ../errors, ../validation, ../account
 
@@ -65,9 +65,10 @@ template createTrieKeyFromSlot(slot: UInt256): ByteRange =
   # XXX: This is too expensive. Similar to `createRangeFromAddress`
   # Converts a number to hex big-endian representation including
   # prefix and leading zeros:
-  @(keccak256.digest(slot.toByteArrayBE).data).toRange
+  @(slot.toByteArrayBE).toRange
   # Original py-evm code:
   # pad32(int_to_big_endian(slot))
+  # morally equivalent to toByteRange_Unnecessary but with different types
 
 template getAccountTrie(stateDb: AccountStateDB, account: Account): auto =
   initSecureHexaryTrie(HexaryTrie(stateDb.trie).db, account.storageRoot)
@@ -126,10 +127,14 @@ proc setCode*(db: var AccountStateDB, address: EthAddress, code: ByteRange) =
   if newCodeHash != account.codeHash:
     account.codeHash = newCodeHash
     # XXX: this uses the journaldb in py-evm
-    db.trie.put(account.codeHash.toByteRange_Unnecessary, code)
+    # Breaks state hash root calculations
+    # db.trie.put(account.codeHash.toByteRange_Unnecessary, code)
     db.setAccount(address, account)
 
 proc getCode*(db: AccountStateDB, address: EthAddress): ByteRange =
   let codeHash = db.getCodeHash(address)
   result = db.trie.get(codeHash.toByteRange_Unnecessary)
 
+proc dumpAccount*(db: AccountStateDB, addressS: string): string =
+  let address = addressS.parseAddress
+  return fmt"{addressS}: Storage: {db.getStorage(address, 0.u256)}; getAccount: {db.getAccount address}"


### PR DESCRIPTION
1. fix overflow/signed confusion when reading large-valued storage entries
2. adjust test fixture validity for GeneralStateTests
3. remove incorrect usage of state trie for code (not codehash) storage
4. add ability to display statedb information for an account;
5. avoid double-hashing keys for already-hashed SecureHexaryTrie for storage;
6. add intentionally local workaround for empty code in GeneralStateTest fixtures lacking 0x prefix
7. fix nonce parsing, which is always hex string in test fixtures

This doesn't fix everything -- there are a couple of additional items. It fixes most of the outstanding issues blocking GeneralStateTests usage.