### PR TITLE
Better cmdline flags handling

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -539,8 +539,18 @@ LOGGING AND DEBUGGING OPTIONS:
 proc processArguments*(msg: var string): ConfigStatus =
   ## Process command line argument and update `NimbusConfiguration`.
   let config = getConfiguration()
+
+  # At this point `config.net.bootnodes` is likely populated with network default
+  # bootnodes. We want to override those if at least one custom bootnode is
+  # specified on the command line. We temporarily set `config.net.bootNodes`
+  # to empty seq, and in the end restore it if no bootnodes were spricified on
+  # the command line.
+  # TODO: This is pretty hacky and it's better to refactor it to make a clear
+  # distinction between default and custom bootnodes.
   var tempBootNodes: seq[ENode]
   swap(tempBootNodes, config.net.bootNodes)
+
+  # The same trick is done to discPort
   config.net.discPort = 0
 
   var opt = initOptParser()
@@ -571,6 +581,8 @@ proc processArguments*(msg: var string): ConfigStatus =
       break
 
   if config.net.bootNodes.len == 0:
+    # No custom bootnodes were specified on the command line, restore to
+    # previous values
     swap(tempBootNodes, config.net.bootNodes)
 
   if config.net.discPort == 0:

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -95,7 +95,8 @@ proc start(): NimbusObject =
       result = "EXITING"
     nimbus.rpcServer.start()
 
-  waitFor nimbus.ethNode.connectToNetwork(conf.net.bootNodes)
+  waitFor nimbus.ethNode.connectToNetwork(conf.net.bootNodes,
+    enableDiscovery = NoDiscover notin conf.net.flags)
 
   # TODO: temp code until the CLI/RPC interface is fleshed out
   let status = waitFor nimbus.ethNode.fastBlockchainSync()


### PR DESCRIPTION
Depends on https://github.com/status-im/nim-eth-p2p/pull/39
* support `--nodiscover` switch
* `--discport` defaults to `--port` value
* `--bootnodes` flag disables network default bootnodes
