### PR TITLE
13 additional GeneralStateTests working

### DIFF
--- a/GeneralStateTests.md
+++ b/GeneralStateTests.md
@@ -727,15 +727,15 @@ OK: 65/67 Fail: 2/67 Skip: 0/67
 + NonZeroValue_SUICIDE_ToNonNonZeroBalance.json                   OK
 + NonZeroValue_SUICIDE_ToOneStorageKey.json                       OK
 + NonZeroValue_TransactionCALL.json                               OK
-- NonZeroValue_TransactionCALL_ToEmpty.json                       Fail
-- NonZeroValue_TransactionCALL_ToNonNonZeroBalance.json           Fail
-- NonZeroValue_TransactionCALL_ToOneStorageKey.json               Fail
++ NonZeroValue_TransactionCALL_ToEmpty.json                       OK
++ NonZeroValue_TransactionCALL_ToNonNonZeroBalance.json           OK
++ NonZeroValue_TransactionCALL_ToOneStorageKey.json               OK
 + NonZeroValue_TransactionCALLwithData.json                       OK
-- NonZeroValue_TransactionCALLwithData_ToEmpty.json               Fail
-- NonZeroValue_TransactionCALLwithData_ToNonNonZeroBalance.json   Fail
-- NonZeroValue_TransactionCALLwithData_ToOneStorageKey.json       Fail
++ NonZeroValue_TransactionCALLwithData_ToEmpty.json               OK
++ NonZeroValue_TransactionCALLwithData_ToNonNonZeroBalance.json   OK
++ NonZeroValue_TransactionCALLwithData_ToOneStorageKey.json       OK
 ```
-OK: 6/24 Fail: 18/24 Skip: 0/24
+OK: 12/24 Fail: 12/24 Skip: 0/24
 ## stPreCompiledContracts
 ```diff
   identity_to_bigger.json                                         Skip
@@ -1556,7 +1556,7 @@ OK: 11/19 Fail: 8/19 Skip: 0/19
 - returndatacopy_0_0_following_successful_create.json             Fail
   returndatacopy_afterFailing_create.json                         Skip
 + returndatacopy_after_failing_callcode.json                      OK
-- returndatacopy_after_failing_delegatecall.json                  Fail
++ returndatacopy_after_failing_delegatecall.json                  OK
 + returndatacopy_after_failing_staticcall.json                    OK
 + returndatacopy_after_revert_in_staticcall.json                  OK
 + returndatacopy_after_successful_callcode.json                   OK
@@ -1585,7 +1585,7 @@ OK: 11/19 Fail: 8/19 Skip: 0/19
 + returndatasize_initial.json                                     OK
 + returndatasize_initial_zero_read.json                           OK
 ```
-OK: 25/37 Fail: 9/37 Skip: 3/37
+OK: 26/37 Fail: 8/37 Skip: 3/37
 ## stRevertTest
 ```diff
 - LoopCallsDepthThenRevert.json                                   Fail
@@ -2125,13 +2125,13 @@ OK: 23/67 Fail: 42/67 Skip: 2/67
 - TransactionSendingToEmpty.json                                  Fail
 + TransactionSendingToZero.json                                   OK
 + TransactionToAddressh160minusOne.json                           OK
-- TransactionToItself.json                                        Fail
++ TransactionToItself.json                                        OK
 - TransactionToItselfNotEnoughFounds.json                         Fail
 + UserTransactionGasLimitIsTooLowWhenZeroCost.json                OK
 + UserTransactionZeroCost.json                                    OK
 + UserTransactionZeroCostWithData.json                            OK
 ```
-OK: 19/44 Fail: 25/44 Skip: 0/44
+OK: 20/44 Fail: 24/44 Skip: 0/44
 ## stTransitionTest
 ```diff
 - createNameRegistratorPerTxsAfter.json                           Fail
@@ -2238,15 +2238,15 @@ OK: 0/24 Fail: 0/24 Skip: 24/24
 + ZeroValue_SUICIDE_ToNonZeroBalance.json                         OK
 + ZeroValue_SUICIDE_ToOneStorageKey.json                          OK
 + ZeroValue_TransactionCALL.json                                  OK
