### PR TITLE
CI: don't set a depth for submodule cloning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,8 +21,6 @@ install:
 
 build_script:
   - cd C:\projects\%APPVEYOR_PROJECT_SLUG%
-  # speed up submodule cloning
-  - git submodule update --init --recursive --depth 10
   # the 32-bit build is done on a 64-bit image, so we need to override the architecture
   - mingw32-make ARCH_OVERRIDE=%PLATFORM% fetch-dlls
   - dir C:\mingw-w64

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 git:
   # when multiple CI builds are queued, the tested commit needs to be in the last X commits cloned with "--depth X"
   depth: 10
-  submodules_depth: 10
 
 matrix:
   include:


### PR DESCRIPTION
because the build will fail when we're too far behind upstream and our
target commit is not included in that depth any more