### PR TITLE
remove misleading/counterproductive Nim version guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Join the Status community chats:
 
 * A recent version of Nim
   * We use the version in the [Status fork](https://github.com/status-im/Nim)
-  * Normally, this is the latest released version of Nim but it may also include custom patches
   * Follow the Nim installation instructions or use [choosenim](https://github.com/dom96/choosenim) to manage your Nim versions
 * A recent version of Facebook's [RocksDB](https://github.com/facebook/rocksdb/)
   * Compile [from source](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) or use the package manager of your OS


### PR DESCRIPTION
This isn't particularly helpful, nor has been true for months in any intuitive sense.

I'm open to reasonable wording should we stabilize on 0.19 or similar, but this is actively counterproductive as-is, and not worth keeping just-in-case.