-- ZeroValue_TransactionCALL_ToEmpty.json                          Fail
-- ZeroValue_TransactionCALL_ToNonZeroBalance.json                 Fail
-- ZeroValue_TransactionCALL_ToOneStorageKey.json                  Fail
++ ZeroValue_TransactionCALL_ToEmpty.json                          OK
++ ZeroValue_TransactionCALL_ToNonZeroBalance.json                 OK
++ ZeroValue_TransactionCALL_ToOneStorageKey.json                  OK
 + ZeroValue_TransactionCALLwithData.json                          OK
-- ZeroValue_TransactionCALLwithData_ToEmpty.json                  Fail
-- ZeroValue_TransactionCALLwithData_ToNonZeroBalance.json         Fail
-- ZeroValue_TransactionCALLwithData_ToOneStorageKey.json          Fail
++ ZeroValue_TransactionCALLwithData_ToEmpty.json                  OK
++ ZeroValue_TransactionCALLwithData_ToNonZeroBalance.json         OK
++ ZeroValue_TransactionCALLwithData_ToOneStorageKey.json          OK
 ```
-OK: 6/24 Fail: 18/24 Skip: 0/24
+OK: 12/24 Fail: 12/24 Skip: 0/24
 ## stZeroKnowledge
 ```diff
   ecmul_1-2_2_28000_128.json                                      Skip

--- a/GeneralStateTests.md
+++ b/GeneralStateTests.md
@@ -623,7 +623,7 @@ OK: 0/8 Fail: 8/8 Skip: 0/8
   MSTORE_Bounds2.json                                             Skip
   MSTORE_Bounds2a.json                                            Skip
   POP_Bounds.json                                                 Skip
-- RETURN_Bounds.json                                              Fail
++ RETURN_Bounds.json                                              OK
   SLOAD_Bounds.json                                               Skip
   SSTORE_Bounds.json                                              Skip
   mload32bitBound.json                                            Skip
@@ -636,7 +636,7 @@ OK: 0/8 Fail: 8/8 Skip: 0/8
   static_CALL_Bounds2a.json                                       Skip
   static_CALL_Bounds3.json                                        Skip
 ```
-OK: 4/38 Fail: 1/38 Skip: 33/38
+OK: 5/38 Fail: 0/38 Skip: 33/38
 ## stMemoryTest
 ```diff
 - callDataCopyOffset.json                                         Fail
@@ -1259,7 +1259,7 @@ OK: 0/16 Fail: 0/16 Skip: 16/16
 + randomStatetest66.json                                          OK
 + randomStatetest67.json                                          OK
 + randomStatetest69.json                                          OK
-- randomStatetest7.json                                           Fail
++ randomStatetest7.json                                           OK
 + randomStatetest72.json                                          OK
 + randomStatetest73.json                                          OK
 + randomStatetest74.json                                          OK
@@ -1284,7 +1284,7 @@ OK: 0/16 Fail: 0/16 Skip: 16/16
 + randomStatetest97.json                                          OK
 + randomStatetest98.json                                          OK
 ```
-OK: 293/327 Fail: 30/327 Skip: 4/327
+OK: 294/327 Fail: 29/327 Skip: 4/327
 ## stRandom2
 ```diff
 + 201503110226PYTHON_DUP6.json                                    OK
@@ -1339,7 +1339,7 @@ OK: 293/327 Fail: 30/327 Skip: 4/327
 + randomStatetest440.json                                         OK
 + randomStatetest441.json                                         OK
 + randomStatetest442.json                                         OK
-- randomStatetest443.json                                         Fail
++ randomStatetest443.json                                         OK
 + randomStatetest444.json                                         OK
 + randomStatetest445.json                                         OK
 + randomStatetest446.json                                         OK
@@ -1515,7 +1515,7 @@ OK: 293/327 Fail: 30/327 Skip: 4/327
 - randomStatetest646.json                                         Fail
   randomStatetest647.json                                         Skip
 ```
-OK: 200/227 Fail: 23/227 Skip: 4/227
+OK: 201/227 Fail: 22/227 Skip: 4/227
 ## stRecursiveCreate
 ```diff
 - recursiveCreate.json                                            Fail
