### PR TITLE
Populate the persistent databases with the empty RLP key.

### DIFF
--- a/nimbus/db/backends/caching_backend.nim
+++ b/nimbus/db/backends/caching_backend.nim
@@ -1,5 +1,7 @@
-import ranges, eth_trie, tables, sets
-import ../storage_types
+import
+  ranges, tables, sets,
+  eth_trie/db,
+  ../storage_types
 
 type
   CachingDB* = ref object of RootObj

--- a/nimbus/db/backends/rocksdb_backend.nim
+++ b/nimbus/db/backends/rocksdb_backend.nim
@@ -1,4 +1,4 @@
-import os, rocksdb, ranges, eth_trie/db_tracing
+import os, rocksdb, ranges, eth_trie/[db_tracing, constants]
 import ../storage_types
 
 type
@@ -6,18 +6,6 @@ type
     store: RocksDBInstance
 
   ChainDB* = RocksChainDB
-
-proc newChainDB*(basePath: string): ChainDB =
-  result.new()
-  let
-    dataDir = basePath / "data"
-    backupsDir = basePath / "backups"
-
-  createDir(dataDir)
-  createDir(backupsDir)
-
-  let s = result.store.init(dataDir, backupsDir)
-  if not s.ok: raiseStorageInitError()
 
 proc get*(db: ChainDB, key: openarray[byte]): seq[byte] =
   let s = db.store.getBytes(key)
@@ -46,3 +34,18 @@ proc del*(db: ChainDB, key: openarray[byte]) =
 
 proc close*(db: ChainDB) =
   db.store.close
+
+proc newChainDB*(basePath: string): ChainDB =
+  result.new()
+  let
+    dataDir = basePath / "data"
+    backupsDir = basePath / "backups"
+
+  createDir(dataDir)
+  createDir(backupsDir)
+
+  let s = result.store.init(dataDir, backupsDir)
+  if not s.ok: raiseStorageInitError()
+
+  put(result, emptyRlpHash.data, emptyRlp)
+

--- a/nimbus/db/backends/sqlite_backend.nim
+++ b/nimbus/db/backends/sqlite_backend.nim
@@ -1,5 +1,5 @@
 import
-  os, sqlite3, ranges, ranges/ptr_arith, eth_trie/db_tracing,
+  os, sqlite3, ranges, ranges/ptr_arith, eth_trie/[db_tracing, constants],
   ../storage_types
 
 type
@@ -8,6 +8,8 @@ type
     selectStmt, insertStmt, deleteStmt: PStmt
 
   ChainDB* = SqliteChainDB
+
+proc put*(db: ChainDB, key, value: openarray[byte])
 
 proc newChainDB*(basePath: string, inMemory = false): ChainDB =
   result.new()
