### PR TITLE
Temp fix for int32.high returning zero

### DIFF
--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -193,7 +193,7 @@ op sha3, inline = true, startPos, length:
   ## 0x20, Compute Keccak-256 hash.
   let (pos, len) = (startPos.toInt, length.toInt)
 
-  if pos < 0 or len < 0 or pos > int32.high:
+  if pos < 0 or len < 0 or pos > 2147483648:
     raise newException(OutOfBoundsRead, "Out of bounds memory access")
 
   computation.gasMeter.consumeGas(


### PR DESCRIPTION
This fixes the failed VM tests that report `Out of bounds memory access`.

`int32.high` returns zero when compiled in 32 bit (`int64.high` returns the correct value).

This is the output I get from the [Status branch](https://github.com/status-im/Nim) of Nim in 32 and 64 bit:

    # x86
    echo high(int32) # 0
    echo high(int64) # 9223372036854775807
    # x64
    echo high(int32) # 2147483647
    echo high(int64) # 9223372036854775807