@@ -1576,7 +1576,7 @@ OK: 11/19 Fail: 8/19 Skip: 0/19
 + returndatasize_after_failing_callcode.json                      OK
   returndatasize_after_failing_delegatecall.json                  Skip
 + returndatasize_after_failing_staticcall.json                    OK
-- returndatasize_after_oog_after_deeper.json                      Fail
++ returndatasize_after_oog_after_deeper.json                      OK
 + returndatasize_after_successful_callcode.json                   OK
 + returndatasize_after_successful_delegatecall.json               OK
 + returndatasize_after_successful_staticcall.json                 OK
@@ -1585,7 +1585,7 @@ OK: 11/19 Fail: 8/19 Skip: 0/19
 + returndatasize_initial.json                                     OK
 + returndatasize_initial_zero_read.json                           OK
 ```
-OK: 24/37 Fail: 10/37 Skip: 3/37
+OK: 25/37 Fail: 9/37 Skip: 3/37
 ## stRevertTest
 ```diff
 - LoopCallsDepthThenRevert.json                                   Fail
@@ -1598,12 +1598,12 @@ OK: 24/37 Fail: 10/37 Skip: 3/37
 - RevertDepth2.json                                               Fail
 - RevertDepthCreateAddressCollision.json                          Fail
 - RevertDepthCreateOOG.json                                       Fail
-- RevertInCallCode.json                                           Fail
++ RevertInCallCode.json                                           OK
 - RevertInCreateInInit.json                                       Fail
-- RevertInDelegateCall.json                                       Fail
++ RevertInDelegateCall.json                                       OK
 + RevertInStaticCall.json                                         OK
 + RevertOnEmptyStack.json                                         OK
-- RevertOpcode.json                                               Fail
++ RevertOpcode.json                                               OK
 - RevertOpcodeCalls.json                                          Fail
 - RevertOpcodeCreate.json                                         Fail
 - RevertOpcodeDirectCall.json                                     Fail
@@ -1618,21 +1618,21 @@ OK: 24/37 Fail: 10/37 Skip: 3/37
   RevertPrecompiledTouchDC.json                                   Skip
 - RevertPrefound.json                                             Fail
 - RevertPrefoundCall.json                                         Fail
-- RevertPrefoundCallOOG.json                                      Fail
++ RevertPrefoundCallOOG.json                                      OK
 - RevertPrefoundEmpty.json                                        Fail
 - RevertPrefoundEmptyCall.json                                    Fail
-- RevertPrefoundEmptyCallOOG.json                                 Fail
++ RevertPrefoundEmptyCallOOG.json                                 OK
 - RevertPrefoundEmptyOOG.json                                     Fail
 - RevertPrefoundOOG.json                                          Fail
 - RevertRemoteSubCallStorageOOG.json                              Fail
 - RevertRemoteSubCallStorageOOG2.json                             Fail
-- RevertSubCallStorageOOG.json                                    Fail
-- RevertSubCallStorageOOG2.json                                   Fail
++ RevertSubCallStorageOOG.json                                    OK
++ RevertSubCallStorageOOG2.json                                   OK
 - TouchToEmptyAccountRevert.json                                  Fail
 - TouchToEmptyAccountRevert2.json                                 Fail
 - TouchToEmptyAccountRevert3.json                                 Fail
 ```
-OK: 3/43 Fail: 35/43 Skip: 5/43
+OK: 10/43 Fail: 28/43 Skip: 5/43
 ## stShift
 ```diff
   sar00.json                                                      Skip
@@ -2041,8 +2041,8 @@ OK: 0/284 Fail: 0/284 Skip: 284/284
 - CallToNameRegistratorTooMuchMemory2.json                        Fail
 - CallToNameRegistratorZeorSizeMemExpansion.json                  Fail
 - CallToReturn1.json                                              Fail
