### PR TITLE
Temp fix for int32.high returning zero

### DIFF
--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -193,8 +193,8 @@ op sha3, inline = true, startPos, length:
   ## 0x20, Compute Keccak-256 hash.
   let (pos, len) = (startPos.toInt, length.toInt)
 
-  if pos < 0 or len < 0 or pos > int32.high:
-    raise newException(OutOfBoundsRead, "Out of bounds memory access")
+  if pos < 0 or len < 0 or pos > 2147483648:
+    raise newException(OutOfBoundsRead, &"Out of bounds memory access len {$len} pos {$pos} pos < 0 {pos < 0} len < 0 {len < 0} pos > int32 {pos > int32.high}")
 
   computation.gasMeter.consumeGas(
     computation.gasCosts[Op.Sha3].m_handler(computation.memory.len, pos, len),


### PR DESCRIPTION
This fixes the failed VM tests that report `Out of bounds memory access`.

`int32.high` returns zero when compiled in 32 bit (`int64.high` returns the correct value).

This is the output I get from the [Status branch](https://github.com/status-im/Nim) of Nim in 32 and 64 bit:

    # x86
    echo high(int32) # 0
    echo high(int64) # 9223372036854775807
    # x64
    echo high(int32) # 2147483647
    echo high(int64) # 9223372036854775807
