### PR TITLE
Various fixes towards state reconstruction

### DIFF
--- a/nimbus/db/backends/rocksdb_backend.nim
+++ b/nimbus/db/backends/rocksdb_backend.nim
@@ -21,8 +21,12 @@ proc newChainDB*(basePath: string): ChainDB =
 
 proc get*(db: ChainDB, key: openarray[byte]): seq[byte] =
   let s = db.store.getBytes(key)
-  if not s.ok: raiseKeyReadError(key)
-  return s.value
+  if s.ok:
+    return s.value
+  elif s.error.len == 0:
+    discard
+  else:
+    raiseKeyReadError(key)
 
 proc put*(db: ChainDB, key, value: openarray[byte]) =
   let s = db.store.put(key, value)

--- a/nimbus/db/backends/sqlite_backend.nim
+++ b/nimbus/db/backends/sqlite_backend.nim
@@ -69,10 +69,12 @@ proc get*(db: ChainDB, key: openarray[byte]): seq[byte] =
     var
       resStart = columnBlob(db.selectStmt, 0)
       resLen   = columnBytes(db.selectStmt, 0)
-      resSeq   = newSeq[byte](resLen)
-    copyMem(resSeq.baseAddr, resStart, resLen)
-    return resSeq
-  else: raiseKeySearchError(key)
+    result = newSeq[byte](resLen)
+    copyMem(result.baseAddr, resStart, resLen)
+  of SQLITE_DONE:
+    discard
+  else:
+    raiseKeyReadError(key)
 
 proc put*(db: ChainDB, key, value: openarray[byte]) =
   template check(op) =

--- a/nimbus/db/storage_types.nim
+++ b/nimbus/db/storage_types.nim
@@ -73,7 +73,7 @@ template raiseKeyWriteError*(key: auto) =
   raise newException(StorageError, "failed to write key " & $key)
 
 template raiseKeySearchError*(key: auto) =
-  raise newException(KeyError, "failure during search for key " & $key)
+  raise newException(StorageError, "failure during search for key " & $key)
 
 template raiseKeyDeletionError*(key: auto) =
   raise newException(StorageError, "failure to delete key " & $key)

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -14,7 +14,7 @@ import
   config, genesis, rpc/[common, p2p], p2p/chain,
   eth_trie
 
-const UseSqlite = true
+const UseSqlite = false
 
 when UseSqlite:
   import db/backends/sqlite_backend

--- a/nimbus/transaction.nim
+++ b/nimbus/transaction.nim
@@ -49,7 +49,7 @@ proc toSignature*(transaction: Transaction): Signature =
   bytes[0..31] = transaction.R.toByteArrayBE()
   bytes[32..63] = transaction.S.toByteArrayBE()
   # TODO: V will become a byte or range soon.
-  bytes[64] = transaction.V
+  bytes[64] = transaction.V - 27 # TODO: 27 should come from somewhere
   initSignature(bytes)
 
 proc getSender*(transaction: Transaction, output: var EthAddress): bool =

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -25,7 +25,7 @@ proc newBaseComputation*(vmState: BaseVMState, blockNumber: UInt256, message: Me
   result.children = @[]
   result.accountsToDelete = initTable[EthAddress, EthAddress]()
   result.logEntries = @[]
-  result.code = newCodeStreamFromUnescaped(message.code) # TODO: what is the best repr
+  result.code = newCodeStream(message.code)
   # result.rawOutput = "0x"
   result.gasCosts = blockNumber.toFork.forkToSchedule
 
@@ -67,7 +67,7 @@ proc prepareChildMessage*(
     to,
     value,
     data,
-    code.bytesToHex, # TODO: use seq[byte] for Message as well
+    code,
     childOptions)
 
 func output*(c: BaseComputation): seq[byte] =

--- a/nimbus/vm/message.nim
+++ b/nimbus/vm/message.nim
@@ -39,7 +39,7 @@ proc newMessage*(
     sender: EthAddress,
     value: UInt256,
     data: seq[byte],
-    code: string,
+    code: seq[byte],
     options: MessageOptions = newMessageOptions()): Message =
 
   validateGte(options.depth, minimum=0, title="Message.depth")

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -90,7 +90,7 @@ type
     # Not in EVMC API
 
     # TODO: Done via callback function (v)table in EVMC
-    code*:                    string    # TODO: seq[byte] is probably a better representation
+    code*:                    seq[byte]
 
     internalOrigin*:          EthAddress
     internalCodeAddress*:     EthAddress

--- a/tests/test_opcode.nim
+++ b/tests/test_opcode.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest, tables, parseutils,
+  unittest, tables, parseutils, byteutils,
   eth_trie/[types, memdb], eth_common/eth_types,
   ../nimbus/[constants, vm_types, vm_state],
   ../nimbus/vm/interpreter,
@@ -32,7 +32,7 @@ proc testCode(code: string, initialGas: GasInt, blockNum: UInt256): BaseComputat
     sender=ZERO_ADDRESS, #fixture{"exec"}{"caller"}.getStr,
     value=0.u256,
     data = @[],
-    code=code,
+    code=code.hexToSeqByte,
     gas=initial_gas,
     gasPrice=1) # What is this used for?
     # gasPrice=fixture{"exec"}{"gasPrice"}.getHexadecimalInt.u256,

--- a/tests/test_storage_backends.nim
+++ b/tests/test_storage_backends.nim
@@ -49,6 +49,8 @@ template backendTests(DB) =
         keyA notin db
         keyB in db
 
+      check db.get(keyA) == @[]
+
       check db.get(keyB) == value1
       db.del(keyA)
 


### PR DESCRIPTION
Now we consistently reach 46147, first block with a transaction :)

Notable changes:
- DB backends return empty seqs if key not found. Hopefully its the last time i'm changing this :) CC @coffeepots 
- Switched db backend to rocksdb, sqlite is barely usable because it is too slow
- Changed `Message.code` type from `string` to `seq[byte]`
- "Fixed" (or should I say mocked) `Transaction.toSignature` so that it works with frontier transactions CC @coffeepots 
- Various fixes here and there.