### PR TITLE
enable global gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,21 @@
+### the following pattern disables global gitignore rules (the ones from core.excludesFile)
 # Ignore all files without extensions (unix executable files)
-*
-!*.*
-!*/
-!LICENSE*
+#*
+#!*.*
+#!*/
+#!LICENSE*
 
 nimcache/
 
 # Executables shall be put in an ignored build/ directory
-# Ignore dynamic, static libs and libtool archive files
 build/
+
+# Ignore dynamic, static libs and libtool archive files
 *.so
 *.dylib
 *.a
 *.la
 *.exe
 *.dll
+
 VMTests.md


### PR DESCRIPTION
Looks like "\*.swp" in a file pointed at by core.excludesFile is not able to override "!\*.\*" in the project's .gitignore file.

Original patterns:
```
$ git check-ignore -v nimbus/.nimbus.nim.swp
.gitignore:4:!*.*	nimbus/.nimbus.nim.swp
```
Problem block commented out in .gitignore:
```
$ git check-ignore -v nimbus/.nimbus.nim.swp
/home/stefan/.gitignore:3:*.swp	nimbus/.nimbus.nim.swp
```