### PR TITLE
add byzantium block validation test

### DIFF
--- a/tests/persistBlockTestGen.nim
+++ b/tests/persistBlockTestGen.nim
@@ -100,6 +100,7 @@ proc main() =
   chainDB.dumpTest(2_463_413) # tangerine call* gas cost bug
   chainDB.dumpTest(2_675_000) # spurious dragon first block
   chainDB.dumpTest(2_675_002) # EIP155 tx.getSender
+  chainDB.dumpTest(4_370_000) # Byzantium first block
 
 when isMainModule:
   var message: string


### PR DESCRIPTION
this is not a real bug test, only a proof nimbus evm really sync past byzantium