### PR TITLE
Under Debian and probably Ubuntu, simply running prometheus does not use local config

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ mkdir ../my_metrics
 cp -a examples/prometheus.yml ../my_metrics/
 # start Prometheus in a separate terminal
 cd ../my_metrics
-prometheus # loads ./prometheus.yml, writes metric data to ./data
+prometheus --config.file=prometheus.yml # loads ./prometheus.yml, writes metric data to ./data
 # start a fresh Nimbus sync and export metrics
 rm -rf ~/.cache/nimbus/db; ./build/nimbus --prune:archive --metricsServer
 ```


### PR DESCRIPTION
This is a problem when following https://github.com/status-im/nimbus/#metric-visualisation

https://manpages.debian.org/buster/prometheus/prometheus.1.en.html shows, for example:
```
--config.file="/etc/prometheus/prometheus.yml"
    Prometheus configuration file path.
```