### PR TITLE
Update rpcutils

### DIFF
--- a/nimbus/rpc/debug.nim
+++ b/nimbus/rpc/debug.nim
@@ -25,7 +25,7 @@ proc setupDebugRpc*(chain: BaseChainDB, rpcsrv: RpcServer) =
     if not chain.getBlockBody(hash, result):
       raise newException(ValueError, "Error when retrieving block body")
 
-  rpcsrv.rpc("debug_traceTransaction") do(data: HexDataStr, options: Option[TraceTxOptions]) -> JsonNode:
+  rpcsrv.rpc("debug_traceTransaction") do(data: EthHashStr, options: Option[TraceTxOptions]) -> JsonNode:
     ## The traceTransaction debugging method will attempt to run the transaction in the exact
     ## same manner as it was executed on the network. It will replay any transaction that may
     ## have been executed prior to this one before it will finally attempt to execute the
@@ -38,7 +38,7 @@ proc setupDebugRpc*(chain: BaseChainDB, rpcsrv: RpcServer) =
     ## * disableMemory: BOOL. Setting this to true will disable memory capture (default = false).
     ## * disableStack: BOOL. Setting this to true will disable stack capture (default = false).
     let
-      txHash = strToHash(data.string)
+      txHash = toHash(data)
       txDetails = chain.getTransactionKey(txHash)
       blockHeader = chain.getBlockHeader(txDetails.blockNumber)
       blockHash = chain.getBlockHash(txDetails.blockNumber)

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -29,14 +29,6 @@ import
 proc `%`*(value: Time): JsonNode =
   result = %value.toSeconds
 
-func toAddress(value: EthAddressStr): EthAddress = hexToPaddedByteArray[20](value.string)
-
-func toHash(value: array[32, byte]): Hash256 {.inline.} =
-  result.data = value
-
-func toHash(value: EthHashStr): Hash256 {.inline.} =
-  result = hexToPaddedByteArray[32](value.string).toHash
-
 template balance(addressDb: AccountStateDb, address: EthAddress): GasInt =
   # TODO: Account balance u256 but GasInt is int64?
   addressDb.getBalance(address).truncate(int64)

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -9,10 +9,11 @@
 
 import hexstrings, nimcrypto, eth_common, byteutils
 
-func strToAddress*(value: string): EthAddress = hexToPaddedByteArray[20](value)
+func toAddress*(value: EthAddressStr): EthAddress = hexToPaddedByteArray[20](value.string)
 
 func toHash*(value: array[32, byte]): Hash256 {.inline.} =
   result.data = value
 
-func strToHash*(value: string): Hash256 {.inline.} =
-  result = hexToPaddedByteArray[32](value).toHash
+func toHash*(value: EthHashStr): Hash256 {.inline.} =
+  result = hexToPaddedByteArray[32](value.string).toHash
+


### PR DESCRIPTION
A small update to `p2p` and `debug` to update the utility names.

As the `toHash` now accepts a `EthHashStr` directly, I took the liberty of changing the input parameter to the `debug_traceTransactions` RPC to accept it. This will mean an error will be raised if the input string isn't a hash - for example if it's too long - which doesn't happen with `HexDataStr`.