### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ On Windows, a precompiled DLL collection download is available through the `fetc
 brew install rocksdb pcre
 
 # Fedora
-dnf install rocksdb-devel pcre
+dnf install rocksdb-devel pcre pcre-devel
 
 # Debian and Ubuntu
 sudo apt-get install librocksdb-dev libpcre3-dev


### PR DESCRIPTION
Without `pcre-devel` I get the following error when running `make`:

```
> make
Building: build/premix

Error: execution of an external compiler program 'gcc -c  -w -pthread -I/home/oskarth/git/status-im/nimbus/vendor/nim-secp256k1/secp256k1_wrapper -I/home/oskarth/git/status-im/nimbus/vendor/nim-secp256k1/secp256k1_wrapper/secp256k1 -I/home/oskarth/git/status-im/nimbus/vendor/nim-secp256k1/secp256k1_wrapper/secp256k1/src -DHAVE_CONFIG_H -I/home/oskarth/git/status-im/nimbus/vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc -I/home/oskarth/git/status-im/nimbus/vendor/nim-nat-traversal/vendor/libnatpmp -DENABLE_STRNATPMPERR -g3 -Og -O3 -fno-strict-aliasing  -I/home/oskarth/git/status-im/nimbus/vendor/nimbus-build-system/vendor/Nim/lib -I/home/oskarth/git/status-im/nimbus/premix -o nimcache/debug/premix/stdlib_re.nim.c.o nimcache/debug/premix/stdlib_re.nim.c' failed with exit code: 1

nimcache/debug/premix/stdlib_re.nim.c:10:10: fatal error: pcre.h: No such file or directory
 #include <pcre.h>
          ^~~~~~~~
compilation terminated.
make: *** [Makefile:48: premix] Error 1
```