### PR TITLE
Ctrl+C handling for a graceful stop

### DIFF
--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -37,9 +37,20 @@ type
     ethNode*: EthereumNode
     state*: NimbusState
 
-proc start(): NimbusObject =
-  var nimbus = NimbusObject()
+var nimbus: NimbusObject
+
+proc start() =
   var conf = getConfiguration()
+
+  nimbus = NimbusObject()
+  nimbus.state = Starting
+
+  ## Ctrl+C handling
+  proc handler() {.noconv.} =
+    # workaround for https://github.com/nim-lang/Nim/issues/4057
+    setupForeignThreadGc()
+    nimbus.state = Stopping
+  setControlCHook(handler)
 
   ## logging
   setLogLevel(conf.debug.logLevel)
@@ -117,10 +128,10 @@ proc start(): NimbusObject =
     setupDebugRpc(chainDB, nimbus.rpcServer)
 
   ## Starting servers
-  nimbus.state = Starting
   if RpcFlags.Enabled in conf.rpc.flags:
     nimbus.rpcServer.rpc("admin_quit") do() -> string:
-      nimbus.state = Stopping
+      {.gcsafe.}:
+        nimbus.state = Stopping
       result = "EXITING"
     nimbus.rpcServer.start()
 
@@ -147,22 +158,18 @@ proc start(): NimbusObject =
     if status != syncSuccess:
       debug "Block sync failed: ", status
 
-  nimbus.state = Running
-  result = nimbus
+  if nimbus.state == Starting:
+    # it might have been set to "Stopping" with Ctrl+C
+    nimbus.state = Running
 
-proc stop*(nimbus: NimbusObject) {.async.} =
+proc stop*() {.async.} =
   trace "Graceful shutdown"
-  nimbus.rpcServer.stop()
+  var conf = getConfiguration()
+  if RpcFlags.Enabled in conf.rpc.flags:
+    nimbus.rpcServer.stop()
 
-proc process*(nimbus: NimbusObject) =
+proc process*() =
   if nimbus.state == Running:
-    when not defined(windows):
-      proc signalBreak(udata: pointer) =
-        nimbus.state = Stopping
-      # Adding SIGINT, SIGTERM handlers
-      # discard addSignal(SIGINT, signalBreak)
-      # discard addSignal(SIGTERM, signalBreak)
-
     # Main loop
     while nimbus.state == Running:
       try:
@@ -172,16 +179,16 @@ proc process*(nimbus: NimbusObject) =
           exc = getCurrentException().name,
           err = getCurrentExceptionMsg()
 
-    # Stop loop
-    waitFor nimbus.stop()
+  # Stop loop
+  waitFor stop()
 
 when isMainModule:
   var message: string
 
-  ## Pring Nimbus header
+  ## Print Nimbus header
   echo NimbusHeader
 
-  ## show logs on stdout until we get the user's logging choice
+  ## Show logs on stdout until we get the user's logging choice
   discard defaultChroniclesStream.output.open(stdout)
 
   ## Processing command line arguments
@@ -193,5 +200,6 @@ when isMainModule:
       echo message
       quit(QuitSuccess)
 
-  var nimbus = start()
-  nimbus.process()
+  start()
+  process()
+

--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -46,11 +46,12 @@ proc start() =
   nimbus.state = Starting
 
   ## Ctrl+C handling
-  proc handler() {.noconv.} =
-    # workaround for https://github.com/nim-lang/Nim/issues/4057
-    setupForeignThreadGc()
+  proc controlCHandler() {.noconv.} =
+    when defined(windows):
+      # workaround for https://github.com/nim-lang/Nim/issues/4057
+      setupForeignThreadGc()
     nimbus.state = Stopping
-  setControlCHook(handler)
+  setControlCHook(controlCHandler)
 
   ## logging
   setLogLevel(conf.debug.logLevel)


### PR DESCRIPTION
`addSignal()` doesn't seem to work, which is probably why it was commented
out. I'm using `setControlCHook()` instead, moved to an earlier point in the
start-up process, but its handler can only change global variables, so I
had to make "nimbus" global.