### PR TITLE
attempt to remove computation children sequence PART 1

### DIFF
--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -246,6 +246,10 @@ proc registerAccountForDeletion*(c: BaseComputation, beneficiary: EthAddress) =
     raise newException(ValueError,
       "invariant:  should be impossible for an account to be " &
       "registered for deletion multiple times")
+  # TODO: collecting touched accounts should be done in state db
+  # we should remove this accountsToDelete map delegate it to state db
+  # we will only keep suicides list here in order to make
+  # evmc integration easier
   c.accountsToDelete[c.msg.storageAddress] = beneficiary
   c.suicides.incl(c.msg.storageAddress)
 
@@ -273,6 +277,7 @@ proc getGasRemaining*(c: BaseComputation): GasInt =
   else:
     result = c.gasMeter.gasRemaining
 
+# TODO: collecting touched accounts should be done in account state db
 proc collectTouchedAccounts*(c: BaseComputation, output: var HashSet[EthAddress], ancestorHadError: bool = false) =
   ## Collect all of the accounts that *may* need to be deleted based on EIP161:
   ## https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -64,6 +64,7 @@ type
     returnData*:            seq[byte]
     error*:                 Error
     accountsToDelete*:      Table[EthAddress, EthAddress]
+    suicides*:              HashSet[EthAddress]
     gasCosts*:              GasCosts # TODO - will be hidden at a lower layer
     forkOverride*:          Option[Fork]
     logEntries*:            seq[Log]


### PR DESCRIPTION
current implementation might be influenced by py-evm by initial implementer.
the result is parent computation keep a list of child computations.
this maybe the reason why deep EVM recursion takes so much memory.

the first part of this PR deals with:
- rather than collecting refund gas through the list of child computation, refund gas are collected after each child computation is done.
- same thing goes to collecting self destructed accounts

the next part will deals with collecting touched accounts:
- current implementation seems out of place, it should be handled in state db, not in computation
- this probably related to coinbase suicide bugs in some blockchain tests

after the child computation list removed, separation between EVM and EMV-host will be clearer and allow us to integrate evmc more easily.

integrating evmc cannot be done without heavy refactoring, and it begins here. as a bonus we reduce memory usage.