### PR TITLE
Support custom networks

### DIFF
--- a/nimbus/nimbus.nim
+++ b/nimbus/nimbus.nim
@@ -106,14 +106,14 @@ proc start() =
 
   createDir(conf.dataDir)
   let trieDB = trieDB newChainDb(conf.dataDir)
-  let chainDB = newBaseChainDB(trieDB,
+  var chainDB = newBaseChainDB(trieDB,
     conf.prune == PruneMode.Full,
     conf.net.networkId.toPublicNetwork())
 
   if canonicalHeadHashKey().toOpenArray notin trieDB:
     initializeEmptyDb(chainDb)
     doAssert(canonicalHeadHashKey().toOpenArray in trieDB)
-
+  
   nimbus.ethNode = newEthereumNode(keypair, address, conf.net.networkId,
                                    nil, nimbusClientId,
                                    addAllCapabilities = false,
@@ -145,7 +145,7 @@ proc start() =
         nimbus.state = Stopping
       result = "EXITING"
     nimbus.rpcServer.start()
-
+ 
   # metrics server
   when defined(insecure):
     if conf.net.metricsServer:


### PR DESCRIPTION
Problem: Nimbus does not currently support custom/private networks for Ethereum 1 like Geth/Parity.

Solution: This PR will bring Nimbus one step closer to feature parity with Geth by accepting a new new `customnetwork` argument that takes a json file as a value and then loads `ChainConfig` values from the genesis block provided.  The format for the genesis block must match the format [specified in the Geth documentation](https://github.com/ethereum/go-ethereum/wiki/Private-network).  This will work out of the box with a `genesis.json` created by [puppeth](https://github.com/ethereum/go-ethereum#executables).

PR status: ready
