### PR TITLE
Whisper rpc types

### DIFF
--- a/nimbus/rpc/rpc_types.nim
+++ b/nimbus/rpc/rpc_types.nim
@@ -119,6 +119,10 @@ type
     toBlock*: Option[string]              # (optional, default: "latest") integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
     address*: Option[EthAddress]          # (optional) contract address or a list of addresses from which logs should originate.
     topics*: Option[seq[FilterData]]      # (optional) list of DATA topics. Topics are order-dependent. Each topic can also be a list of DATA with "or" options.
+  
+  WhisperFilterOptions* = object
+    to*: Option[WhisperIdentityStr]
+    topics*: seq[HexDataStr]
 
   WhisperPost* = object
     # Parameter from user

--- a/nimbus/rpc/rpc_types.nim
+++ b/nimbus/rpc/rpc_types.nim
@@ -115,21 +115,19 @@ type
 
   FilterOptions* = object
     # Parameter from user
-    fromBlock*: string              # (optional, default: "latest") integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
-    toBlock*: string                # (optional, default: "latest") integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
-    address*: EthAddress            # (optional) contract address or a list of addresses from which logs should originate.
-    topics*: seq[FilterData]        # (optional) list of DATA topics. Topics are order-dependent. Each topic can also be a list of DATA with "or" options.
+    fromBlock*: Option[string]            # (optional, default: "latest") integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+    toBlock*: Option[string]              # (optional, default: "latest") integer block number, or "latest" for the last mined block or "pending", "earliest" for not yet mined transactions.
+    address*: Option[EthAddress]          # (optional) contract address or a list of addresses from which logs should originate.
+    topics*: Option[seq[FilterData]]      # (optional) list of DATA topics. Topics are order-dependent. Each topic can also be a list of DATA with "or" options.
 
   WhisperPost* = object
     # Parameter from user
-    source*: WhisperIdentityStr # (optional) the identity of the sender.
-    to*: WhisperIdentityStr     # (optional) the identity of the receiver. When present whisper will encrypt the message so that only the receiver can decrypt it.
-    topics*: seq[HexDataStr]    # list of DATA topics, for the receiver to identify messages.
-    payload*: HexDataStr        # the payload of the message.
-    priority*: int              # integer of the priority in a rang from.
-    ttl*: int                   # integer of the time to live in seconds.
-
-  WhisperIdentity = array[60, byte]
+    source*: Option[WhisperIdentityStr]   # (optional) the identity of the sender.
+    to*: Option[WhisperIdentityStr]       # (optional) the identity of the receiver. When present whisper will encrypt the message so that only the receiver can decrypt it.
+    topics*: seq[HexDataStr]              # list of DATA topics, for the receiver to identify messages.
+    payload*: HexDataStr                  # the payload of the message.
+    priority*: int                        # integer of the priority in a rang from.
+    ttl*: int                             # integer of the time to live in seconds.
 
   WhisperMessage* = object
     # Returned to user

--- a/nimbus/rpc/whisper.nim
+++ b/nimbus/rpc/whisper.nim
@@ -38,7 +38,7 @@ proc setupWhisperRPC*(rpcsrv: RpcServer) =
     ## Returns true if the identity was successfully added to the group, otherwise false (?).
     discard
 
-  rpcsrv.rpc("shh_newFilter") do(filterOptions: FilterOptions, to: WhisperIdentityStr, topics: seq[HexDataStr]) -> int:
+  rpcsrv.rpc("shh_newFilter") do(filterOptions: WhisperFilterOptions) -> int:
     ## Creates filter to notify, when client receives whisper message matching the filter options.
     ##
     ## filterOptions: The filter options:


### PR DESCRIPTION
Small PR that:

* Updates the whisper types and `FilterOptions` to be optional
* Removs the duplicated `WhisperIdentity` from `rpc_types.nim` as it's already present in `eth_common.eth_types`.
* Adds `WhisperFilterOptions`
* Updates the signature for `shh_newFilter` to use `WhisperFilterOptions` rather than the eth `FilterOptions`