### PR TITLE
more VM tracing

### DIFF
--- a/nimbus/vm/interpreter_dispatch.nim
+++ b/nimbus/vm/interpreter_dispatch.nim
@@ -13,6 +13,9 @@ import
   ../vm_types, ../errors, precompiles,
   ./stack, ./computation, terminal # Those are only needed for logging
 
+logScope:
+  topics = "vm opcode"
+
 func invalidInstruction*(computation: var BaseComputation) {.inline.} =
   raise newException(ValueError, "Invalid instruction, received an opcode not implemented in the current fork.")
 
@@ -186,7 +189,9 @@ proc opTableToCaseStmt(opTable: array[Op, NimNode], computation: NimNode): NimNo
   for op, opImpl in opTable.pairs:
     let branchStmt = block:
       if op == Stop:
-        quote do: break
+        quote do:
+          trace "op: Stop"
+          break
       else:
         let asOp = quote do: Op(`op`) # TODO: unfortunately when passing to runtime, ops are transformed into int
         if BaseGasCosts[op].kind == GckFixed:

--- a/nimbus/vm/precompiles.nim
+++ b/nimbus/vm/precompiles.nim
@@ -277,7 +277,7 @@ proc execPrecompiles*(computation: var BaseComputation): bool {.inline.} =
   if lb in PrecompileAddresses.low.byte .. PrecompileAddresses.high.byte:
     result = true
     let precompile = PrecompileAddresses(lb)
-    trace "Call precompile ", precompile = precompile, codeAddr = computation.msg.codeAddress
+    trace "Call precompile", precompile = precompile, codeAddr = computation.msg.codeAddress
     case precompile
     of paEcRecover: ecRecover(computation)
     of paSha256: sha256(computation)

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:"chronicles_sinks=textblocks"
+

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -9,7 +9,7 @@ import
   unittest, strformat, strutils, tables, json, ospaths, times,
   byteutils, ranges/typedranges, nimcrypto/[keccak, hash], options,
   rlp, eth_trie/db, eth_common,
-  eth_keys,
+  eth_keys, chronicles,
   ./test_helpers,
   ../nimbus/[constants, errors],
   ../nimbus/[vm_state, vm_types, vm_state_transactions],
@@ -24,7 +24,11 @@ suite "generalstate json tests":
 
 
 proc testFixtureIndexes(header: BlockHeader, pre: JsonNode, transaction: Transaction, sender: EthAddress, expectedHash: string, testStatusIMPL: var TestStatus, fork: Fork) =
-  var vmState = newBaseVMState(header, newBaseChainDB(newMemoryDb()))
+  when enabledLogLevel <= TRACE:
+    let tracerFlags = {TracerFlags.EnableTracing}
+  else:
+    let tracerFlags: set[TracerFlags] = {}
+  var vmState = newBaseVMState(header, newBaseChainDB(newMemoryDb()), tracerFlags)
   vmState.mutateStateDB:
     setupStateDB(pre, db)
 


### PR DESCRIPTION
The existing vmState tracing is plugged into chronicles, at the TRACE level, to facilitate state test debugging.

Some useful chronicles defines are added to "tests/nim.cfg" to simplify the compile-and-run command for individual tests.