### PR TITLE
Initial TransactionTracer impl

### DIFF
--- a/nimbus/vm/transaction_tracer.nim
+++ b/nimbus/vm/transaction_tracer.nim
@@ -1,0 +1,40 @@
+import
+  json, strutils,
+  eth_common, stint, byteutils,
+  ../vm_types, memory, stack
+
+proc initTrace(t: var TransactionTracer) =
+  t.trace = newJObject()
+  t.trace["structLogs"] = newJArray()
+
+proc traceOpCodeStarted*(t: var TransactionTracer, c: BaseComputation, op: string) =
+  if unlikely t.trace.isNil:
+    t.initTrace()
+
+  let j = newJObject()
+  t.trace["structLogs"].add(j)
+
+  j["op"] = %op.toUpperAscii
+  j["pc"] = %(c.code.pc - 1)
+  j["depth"] = %1 # stub
+  j["gas"] = %c.gasMeter.gasRemaining
+  t.gasRemaining = c.gasMeter.gasRemaining
+
+  # log stack
+  let st = newJArray()
+  for v in c.stack.values:
+    st.add(%v.dumpHex())
+  j["stack"] = st
+  # log memory
+  let mem = newJArray()
+  const chunkLen = 32
+  let numChunks = c.memory.len div chunkLen
+  for i in 0 ..< numChunks:
+    mem.add(%c.memory.bytes.toOpenArray(i * chunkLen, (i + 1) * chunkLen - 1).toHex())
+  j["memory"] = mem
+  # TODO: log storage
+
+proc traceOpCodeEnded*(t: var TransactionTracer, c: BaseComputation) =
+  let j = t.trace["structLogs"].elems[^1]
+  j["gasCost"] = %(t.gasRemaining - c.gasMeter.gasRemaining)
+

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  tables,
+  tables, json,
   eth_common,
   ./constants, ./vm_state,
   ./vm/[memory, stack, code_stream],
@@ -35,6 +35,8 @@ type
     precompiles*:           Table[string, Opcode]
     gasCosts*:              GasCosts # TODO - will be hidden at a lower layer
     opCodeExec*:            OpcodeExecutor
+    tracingEnabled*:        bool
+    tracer*:                TransactionTracer
 
   Error* = ref object
     info*:                  string
@@ -105,3 +107,8 @@ type
     createAddress*:           EthAddress
     codeAddress*:             EthAddress
     flags*:                   MsgFlags
+
+  TransactionTracer* = object
+    trace*: JsonNode
+    gasRemaining*: GasInt
+


### PR DESCRIPTION
This partially implements the transaction trace in geth format. Currently the traces are disabled, intended to be used (and enabled) in traceTransaction rpc call.