### PR TITLE
Add separate badges for appveyor jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Nimbus: an Ethereum 2.0 Sharding Client for Resource-Restricted Devices
 
+Windows 64-bit: [![Windows x64 build status (Appveyor)](https://appveyor-matrix-badges.herokuapp.com/repos/nimbus/nimbus/branch/master/2 "Windows x64 build status (Appveyor)")](https://ci.appveyor.com/project/nimbus/nimbus)
+
+Windows 32-bit: [![Windows x86 build status (Appveyor)](https://appveyor-matrix-badges.herokuapp.com/repos/nimbus/nimbus/branch/master/1 "Windows x86 build status (Appveyor)")](https://ci.appveyor.com/project/nimbus/nimbus)
+
 [![Build Status (Travis)](https://img.shields.io/travis/status-im/nimbus/master.svg?label=Linux%20/%20macOS "Linux/macOS build status (Travis)")](https://travis-ci.org/status-im/nimbus)
-[![Windows build status (Appveyor)](https://img.shields.io/appveyor/ci/nimbus/nimbus/master.svg?label=Windows "Windows build status (Appveyor)")](https://ci.appveyor.com/project/nimbus/nimbus)
 [![License: Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![Stability: experimental](https://img.shields.io/badge/stability-experimental-orange.svg)


### PR DESCRIPTION
Appveyor does not support badges per job yet, so this is a workaround. Badges much less customizable and using 3 proxy services, but it's a solution unless we want to roll our own server with little things like these. Had to list the windows jobs because the badges look the same, and pure text with no list doesn't look so good. Ideas for improving visuals?