### PR TITLE
example Grafana dashboard + nim-metrics bump [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,42 @@ cd vendor/nim-rocksdb
 ../../env.sh nimble test
 ```
 
+### Metric visualisation
+
+Install Prometheus and Grafana. On Gentoo, it's `emerge prometheus grafana-bin`.
+
+```bash
+# build Nimbus with support for the HTTP endpoint
+make NIMFLAGS="-d:insecure" nimbus
+# the Prometheus daemon will create its data dir in the current dir, so give it its own directory
+mkdir ../my_metrics
+# copy the basic config file over there
+cp -a examples/prometheus.yml ../my_metrics/
+# start Prometheus in a separate terminal
+cd ../my_metrics
+prometheus # loads ./prometheus.yml, writes metric data to ./data
+# start a fresh Nimbus sync and export metrics
+rm -rf ~/.cache/nimbus/db; ./build/nimbus --prune:archive --metricsServer
+```
+
+Start the Grafana server. On Gentoo it's `/etc/init.d/grafana start`. Go to
+http://localhost:3000, log in with admin:admin and change the password.
+
+Add Prometheus as a data source. The default address of http://localhost:9090
+is OK, but Grafana 6.3.5 will not apply that semitransparent default you see in
+the form field, unless you click on it.
+
+Create a new dashboard. Click on its default title in the upper left corner
+("New Dashboard"). In the new page, click "Import dashboard" in the right
+column and upload "examples/Nimbus-Grafana-dashboard.json".
+
+In the main panel, there's a hidden button used to assign metrics to the left
+or right Y-axis - it's the coloured line on the left of the metric name, in the
+graph legend.
+
+To see a single metric, click on its name in the legend. Click it again to go back
+to the combined view. To edit a panel, click on its title and select "Edit".
+
 ### Troubleshooting
 
 Report any errors you encounter, please, if not [already documented](https://github.com/status-im/nimbus/issues)!

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ graph legend.
 To see a single metric, click on its name in the legend. Click it again to go back
 to the combined view. To edit a panel, click on its title and select "Edit".
 
+[Obligatory screenshot.](https://i.imgur.com/AdtavDA.png)
+
 ### Troubleshooting
 
 Report any errors you encounter, please, if not [already documented](https://github.com/status-im/nimbus/issues)!

--- a/examples/Nimbus-Grafana-dashboard.json
+++ b/examples/Nimbus-Grafana-dashboard.json
@@ -182,6 +182,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 100
               }
             ]
           },
@@ -225,6 +229,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 2147483648
               }
             ],
             "unit": "bytes"
@@ -269,6 +277,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 200
               }
             ],
             "unit": "percent"
@@ -321,5 +333,5 @@
   "timezone": "",
   "title": "Nimbus",
   "uid": "mmSk-ShZk",
-  "version": 23
+  "version": 30
 }

--- a/examples/Nimbus-Grafana-dashboard.json
+++ b/examples/Nimbus-Grafana-dashboard.json
@@ -1,0 +1,325 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "process_resident_memory_bytes{instance=\"localhost:9093\",job=\"nimbus\"}",
+          "yaxis": 2
+        },
+        {
+          "alias": "process_virtual_memory_bytes{instance=\"localhost:9093\",job=\"nimbus\"}",
+          "yaxis": 2
+        },
+        {
+          "alias": "nim_gc_mem_bytes{instance=\"localhost:9093\",job=\"nimbus\"}",
+          "yaxis": 2
+        },
+        {
+          "alias": "nim_gc_mem_occupied_bytes{instance=\"localhost:9093\",job=\"nimbus\"}",
+          "yaxis": 2
+        },
+        {
+          "alias": "RSS",
+          "yaxis": 2
+        },
+        {
+          "alias": "virtual mem",
+          "yaxis": 2
+        },
+        {
+          "alias": "Nim GC mem total",
+          "yaxis": 2
+        },
+        {
+          "alias": "Nim GC mem used",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[2s]) * 100",
+          "legendFormat": "CPU usage %",
+          "refId": "A"
+        },
+        {
+          "expr": "process_open_fds",
+          "legendFormat": "open file descriptors",
+          "refId": "C"
+        },
+        {
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS",
+          "refId": "D"
+        },
+        {
+          "expr": "nim_gc_mem_bytes",
+          "legendFormat": "Nim GC mem total",
+          "refId": "F"
+        },
+        {
+          "expr": "nim_gc_mem_occupied_bytes",
+          "legendFormat": "Nim GC mem used",
+          "refId": "G"
+        },
+        {
+          "expr": "connected_peers",
+          "legendFormat": "connected peers",
+          "refId": "H"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Nimbus",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 4,
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "defaults": {
+            "mappings": [],
+            "max": 100,
+            "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "override": {},
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.3.5",
+      "targets": [
+        {
+          "expr": "connected_peers",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "peers",
+      "type": "gauge"
+    },
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 6,
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "defaults": {
+            "mappings": [],
+            "max": 2147483648,
+            "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ],
+            "unit": "bytes"
+          },
+          "override": {},
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.3.5",
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "RSS mem",
+      "type": "gauge"
+    },
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "defaults": {
+            "mappings": [],
+            "max": 200,
+            "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ],
+            "unit": "percent"
+          },
+          "override": {},
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.3.5",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[2s]) * 100",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU usage",
+      "type": "gauge"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 19,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Nimbus",
+  "uid": "mmSk-ShZk",
+  "version": 23
+}


### PR DESCRIPTION
Dashboard exported from Grafana 6.3.5 running locally, with Prometheus as a data source. Once imported, it would look almost like this:
![screenshot](https://i.imgur.com/AdtavDA.png)

("almost", because importing is a bit broken and Grafana fills in missing gauge graph limits with a default value)

You'll notice that the metrics have been manually grouped on two different vertical axes, based on the range of their values. No, there's no apparent way to set a display gauge's maximum value to a metric's historical max. It wants fixed numbers there.