### PR TITLE
Ecrecover index error

### DIFF
--- a/nimbus/errors.nim
+++ b/nimbus/errors.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 type
-  EVMError* = object of Exception
+  EVMError* = object of CatchableError
     ## Base error class for all evm errors.
 
   BlockNotFound* = object of EVMError

--- a/nimbus/vm/precompiles.nim
+++ b/nimbus/vm/precompiles.nim
@@ -233,7 +233,7 @@ proc modExp*(computation: BaseComputation) =
   elif maxBytes <= 1024:
     computation.modExpInternal(base_len, exp_len, mod_len, StUint[8192])
   else:
-    raise newException(ValueError, "The Nimbus VM doesn't support modular exponentiation with numbers larger than uint8192")
+    raise newException(EVMError, "The Nimbus VM doesn't support modular exponentiation with numbers larger than uint8192")
 
 proc bn256ecAdd*(computation: BaseComputation) =
   computation.gasMeter.consumeGas(GasECAdd, reason = "ecAdd Precompile")
@@ -335,7 +335,7 @@ proc execPrecompiles*(computation: BaseComputation, fork: Fork): bool {.inline.}
       let msg = getCurrentExceptionMsg()
       # cannot use setError here, cyclic dependency
       computation.error = Error(info: msg, burnsGas: true)
-    except:
+    except CatchableError:
       let msg = getCurrentExceptionMsg()
       if fork >= FKByzantium and precompile > paIdentity:
         computation.error = Error(info: msg, burnsGas: true)

--- a/nimbus/vm/precompiles.nim
+++ b/nimbus/vm/precompiles.nim
@@ -21,7 +21,7 @@ proc getSignature*(computation: BaseComputation): (array[32, byte], Signature) =
   template data: untyped = computation.msg.data
   var bytes: array[65, byte]
   let maxPos = min(data.high, 127)
-  if maxPos >= 31:
+  if maxPos >= 63:
     # extract message hash
     result[0][0..31] = data[0..31]
     if maxPos >= 127:
@@ -31,7 +31,7 @@ proc getSignature*(computation: BaseComputation): (array[32, byte], Signature) =
     elif maxPos >= 64:
       bytes[0..(maxPos-64)] = data[64..maxPos]
   else:
-    result[0][0..maxPos] = data[0..maxPos]
+    raise newException(ValidationError, "Invalid V in getSignature")
 
   var VOK = true
   let v = data[63]


### PR DESCRIPTION
When syncing Nimbus there was a segfault occuring (release mode) at block number 1352922.

The problem was invalid access to `data[63]`,  in `getSignature` used by `ecRecover`.
The data provided there does not necessarily have 64 bytes, and can in fact be completely empty.

The reason as to why this happens at block 1352922, is because it is the first TX to 0x0...01 (ecrecover precompile) with empty input data, see:
https://etherscan.io/txs?a=0x0000000000000000000000000000000000000001&p=166
https://etherscan.io/tx/0x4127eb13b273120f81267673dc89a158cae570215eb06e795ab0636ee7f7f015

The first commit  fixes this. The second commit is a rework of the code in hope to make it more clear + do certain actions in a more reasonable order.

Additionally, this bug would only be noticed in `release` mode, without much debug data to work from.
`IndexError` would be raised in `debug` mode, but quickly catched by the catch all. The last commit should make debug mode also crash on this type of errors. This could create some new crashes, I haven't seen any yet but I have not yet tested to sync again from start. 

I did run the general state tests, and have same results, skipping the 2 known failed and slow tests (slow tests seem to not give reliable results, with or without this change)