-- CallToReturn1ForDynamicJump0.json                               Fail
-- CallToReturn1ForDynamicJump1.json                               Fail
++ CallToReturn1ForDynamicJump0.json                               OK
++ CallToReturn1ForDynamicJump1.json                               OK
 - CalltoReturn2.json                                              Fail
 - CreateHashCollision.json                                        Fail
 - PostToReturn1.json                                              Fail
@@ -2083,7 +2083,7 @@ OK: 0/284 Fail: 0/284 Skip: 284/284
 + suicideSendEtherToMe.json                                       OK
 - testRandomTest.json                                             Fail
 ```
-OK: 21/67 Fail: 44/67 Skip: 2/67
+OK: 23/67 Fail: 42/67 Skip: 2/67
 ## stTransactionTest
 ```diff
 + ContractStoreClearsOOG.json                                     OK

--- a/nimbus/db/state_db.nim
+++ b/nimbus/db/state_db.nim
@@ -61,7 +61,7 @@ proc setBalance*(db: var AccountStateDB, address: EthAddress, balance: UInt256) 
   account.balance = balance
   db.setAccount(address, account)
 
-proc deltaBalance*(db: var AccountStateDB, address: EthAddress, delta: UInt256) =
+proc increaseBalance*(db: var AccountStateDB, address: EthAddress, delta: UInt256) =
   db.setBalance(address, db.getBalance(address) + delta)
 
 template createTrieKeyFromSlot(slot: UInt256): ByteRange =
@@ -76,12 +76,19 @@ template createTrieKeyFromSlot(slot: UInt256): ByteRange =
 template getAccountTrie(stateDb: AccountStateDB, account: Account): auto =
   initSecureHexaryTrie(HexaryTrie(stateDb.trie).db, account.storageRoot)
 
+# XXX: https://github.com/status-im/nimbus/issues/142#issuecomment-420583181
+proc setStorageRoot*(db: var AccountStateDB, address: EthAddress, storageRoot: Hash256) =
+  var account = db.getAccount(address)
+  account.storageRoot = storageRoot
+  db.setAccount(address, account)
+
+proc getStorageRoot*(db: var AccountStateDB, address: EthAddress): Hash256 =
+  var account = db.getAccount(address)
+  account.storageRoot
+
 proc setStorage*(db: var AccountStateDB,
                  address: EthAddress,
                  slot: UInt256, value: UInt256) =
-  #validateGte(value, 0, title="Storage Value")
-  #validateGte(slot, 0, title="Storage Slot")
-
   var account = db.getAccount(address)
   var accountTrie = getAccountTrie(db, account)
   let slotAsKey = createTrieKeyFromSlot slot

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -101,9 +101,7 @@ func getAccountsForDeletion*(c: BaseComputation): seq[EthAddress] =
   if c.isError:
     result = @[]
   else:
-    result = @[]
-    for account in c.accountsToDelete.keys:
-        result.add(account)
+    result = toSeq c.accountsToDelete.keys
 
 proc getLogEntries*(c: BaseComputation): seq[(string, seq[UInt256], string)] =
   # TODO


### PR DESCRIPTION
PR title's out of date -- it's 27 additional GSTs working.

- put in a kludge around `CachingDB` not being fully developed (e.g., it doesn't clear `deleted` and `changed` after a `commit`). It won't work once called contracts start changing state and needing reverting, but until https://github.com/status-im/nimbus/issues/142 is done, these are the sort of one-off kludges I'm using.
- remove commented auto-ported Py-EVM validations which are implicit in UInt256
- address comments to last commit (`toSeq`, hoising `vmState.readOnlyStateDB`, `deltaBalance` to `increaseBalance`)
- wrapped `hexToSeqByte`, after discovering the third place where it'd have to be special-cased to handle "" as an empty sequence (14 new working tests)

Current progress:
- Same 1011 skipped tests
- 738 working tests
- 585 failing tests
- 74 failing tests without a `CREATE` or `CALL` instruction in the executed code
- 23 failing tests without a `CREATE` instruction, `CALL` instruction, or `transaction.to` being empty (this category is my current focus).