### PR TITLE
 Forward maxPeers config to EthereumNode minPeers 

### DIFF
--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -94,7 +94,8 @@ proc start(): NimbusObject =
 
   nimbus.ethNode = newEthereumNode(keypair, address, conf.net.networkId,
                                    nil, nimbusClientId,
-                                   addAllCapabilities = false)
+                                   addAllCapabilities = false,
+                                   minPeers = conf.net.maxPeers)
   # Add protocol capabilities based on protocol flags
   if ProtocolFlags.Eth in conf.net.protocols:
     nimbus.ethNode.addCapability eth


### PR DESCRIPTION
`maxPeers` config is currently not used and thus we would always be stuck on 10 peers, this changes that.
The change is not 100% correct, as it is basically "minPeers before stopping to connect". The listener still stays active for incoming connections. (And if you provide enough `--staticnodes` you could also go over the max).
Could change this in nim-eth though. Or could alter the meaning of `maxPeers` here in the documentation.


