### PR TITLE
Add txRoot check to avoid assertions in tracer + don't throw exception

### DIFF
--- a/nimbus/p2p/chain.nim
+++ b/nimbus/p2p/chain.nim
@@ -52,9 +52,10 @@ method persistBlocks*(c: Chain, headers: openarray[BlockHeader], bodies: openarr
     let validationResult = processBlock(c.db, headers[i], bodies[i], vmState)
 
     when not defined(release):
-      if validationResult == ValidationResult.Error:
+      if validationResult == ValidationResult.Error and
+          bodies[i].transactions.calcTxRoot == headers[i].txRoot:
         dumpDebuggingMetaData(c.db, headers[i], bodies[i], vmState)
-        raise newException(Exception, "Validation error. Debugging metadata dumped.")
+        warn "Validation error. Debugging metadata dumped."
 
     if validationResult != ValidationResult.OK:
       return validationResult


### PR DESCRIPTION
I would run into this assertion when running Nimbus in debug mode:
```
Error: unhandled exception: /home/deme/repos/nimbus/nimbus/tracer.nim(202, 11) `calcRootHash(body.transactions) == header.txRoot`
```
This already gets reported before in `processBlock` : see also log statement:
```
DBG 2019-07-12 11:02:01+02:00 Mismatched txRoot tid=2989 file=p2p/executor.nim:122 blockNumber=1353812
```

So I added a check before dumping the debug information, to avoid the assertions. Because I don't think we need to raise (anything) and also as I didn't know for sure if other code (premix) requires/assumes these assertions.

I've also removed the raised exception, as I think it is/was not the intention to raise this all the way up (and potentially crash on it, if not catched in nimbus.nim).

I also checked a bit the history and I noticed that originally we would only raise here:  https://github.com/status-im/nimbus/commit/048a43b2f1cc8835f3556147842618dd8c29f765#diff-04e63af065108e405533c68136d6ef55R137
And then that also got removed: https://github.com/status-im/nimbus/blob/master/nimbus/p2p/executor.nim#L168
That's OK, I guess? As there is the `dumpDebuggingMetaData` now?





