### PR TITLE
Get blockchain reading through block 49017

### DIFF
--- a/nimbus/vm/interpreter/gas_meter.nim
+++ b/nimbus/vm/interpreter/gas_meter.nim
@@ -18,10 +18,6 @@ proc init*(m: var GasMeter, startGas: GasInt) =
   m.gasRefunded = 0
 
 proc consumeGas*(gasMeter: var GasMeter; amount: GasInt; reason: string) =
-  #if amount < 0.u256:
-  #  raise newException(ValidationError, "Gas consumption amount must be positive")
-  # Alternatively: use a range type `range[0'i64 .. high(int64)]`
-  #   https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
   if amount > gasMeter.gasRemaining:
     raise newException(OutOfGas,
       &"Out of gas: Needed {amount} - Remaining {gasMeter.gasRemaining} - Reason: {reason}")
@@ -32,20 +28,12 @@ proc consumeGas*(gasMeter: var GasMeter; amount: GasInt; reason: string) =
       "GAS CONSUMPTION", total = gasMeter.gasRemaining + amount, amount, remaining = gasMeter.gasRemaining, reason)
 
 proc returnGas*(gasMeter: var GasMeter; amount: GasInt) =
-  #if amount < 0.int256:
-  #  raise newException(ValidationError, "Gas return amount must be positive")
-  # Alternatively: use a range type `range[0'i64 .. high(int64)]`
-  #   https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
   gasMeter.gasRemaining += amount
   when defined(nimbusTrace): # XXX: https://github.com/status-im/nim-chronicles/issues/26
     debug(
       "GAS RETURNED", consumed = gasMeter.gasRemaining - amount, amount, remaining = gasMeter.gasRemaining)
 
 proc refundGas*(gasMeter: var GasMeter; amount: GasInt) =
-  #if amount < 0.int256:
-  #  raise newException(ValidationError, "Gas refund amount must be positive")
-  # Alternatively: use a range type `range[0'i64 .. high(int64)]`
-  #   https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
   gasMeter.gasRefunded += amount
   when defined(nimbusTrace): # XXX: https://github.com/status-im/nim-chronicles/issues/26
     debug(


### PR DESCRIPTION
This reads through block 49017 by properly setting createAddress/storageAddress of the computation message and detecting whether the computation has the gas required to pay 200*code length; also, clean up pointless commented nonnegativity assertions for nonnegative GasInt type.

This is as far as I intend to go with blockchain reconstruction until it doesn't need `del` from `rocksdb_backend` commented out to even get this far (as advised by @yglukhov). I've checked that `eth.getBalance` on the coinbase, on the contract, and on the sender all match what Nimbus sets, and similarly with `eth.getCode`. The remaining checkable item is `eth.getStorage`, which just commenting out such a routine as `del` could do interesting things with, that I'm not going to waste time hoping disabling that and actual state calculations don't interact unfortunately.

The deleted comments in `gas_meter` are left over from pre-`GasInt` conversion.