### PR TITLE
drop name of network from docker image tag

### DIFF
--- a/docker/beacon_node/Makefile
+++ b/docker/beacon_node/Makefile
@@ -5,7 +5,7 @@ GIT_REVISION    ?= $(git rev-parse HEAD)
 NETWORK         ?= testnet0
 NETWORK_BACKEND ?= rlpx
 
-IMAGE_TAG       ?= $(NETWORK)-$(NETWORK_BACKEND)
+IMAGE_TAG       ?= $(NETWORK)
 IMAGE_NAME      ?= statusteam/nimbus_beacon_node:$(IMAGE_TAG)
 
 build: $(NIX_INSTALL)

--- a/docker/build_beacon_node.sh
+++ b/docker/build_beacon_node.sh
@@ -15,6 +15,3 @@ buildAndPush() {
 
 buildAndPush testnet0 rlpx
 buildAndPush testnet1 rlpx
-
-#buildAndPush testnet0 libp2p
-#buildAndPush testnet1 libp2p


### PR DESCRIPTION
We no longer support different flavors of images depending on protocol used.