### PR TITLE
add "--threads:on" to tests and main binary

### DIFF
--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -13,12 +13,9 @@ import
   ./db/select_backend,
   ./vm/interpreter/vm_forks
 
-let
+const
   NimbusName* = "Nimbus"
   ## project name string
-
-  NimbusCopyright* = "Copyright (C) 2018-" & $(now().utc.year) & " Status Research & Development GmbH"
-  ## copyright string
 
   NimbusMajor*: int = 0
   ## is the major number of Nimbus' version.
@@ -32,13 +29,17 @@ let
   NimbusVersion* = $NimbusMajor & "." & $NimbusMinor & "." & $NimbusPatch
   ## is the version of Nimbus as a string.
 
+  NimbusIdent* = "$1/$2 ($3/$4)" % [NimbusName, NimbusVersion, hostCPU, hostOS]
+  ## project ident name for networking services
+
+let
+  NimbusCopyright* = "Copyright (C) 2018-" & $(now().utc.year) & " Status Research & Development GmbH"
+  ## copyright string
+
   NimbusHeader* = NimbusName & " Version " & NimbusVersion &
                   " [" & hostOS & ": " & hostCPU & ", " & nimbus_db_backend & "]\r\n" &
                   NimbusCopyright
   ## is the header which printed, when nimbus binary got executed
