### PR TITLE
update Nimbus header and refine db backend picking

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ nimble nimbus
 
 Report any errors you encounter, please, if not [already documented](https://github.com/status-im/nimbus)!
 
+### Development tips
+
+- you can switch the DB backend with a Nim compiler define:
+  `-d:nimbus_db_backend=...` where the (case-insensitive) value is one of
+  "rocksdb" (the default), "sqlite", "lmdb".
+
 #### Troubleshooting
 
 Sometimes, the build will fail even though the latest CI is green - here are a few tips to handle this:

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2019 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -8,15 +8,16 @@
 # those terms.
 
 import
-  parseopt, strutils, macros, os,
+  parseopt, strutils, macros, os, times,
   asyncdispatch2, eth_keys, eth_p2p, eth_common, chronicles, nimcrypto/hash,
+  ./db/select_backend,
   ./vm/interpreter/vm_forks
 
-const
+let
   NimbusName* = "Nimbus"
   ## project name string
 
-  NimbusCopyright* = "Copyright (C) 2018 Status Research & Development GmbH"
+  NimbusCopyright* = "Copyright (C) 2018-" & $(now().utc.year) & " Status Research & Development GmbH"
   ## copyright string
 
   NimbusMajor*: int = 0
@@ -32,7 +33,7 @@ const
   ## is the version of Nimbus as a string.
 
   NimbusHeader* = NimbusName & " Version " & NimbusVersion &
-                  " [" & hostOS & ": " & hostCPU & "]\r\n" &
+                  " [" & hostOS & ": " & hostCPU & ", " & nimbus_db_backend & "]\r\n" &
                   NimbusCopyright
   ## is the header which printed, when nimbus binary got executed
 

--- a/nimbus/db/select_backend.nim
+++ b/nimbus/db/select_backend.nim
@@ -1,10 +1,19 @@
-const nimbus_db_backend* {.strdefine.} = "rocksdb"
+import strutils
 
-when nimbus_db_backend == "sqlite":
+type DbBackend = enum
+  sqlite,
+  rocksdb,
+  lmdb
+
+const
+  nimbus_db_backend* {.strdefine.} = "rocksdb"
+  dbBackend = parseEnum[DbBackend](nimbus_db_backend)
+
+when dbBackend == sqlite:
   import ./backends/sqlite_backend as database_backend
-elif nimbus_db_backend == "rocksdb":
+elif dbBackend == rocksdb:
   import ./backends/rocksdb_backend as database_backend
-else:
+elif dbBackend == lmdb:
   import ./backends/lmdb_backend as database_backend
 
 export database_backend


### PR DESCRIPTION
- dynamically generated copyright year interval
- added the db backend to the header
- documented the db-backend-changing define, made it case insensitive
  and ensured wrong values would trigger compilation errors