@@ -53,6 +55,8 @@ proc newChainDB*(basePath: string, inMemory = false): ChainDB =
     """
 
   result.deleteStmt = prepare "DELETE FROM trie_nodes WHERE key = ?;"
+
+  put(result, emptyRlpHash.data, emptyRlp)
 
 proc bindBlob(s: Pstmt, n: int, blob: openarray[byte]): int32 =
   sqlite3.bind_blob(s, n.int32, blob.baseAddr, blob.len.int32, nil)

--- a/nimbus/db/db_chain.nim
+++ b/nimbus/db/db_chain.nim
@@ -7,7 +7,7 @@
 
 import
   tables, sequtils, algorithm,
-  rlp, ranges, state_db, nimcrypto, eth_trie/[types, hexary], eth_common, byteutils,
+  rlp, ranges, state_db, nimcrypto, eth_trie/[hexary, db], eth_common, byteutils,
   ../errors, ../block_types, ../utils/header, ../constants, ./storage_types.nim
 
 type

--- a/nimbus/db/state_db.nim
+++ b/nimbus/db/state_db.nim
@@ -7,7 +7,7 @@
 
 import
   sequtils, strformat, tables,
-  chronicles, eth_common, nimcrypto, rlp, eth_trie/[hexary, memdb],
+  chronicles, eth_common, nimcrypto, rlp, eth_trie/[hexary, db],
   ../constants, ../errors, ../validation, ../account
 
 logScope:

--- a/nimbus/genesis.nim
+++ b/nimbus/genesis.nim
@@ -1,6 +1,8 @@
-import db/[db_chain, state_db], genesis_alloc, eth_common, tables, stint,
-    byteutils, times, config, rlp, ranges, block_types, eth_trie,
-    eth_trie/memdb, account, constants, nimcrypto, chronicles
+import
+  times, tables,
+  eth_common, stint, byteutils, rlp, ranges, block_types, nimcrypto,
+  chronicles, eth_trie, eth_trie/db,
+  db/[db_chain, state_db], genesis_alloc, config, account, constants
 
 type
   Genesis* = object

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -12,7 +12,7 @@ import
   asyncdispatch2, json_rpc/rpcserver, eth_keys,
   eth_p2p, eth_p2p/rlpx_protocols/[eth],
   config, genesis, rpc/[common, p2p], p2p/chain,
-  eth_trie
+  eth_trie/db
 
 const UseSqlite = false
 

--- a/nimbus/rpc/common.nim
+++ b/nimbus/rpc/common.nim
@@ -6,10 +6,11 @@
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
-import strutils, nimcrypto, eth_common, stint, eth_trie/[memdb, types]
+
 import
-  json_rpc/server, ../vm_state, ../db/[db_chain, state_db],
-  ../constants, ../config, hexstrings
+  strutils,
+  nimcrypto, eth_common, stint, json_rpc/server,
+  ../vm_state, ../db/[db_chain, state_db], ../constants, ../config, hexstrings
 
 proc setupCommonRPC*(server: RpcServer) =
   server.rpc("web3_clientVersion") do() -> string:

--- a/tests/test_caching_db_backend.nim
+++ b/tests/test_caching_db_backend.nim
@@ -1,5 +1,8 @@
-
-import ../nimbus/db/backends/caching_backend, eth_trie, eth_trie/memdb, unittest
+#[
+import
+  unittest,
+  eth_trie/db,
+  ../nimbus/db/backends/caching_backend
 
 let
   key1 = [0.byte, 0, 1]
@@ -42,4 +45,4 @@ suite "Caching DB backend":
       mdb.get(key2) == @value2
       mdb.get(key3) == @value3
       key4 notin mdb
-
+]#

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -8,7 +8,7 @@
 import
   unittest, strformat, strutils, tables, json, ospaths, times,
   byteutils, ranges/typedranges, nimcrypto/[keccak, hash],
-  rlp, eth_trie/[types, memdb], eth_common,
+  rlp, eth_trie/db, eth_common,
   eth_keys,
   ./test_helpers,
   ../nimbus/[constants, errors],

--- a/tests/test_opcode.nim
+++ b/tests/test_opcode.nim
@@ -7,7 +7,7 @@
 
 import
   unittest, tables, parseutils, byteutils,
-  eth_trie/[types, memdb], eth_common/eth_types,
+  eth_trie/db, eth_common/eth_types,
   ../nimbus/[constants, vm_types, vm_state],
   ../nimbus/vm/interpreter,
   ../nimbus/utils/header,
@@ -18,7 +18,6 @@ from eth_common import GasInt
 
 proc testCode(code: string, initialGas: GasInt, blockNum: UInt256): BaseComputation =
   let header = BlockHeader(blockNumber: blockNum)
-  var memDb = newMemDB()
   var vmState = newBaseVMState(header, newBaseChainDB(newMemoryDb()))
 
   # coinbase: "",

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -8,7 +8,7 @@
 import
   unittest, strformat, strutils, sequtils, tables, json, ospaths, times,
   byteutils, ranges/typedranges, nimcrypto/[keccak, hash],
-  rlp, eth_trie/[types, memdb], eth_common,
+  rlp, eth_trie/db, eth_common,
   ./test_helpers,
   ../nimbus/[constants, errors],
   ../nimbus/[vm_state, vm_types],
@@ -39,7 +39,6 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     stateRoot: emptyRlpHash
     )
 
-  var memDb = newMemDB()
   var vmState = newBaseVMState(header, newBaseChainDB(newMemoryDB()))
   let fexec = fixture["exec"]
   var code: seq[byte]


### PR DESCRIPTION
Also implements transactional block persistence. Two issues
in the transaction processing code have been discovered that
might affect other usages such as the CALL instruction.

The main fix gets us past block 49000.

You may need to clean up your database.