-
-  NimbusIdent* = "$1/$2 ($3/$4)" % [NimbusName, NimbusVersion, hostCPU, hostOS]
-  ## project ident name for networking services
 
 const
   MainnetBootnodes = [
@@ -533,8 +534,7 @@ proc initConfiguration(): NimbusConfiguration =
   result.net.maxPendingPeers = 0
   result.net.bindPort = 30303'u16
   result.net.discPort = 30303'u16
-  {.gcsafe.}:
-    result.net.ident = NimbusIdent
+  result.net.ident = NimbusIdent
 
   const dataDir = getDefaultDataDir()
 

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -533,7 +533,8 @@ proc initConfiguration(): NimbusConfiguration =
   result.net.maxPendingPeers = 0
   result.net.bindPort = 30303'u16
   result.net.discPort = 30303'u16
-  result.net.ident = NimbusIdent
+  {.gcsafe.}:
+    result.net.ident = NimbusIdent
 
   const dataDir = getDefaultDataDir()
 

--- a/nimbus/nim.cfg
+++ b/nimbus/nim.cfg
@@ -1,4 +1,5 @@
 -d:chronicles_line_numbers
 -d:"chronicles_sinks=textblocks"
 -d:nimDebugDlOpen
+--threads:on
 

--- a/nimbus/p2p/chain.nim
+++ b/nimbus/p2p/chain.nim
@@ -10,20 +10,20 @@ proc newChain*(db: BaseChainDB): Chain =
   result.new
   result.db = db
 
-method genesisHash*(c: Chain): KeccakHash =
+method genesisHash*(c: Chain): KeccakHash {.gcsafe.} =
   c.db.getBlockHash(0.toBlockNumber)
 
-method getBlockHeader*(c: Chain, b: HashOrNum, output: var BlockHeader): bool =
+method getBlockHeader*(c: Chain, b: HashOrNum, output: var BlockHeader): bool {.gcsafe.} =
   case b.isHash
   of true:
     c.db.getBlockHeader(b.hash, output)
   else:
     c.db.getBlockHeader(b.number, output)
 
-method getBestBlockHeader*(c: Chain): BlockHeader =
+method getBestBlockHeader*(c: Chain): BlockHeader {.gcsafe.} =
   c.db.getCanonicalHead()
 
-method getSuccessorHeader*(c: Chain, h: BlockHeader, output: var BlockHeader): bool =
+method getSuccessorHeader*(c: Chain, h: BlockHeader, output: var BlockHeader): bool {.gcsafe.} =
   let n = h.blockNumber + 1
   c.db.getBlockHeader(n, output)
 

--- a/nimbus/rpc/common.nim
+++ b/nimbus/rpc/common.nim
@@ -14,7 +14,8 @@ import
 
 proc setupCommonRPC*(server: RpcServer) =
   server.rpc("web3_clientVersion") do() -> string:
-    result = NimbusIdent
+    {.gcsafe.}:
+      result = NimbusIdent
 
   server.rpc("web3_sha3") do(data: HexDataStr) -> string:
     var rawdata = nimcrypto.fromHex(data.string)

--- a/nimbus/rpc/common.nim
+++ b/nimbus/rpc/common.nim
@@ -14,8 +14,7 @@ import
 
 proc setupCommonRPC*(server: RpcServer) =
   server.rpc("web3_clientVersion") do() -> string:
-    {.gcsafe.}:
-      result = NimbusIdent
+    result = NimbusIdent
 
   server.rpc("web3_sha3") do(data: HexDataStr) -> string:
     var rawdata = nimcrypto.fromHex(data.string)

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -85,7 +85,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
     let vmState = newBaseVMState(header, chain)
     result = vmState.readOnlyStateDB()
 
-  func accountDbFromTag(tag: string, readOnly = true): ReadOnlyStateDB =
+  proc accountDbFromTag(tag: string, readOnly = true): ReadOnlyStateDB =
     result = getAccountDb(chain.headerFromTag(tag))
 
   proc getBlockBody(hash: KeccakHash): BlockBody =

--- a/nimbus/rpc/rpc_utils.nim
+++ b/nimbus/rpc/rpc_utils.nim
@@ -19,7 +19,7 @@ func toHash*(value: array[32, byte]): Hash256 {.inline.} =
 func toHash*(value: EthHashStr): Hash256 {.inline.} =
   result = hexToPaddedByteArray[32](value.string).toHash
 
-func headerFromTag*(chain: BaseChainDB, blockTag: string): BlockHeader =
+proc headerFromTag*(chain: BaseChainDB, blockTag: string): BlockHeader =
   let tag = blockTag.toLowerAscii
   case tag
   of "latest": result = chain.getCanonicalHead()

--- a/nimbus/vm_state.nim
+++ b/nimbus/vm_state.nim
@@ -39,25 +39,25 @@ proc newBaseVMState*(header: BlockHeader, chainDB: BaseChainDB, tracerFlags: set
 proc stateRoot*(vmState: BaseVMState): Hash256 =
   vmState.blockHeader.stateRoot
 
-method blockhash*(vmState: BaseVMState): Hash256 =
+method blockhash*(vmState: BaseVMState): Hash256 {.base, gcsafe.} =
   vmState.blockHeader.hash
 
-method coinbase*(vmState: BaseVMState): EthAddress =
+method coinbase*(vmState: BaseVMState): EthAddress {.base, gcsafe.} =
   vmState.blockHeader.coinbase
 
-method timestamp*(vmState: BaseVMState): EthTime =
+method timestamp*(vmState: BaseVMState): EthTime {.base, gcsafe.} =
   vmState.blockHeader.timestamp
 
-method blockNumber*(vmState: BaseVMState): BlockNumber =
+method blockNumber*(vmState: BaseVMState): BlockNumber {.base, gcsafe.} =
   vmState.blockHeader.blockNumber
 
-method difficulty*(vmState: BaseVMState): UInt256 =
+method difficulty*(vmState: BaseVMState): UInt256 {.base, gcsafe.} =
   vmState.blockHeader.difficulty
 
-method gasLimit*(vmState: BaseVMState): GasInt =
+method gasLimit*(vmState: BaseVMState): GasInt {.base, gcsafe.} =
   vmState.blockHeader.gasLimit
 
-method getAncestorHash*(vmState: BaseVMState, blockNumber: BlockNumber): Hash256 =
+method getAncestorHash*(vmState: BaseVMState, blockNumber: BlockNumber): Hash256 {.base, gcsafe.} =
   var ancestorDepth = vmState.blockHeader.blockNumber - blockNumber - 1
   if ancestorDepth >= constants.MAX_PREV_HEADER_DEPTH or ancestorDepth < 0:
     return

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,3 +1,4 @@
 -d:chronicles_line_numbers
 -d:"chronicles_sinks=textblocks"
+--threads:on
 


### PR DESCRIPTION
- some "funcs" were no longer considered side-effect free, so I made
  them procs
- added {.base.} to some base methods to avoid a deprecation warning

This should be merged after: https://github.com/status-im/nim-rlp/pull/24 https://github.com/status-im/nim-eth-trie/pull/34 https://github.com/status-im/nim-eth-common/pull/26 https://github.com/status-im/nim-eth-p2p/pull/63