### PR TITLE
CI: use a release build for the test suite

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ build_script:
 test_script:
   - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% V=0
   - build\nimbus.exe --help
-  - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% V=0 EXTRA_NIM_PARAMS="-d:release" test
+  - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% V=0 NIMFLAGS="-d:release" test
   - IF "%PLATFORM%" == "x64" mingw32-make -j2 test-reproducibility
 
 deploy: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ build_script:
 test_script:
   - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% V=0
   - build\nimbus.exe --help
-  - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% V=0 test
+  - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% V=0 EXTRA_NIM_PARAMS="-d:release" test
   - IF "%PLATFORM%" == "x64" mingw32-make -j2 test-reproducibility
 
 deploy: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,6 @@ script:
   - set -e # fail fast
   - make -j${NPROC} V=0
   - ./build/nimbus --help
-  - make -j${NPROC} V=0 test test-reproducibility
+  - make -j${NPROC} V=0 EXTRA_NIM_PARAMS="-d:release" test
+  - make -j${NPROC} V=0 test-reproducibility
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ script:
   - set -e # fail fast
   - make -j${NPROC} V=0
   - ./build/nimbus --help
-  - make -j${NPROC} V=0 EXTRA_NIM_PARAMS="-d:release" test
+  - make -j${NPROC} V=0 NIMFLAGS="-d:release" test
   - make -j${NPROC} V=0 test-reproducibility
 

--- a/Makefile
+++ b/Makefile
@@ -139,13 +139,9 @@ $(NIMBLE_DIR): | $(NIM_BINARY)
 nimbus.nims:
 	ln -s nimbus.nimble $@
 
-# builds and runs the testsuite
-testsuite: | build deps
+# builds and runs the test suite
+test: | build deps
 	$(ENV_SCRIPT) nim test $(NIM_PARAMS) nimbus.nims
-
-#- builds the tools, to make sure they're still compilable
-#- builds and runs all tests
-test: | testsuite
 
 # primitive reproducibility test
 test-reproducibility:

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ RUN_CMD_IN_ALL_REPOS = git submodule foreach --recursive --quiet 'echo -e "\n\e[
 ENV_SCRIPT := "$(CURDIR)/env.sh"
 # duplicated in "env.sh" to prepend NIM_DIR/bin to PATH
 NIM_DIR := vendor/Nim
-# extra parameters for the Nim compiler
-NIM_PARAMS := $(EXTRA_NIM_PARAMS)
+#- extra parameters for the Nim compiler
+#- NIMFLAGS should come from the environment or make's command line
+NIM_PARAMS := $(NIMFLAGS)
 # verbosity level
 V := 1
 NIM_PARAMS := $(NIM_PARAMS) --verbosity:$(V)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ make LOG_LEVEL=TRACE nimbus # log everything
 - pass arbitrary parameters to the Nim compiler:
 
 ```bash
-make EXTRA_NIM_PARAMS="-d:release"
+make NIMFLAGS="-d:release"
 ```
 
 - if you want to use SSH keys with GitHub:

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -23,3 +23,4 @@ import  ./test_code_stream,
         ./test_op_memory,
         ./test_op_misc,
         ./test_state_db
+


### PR DESCRIPTION
Makefile: the "testsuite" target is no longer needed

## Rationale

There's a significant speed-up when these tests are built with "-d:release", but this is only enabled in the CI pipeline, because developers running `make test` should still benefit from all runtime checks and assertions enabled by default during a debug build.

Manually opting into release builds is relatively easy: `make EXTRA_NIM_PARAMS="-d:release" test`

Some timings from my system:

```bash
rm -rf nimcache; time make V=0 test
[...]
real	3m8.621s
user	3m25.824s
sys	0m20.684s

rm -rf nimcache; time make V=0 EXTRA_NIM_PARAMS="-d:release" test
[...]
real	1m25.348s
user	3m6.899s
sys	0m23.273s

rm -rf nimcache; time make V=0 EXTRA_NIM_PARAMS="-d:release --assertions:on" test
[...]
real	1m30.413s
user	3m15.356s
sys	0m22.995s

rm -rf nimcache; time make V=0 EXTRA_NIM_PARAMS="-d:release --assertions:on --checks:on" test
[...]
real	1m40.409s
user	3m36.361s
sys	0m23.686s
```
