### PR TITLE
Prepare EVMC integration

### DIFF
--- a/BlockchainTests.md
+++ b/BlockchainTests.md
@@ -228,7 +228,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + OverflowGasRequire.json                                         OK
 + RefundOverflow.json                                             OK
 + RefundOverflow2.json                                            OK
-  SuicidesMixingCoinbase.json                                     Skip
++ SuicidesMixingCoinbase.json                                     OK
 + TransactionFromCoinbaseHittingBlockGasLimit1.json               OK
 + TransactionFromCoinbaseNotEnoughFounds.json                     OK
 + TransactionNonceCheck.json                                      OK
@@ -277,8 +277,8 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + randomStatetest619.json                                         OK
   randomStatetest94.json                                          Skip
 + simpleSuicide.json                                              OK
-  suicideCoinbase.json                                            Skip
-  suicideCoinbaseState.json                                       Skip
++ suicideCoinbase.json                                            OK
++ suicideCoinbaseState.json                                       OK
 + suicideStorageCheck.json                                        OK
 + suicideStorageCheckVCreate.json                                 OK
 + suicideStorageCheckVCreate2.json                                OK
@@ -286,7 +286,7 @@ OK: 96/96 Fail: 0/96 Skip: 0/96
 + transactionFromNotExistingAccount.json                          OK
 + txCost-sec73.json                                               OK
 ```
-OK: 63/67 Fail: 0/67 Skip: 4/67
+OK: 66/67 Fail: 0/67 Skip: 1/67
 ## bcTotalDifficultyTest
 ```diff
 + lotsOfBranchesOverrideAtTheEnd.json                             OK
@@ -404,4 +404,4 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 312/318 Fail: 0/318 Skip: 6/318
+OK: 315/318 Fail: 0/318 Skip: 3/318

--- a/GeneralStateTests.md
+++ b/GeneralStateTests.md
@@ -1364,13 +1364,13 @@ OK: 0/16 Fail: 0/16 Skip: 16/16
 + randomStatetest9.json                                           OK
 + randomStatetest90.json                                          OK
 + randomStatetest92.json                                          OK
-  randomStatetest94.json                                          Skip
++ randomStatetest94.json                                          OK
 + randomStatetest95.json                                          OK
 + randomStatetest96.json                                          OK
 + randomStatetest97.json                                          OK
 + randomStatetest98.json                                          OK
 ```
-OK: 322/327 Fail: 0/327 Skip: 5/327
+OK: 323/327 Fail: 0/327 Skip: 4/327
 ## stRandom2
 ```diff
 + 201503110226PYTHON_DUP6.json                                    OK
@@ -1963,7 +1963,7 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 + static_RETURN_Bounds.json                                       OK
 + static_RETURN_BoundsOOG.json                                    OK
 + static_RawCallGasAsk.json                                       OK
-  static_Return50000_2.json                                       Skip
++ static_Return50000_2.json                                       OK
 + static_ReturnTest.json                                          OK
 + static_ReturnTest2.json                                         OK
 + static_RevertDepth2.json                                        OK
@@ -2137,7 +2137,7 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 + static_refund_CallToSuicideNoStorage.json                       OK
 + static_refund_CallToSuicideTwice.json                           OK
 ```
-OK: 270/284 Fail: 0/284 Skip: 14/284
+OK: 271/284 Fail: 0/284 Skip: 13/284
 ## stSystemOperationsTest
 ```diff
 + ABAcalls0.json                                                  OK
@@ -2201,14 +2201,14 @@ OK: 270/284 Fail: 0/284 Skip: 14/284
 + suicideCaller.json                                              OK
 + suicideCallerAddresTooBigLeft.json                              OK
 + suicideCallerAddresTooBigRight.json                             OK
-  suicideCoinbase.json                                            Skip
++ suicideCoinbase.json                                            OK
 + suicideNotExistingAccount.json                                  OK
 + suicideOrigin.json                                              OK
 + suicideSendEtherPostDeath.json                                  OK
 + suicideSendEtherToMe.json                                       OK
 + testRandomTest.json                                             OK
 ```
-OK: 56/67 Fail: 0/67 Skip: 11/67
+OK: 57/67 Fail: 0/67 Skip: 10/67
 ## stTransactionTest
 ```diff
 + ContractStoreClearsOOG.json                                     OK
@@ -2239,7 +2239,7 @@ OK: 56/67 Fail: 0/67 Skip: 11/67
 + SuicidesAndInternlCallSuicidesOOG.json                          OK
 + SuicidesAndInternlCallSuicidesSuccess.json                      OK
 + SuicidesAndSendMoneyToItselfEtherDestroyed.json                 OK
-  SuicidesMixingCoinbase.json                                     Skip
++ SuicidesMixingCoinbase.json                                     OK
 + SuicidesStopAfterSuicide.json                                   OK
 + TransactionDataCosts652.json                                    OK
 + TransactionFromCoinbaseHittingBlockGasLimit.json                OK
@@ -2256,7 +2256,7 @@ OK: 56/67 Fail: 0/67 Skip: 11/67
 + UserTransactionZeroCost.json                                    OK
 + UserTransactionZeroCostWithData.json                            OK
 ```
-OK: 43/44 Fail: 0/44 Skip: 1/44
+OK: 44/44 Fail: 0/44 Skip: 0/44
 ## stTransitionTest
 ```diff
 + createNameRegistratorPerTxsAfter.json                           OK
@@ -2644,4 +2644,5 @@ OK: 133/133 Fail: 0/133 Skip: 0/133
 ```
 OK: 130/130 Fail: 0/130 Skip: 0/130
 
-OK: 2336/2447 Fail: 0/2447 Skip: 111/2447
+---TOTAL---
+OK: 2343/2447 Fail: 0/2447 Skip: 104/2447

--- a/GeneralStateTests.md
+++ b/GeneralStateTests.md
@@ -405,7 +405,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + create2collisionSelfdestructedOOG.json                          OK
 + create2collisionSelfdestructedRevert.json                       OK
 + create2collisionStorage.json                                    OK
-  create2noCash.json                                              Skip
++ create2noCash.json                                              OK
 + returndatacopy_0_0_following_successful_create.json             OK
 + returndatacopy_afterFailing_create.json                         OK
 + returndatacopy_following_create.json                            OK
@@ -413,7 +413,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + returndatacopy_following_successful_create.json                 OK
 + returndatasize_following_successful_create.json                 OK
 ```
-OK: 42/44 Fail: 0/44 Skip: 2/44
+OK: 43/44 Fail: 0/44 Skip: 1/44
 ## stCreateTest
 ```diff
 + CREATE_AcreateB_BSuicide_BStore.json                            OK
@@ -2645,4 +2645,4 @@ OK: 133/133 Fail: 0/133 Skip: 0/133
 OK: 130/130 Fail: 0/130 Skip: 0/130
 
 ---TOTAL---
-OK: 2343/2447 Fail: 0/2447 Skip: 104/2447
+OK: 2344/2447 Fail: 0/2447 Skip: 103/2447

--- a/newBlockchainTests.md
+++ b/newBlockchainTests.md
@@ -2362,7 +2362,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + static_RETURN_Bounds.json                                       OK
 + static_RETURN_BoundsOOG.json                                    OK
 + static_RawCallGasAsk.json                                       OK
-  static_Return50000_2.json                                       Skip
++ static_Return50000_2.json                                       OK
 + static_ReturnTest.json                                          OK
 + static_ReturnTest2.json                                         OK
 + static_RevertDepth2.json                                        OK
@@ -2536,7 +2536,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + static_refund_CallToSuicideNoStorage.json                       OK
 + static_refund_CallToSuicideTwice.json                           OK
 ```
-OK: 270/283 Fail: 0/283 Skip: 13/283
+OK: 271/283 Fail: 0/283 Skip: 12/283
 ## stSystemOperationsTest
 ```diff
 + ABAcalls0.json                                                  OK
@@ -3028,4 +3028,4 @@ OK: 133/133 Fail: 0/133 Skip: 0/133
 OK: 130/130 Fail: 0/130 Skip: 0/130
 
 ---TOTAL---
-OK: 2619/2730 Fail: 0/2730 Skip: 111/2730
+OK: 2620/2730 Fail: 0/2730 Skip: 110/2730

--- a/newBlockchainTests.md
+++ b/newBlockchainTests.md
@@ -814,7 +814,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + create2collisionSelfdestructedOOG.json                          OK
 + create2collisionSelfdestructedRevert.json                       OK
 + create2collisionStorage.json                                    OK
-  create2noCash.json                                              Skip
++ create2noCash.json                                              OK
 + returndatacopy_0_0_following_successful_create.json             OK
 + returndatacopy_afterFailing_create.json                         OK
 + returndatacopy_following_create.json                            OK
@@ -822,7 +822,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + returndatacopy_following_successful_create.json                 OK
 + returndatasize_following_successful_create.json                 OK
 ```
-OK: 41/44 Fail: 0/44 Skip: 3/44
+OK: 42/44 Fail: 0/44 Skip: 2/44
 ## stCreateTest
 ```diff
 + CREATE_AcreateB_BSuicide_BStore.json                            OK
@@ -3028,4 +3028,4 @@ OK: 133/133 Fail: 0/133 Skip: 0/133
 OK: 130/130 Fail: 0/130 Skip: 0/130
 
 ---TOTAL---
-OK: 2620/2730 Fail: 0/2730 Skip: 110/2730
+OK: 2621/2730 Fail: 0/2730 Skip: 109/2730

--- a/newGeneralStateTests.md
+++ b/newGeneralStateTests.md
@@ -411,7 +411,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + create2collisionSelfdestructedOOG.json                          OK
 + create2collisionSelfdestructedRevert.json                       OK
 + create2collisionStorage.json                                    OK
-  create2noCash.json                                              Skip
++ create2noCash.json                                              OK
 + returndatacopy_0_0_following_successful_create.json             OK
 + returndatacopy_afterFailing_create.json                         OK
 + returndatacopy_following_create.json                            OK
@@ -419,7 +419,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + returndatacopy_following_successful_create.json                 OK
 + returndatasize_following_successful_create.json                 OK
 ```
-OK: 41/44 Fail: 0/44 Skip: 3/44
+OK: 42/44 Fail: 0/44 Skip: 2/44
 ## stCreateTest
 ```diff
 + CREATE_AcreateB_BSuicide_BStore.json                            OK
@@ -2625,4 +2625,4 @@ OK: 133/133 Fail: 0/133 Skip: 0/133
 OK: 130/130 Fail: 0/130 Skip: 0/130
 
 ---TOTAL---
-OK: 2303/2411 Fail: 0/2411 Skip: 108/2411
+OK: 2304/2411 Fail: 0/2411 Skip: 107/2411

--- a/nimbus/db/state_db.nim
+++ b/nimbus/db/state_db.nim
@@ -7,7 +7,7 @@
 
 import
   strformat,
-  chronicles, eth/[common, rlp], eth/trie/[hexary, db],
+  chronicles, eth/[common, rlp], eth/trie/[hexary, db, trie_defs],
   ../constants, ../utils, storage_types
 
 logScope:
@@ -93,10 +93,9 @@ template getAccountTrie(db: AccountStateDB, account: Account): auto =
   # see nim-eth#9
   initSecureHexaryTrie(trieDB(db), account.storageRoot, false)
 
-# XXX: https://github.com/status-im/nimbus/issues/142#issuecomment-420583181
-proc setStorageRoot*(db: var AccountStateDB, address: EthAddress, storageRoot: Hash256) =
+proc clearStorage*(db: var AccountStateDB, address: EthAddress) =
   var account = db.getAccount(address)
-  account.storageRoot = storageRoot
+  account.storageRoot = emptyRlpHash
   db.setAccount(address, account)
 
 proc getStorageRoot*(db: AccountStateDB, address: EthAddress): Hash256 =

--- a/nimbus/errors.nim
+++ b/nimbus/errors.nim
@@ -23,8 +23,6 @@ type
 
   VMError* = object of EVMError
     ## Class of errors which can be raised during VM execution.
-    erasesReturnData*: bool
-    burnsGas*: bool
 
   OutOfGas* = object of VMError
     ## Error signaling that VM execution has run out of gas.
@@ -67,8 +65,3 @@ type
 
   StaticContextError* = object of VMError
     ## State changes not allowed in static call context
-
-proc makeVMError*: ref VMError =
-  new(result)
-  result.burnsGas = true
-  result.erasesReturnData = true

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -29,7 +29,6 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
     if balance < upfrontGasCost: break
 
     let recipient = tx.getRecipient()
-    let isCollision = vmState.readOnlyStateDb().hasCodeOrNonce(recipient)
 
     var c = setupComputation(vmState, tx, sender, recipient, fork)
     if c.isNil: # OOG in setupComputation
@@ -40,7 +39,6 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
       db.incNonce(sender)
       db.subBalance(sender, upfrontGasCost)
 
-    if tx.isContractCreation and isCollision: break
     execComputation(c)
     if not c.shouldBurnGas:
       gasUsed = c.refundGas(tx, sender)

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -35,7 +35,7 @@ template balance(addressDb: ReadOnlyStateDb, address: EthAddress): GasInt =
   addressDb.getBalance(address).truncate(int64)
 
 proc binarySearchGas(vmState: var BaseVMState, transaction: Transaction, sender: EthAddress, gasPrice: GasInt, tolerance = 1): GasInt =
-  proc dummyComputation(vmState: var BaseVMState, transaction: Transaction, sender: EthAddress): BaseComputation =
+  proc dummyComputation(vmState: var BaseVMState, transaction: Transaction, sender: EthAddress): Computation =
     let recipient = transaction.getRecipient()
     # Note that vmState may be altered
     setupComputation(
@@ -276,7 +276,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
       value: UInt256, data: seq[byte],
       sender, destination: EthAddress,
       gasLimit, gasPrice: GasInt,
-      contractCreation: bool): BaseComputation =
+      contractCreation: bool): Computation =
     let
       # Handle optional defaults.
       message = Message(
@@ -292,7 +292,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
         data: data,
         code: vmState.readOnlyStateDB.getCode(destination).toSeq
       )
-    result = newBaseComputation(vmState, message)
+    result = newComputation(vmState, message)
 
   rpcsrv.rpc("eth_call") do(call: EthCall, quantityTag: string) -> HexDataStr:
     ## Executes a new message call immediately without creating a transaction on the block chain.

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -272,7 +272,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
     # TODO: Relies on pending pool implementation
     discard
 
-  proc setupComputation(vmState: BaseVMState, blockNumber: BlockNumber,
+  proc setupComputation(vmState: BaseVMState,
       value: UInt256, data: seq[byte],
       sender, destination: EthAddress,
       gasLimit, gasPrice: GasInt,
@@ -292,7 +292,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
         data: data,
         code: vmState.readOnlyStateDB.getCode(destination).toSeq
       )
-    result = newBaseComputation(vmState, blockNumber, message)
+    result = newBaseComputation(vmState, message)
 
   rpcsrv.rpc("eth_call") do(call: EthCall, quantityTag: string) -> HexDataStr:
     ## Executes a new message call immediately without creating a transaction on the block chain.
@@ -325,7 +325,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
       destination = if call.to.isSome: call.to.get.toAddress else: ZERO_ADDRESS
       data = if call.data.isSome: nimcrypto.utils.fromHex(call.data.get.string) else: @[]
       value = if call.value.isSome: call.value.get else: 0.u256
-      comp = setupComputation(vmState, header.blockNumber, value, data, sender, destination, gasLimit, gasPrice, call.to.isNone)
+      comp = setupComputation(vmState, value, data, sender, destination, gasLimit, gasPrice, call.to.isNone)
 
     comp.execComputation
     result = ("0x" & nimcrypto.toHex(comp.output)).HexDataStr

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -283,8 +283,6 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
         kind: if contractCreation: evmcCreate else: evmcCall,
         depth: 0,
         gas: gasLimit,
-        gasPrice: gasPrice,
-        origin: sender,
         sender: sender,
         contractAddress: destination,
         codeAddress: CREATE_CONTRACT_ADDRESS,
@@ -292,6 +290,12 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
         data: data,
         code: vmState.readOnlyStateDB.getCode(destination).toSeq
       )
+
+    vmState.txContext(
+      origin = sender,
+      gasPrice = gasPrice
+      )
+
     result = newComputation(vmState, message)
 
   rpcsrv.rpc("eth_call") do(call: EthCall, quantityTag: string) -> HexDataStr:

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -222,10 +222,9 @@ proc registerAccountForDeletion*(c: Computation, beneficiary: EthAddress) =
 proc addLogEntry*(c: Computation, log: Log) {.inline.} =
   c.logEntries.add(log)
 
-iterator accountsForDeletion*(c: Computation): EthAddress =
+proc getSuicides*(c: Computation): HashSet[EthAddress] =
   if c.isSuccess:
-    for address in c.suicides:
-      yield address
+    result = c.suicides
 
 proc getGasRefund*(c: Computation): GasInt =
   if c.isSuccess:
@@ -242,6 +241,10 @@ proc getGasRemaining*(c: Computation): GasInt =
     result = 0
   else:
     result = c.gasMeter.gasRemaining
+
+proc refundSelfDestruct*(c: Computation) =
+  let cost = gasFees[c.fork][RefundSelfDestruct]
+  c.gasMeter.refundGas(cost * c.suicides.len)
 
 proc collectTouchedAccounts*(c: Computation) =
   ## Collect all of the accounts that *may* need to be deleted based on EIP161:

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -50,26 +50,15 @@ template isError*(c: Computation): bool =
 func shouldBurnGas*(c: Computation): bool =
   c.isError and c.error.burnsGas
 
-func shouldEraseReturnData*(c: Computation): bool =
-  c.isError and c.error.erasesReturnData
-
 func bytesToHex(x: openarray[byte]): string {.inline.} =
   ## TODO: use seq[byte] for raw data and delete this proc
   foldl(x, a & b.int.toHex(2).toLowerAscii, "0x")
 
 func output*(c: Computation): seq[byte] =
-  if c.shouldEraseReturnData:
-    @[]
-  else:
-    c.rawOutput
+  c.rawOutput
 
 func `output=`*(c: Computation, value: openarray[byte]) =
   c.rawOutput = @value
-
-proc outputHex*(c: Computation): string =
-  if c.shouldEraseReturnData:
-    return "0x"
-  c.rawOutput.bytesToHex
 
 proc isSuicided*(c: Computation, address: EthAddress): bool =
   result = address in c.suicides

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -144,11 +144,6 @@ proc postExecuteVM(c: Computation, opCode: static[Op]) {.gcsafe.} =
 proc executeOpcodes*(c: Computation) {.gcsafe.}
 
 proc applyMessage*(c: Computation, opCode: static[Op]) =
-  if c.msg.depth > MaxCallDepth:
-    c.setError(&"Stack depth limit reached depth={c.msg.depth}")
-    c.nextProc()
-    return
-
   c.snapshot()
   defer:
     c.dispose()

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -39,7 +39,7 @@ proc newComputation*(vmState: BaseVMState, message: Message, forkOverride=none(F
 
 proc isOriginComputation*(c: Computation): bool =
   # Is this computation the computation initiated by a transaction
-  c.msg.isOrigin
+  c.msg.sender == c.vmState.txOrigin
 
 template isSuccess*(c: Computation): bool =
   c.error.isNil

--- a/nimbus/vm/computation.nim
+++ b/nimbus/vm/computation.nim
@@ -17,7 +17,7 @@ import
 logScope:
   topics = "vm computation"
 
-proc newComputation*(vmState: BaseVMState, message: Message, forkOverride=none(Fork)): Computation =
+proc newComputation*(vmState: BaseVMState, message: Message): Computation =
   new result
   result.vmState = vmState
   result.msg = message
@@ -27,15 +27,15 @@ proc newComputation*(vmState: BaseVMState, message: Message, forkOverride=none(F
   result.touchedAccounts = initHashSet[EthAddress]()
   result.suicides = initHashSet[EthAddress]()
   result.code = newCodeStream(message.code)
-  result.fork =
-    if forkOverride.isSome:
-      forkOverride.get
-    else:
-      vmState.blockNumber.toFork
-  result.gasCosts = result.fork.forkToSchedule
   # a dummy/terminus continuation proc
   result.nextProc = proc() =
     discard
+
+template gasCosts*(c: Computation): untyped =
+  c.vmState.gasCosts
+
+template fork*(c: Computation): untyped =
+  c.vmState.fork
 
 proc isOriginComputation*(c: Computation): bool =
   # Is this computation the computation initiated by a transaction

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -22,7 +22,7 @@ logScope:
 
 template push(x: typed) {.dirty.} =
   ## Push an expression on the computation stack
-  computation.stack.push x
+  c.stack.push x
 
 # ##################################
 # 0s: Stop and Arithmetic Operations
@@ -94,8 +94,8 @@ op mulmod, inline = true, lhs, rhs, modulus:
 
 op exp, inline = true, base, exponent:
   ## 0x0A, Exponentiation
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[Exp].d_handler(exponent),
+  c.gasMeter.consumeGas(
+    c.gasCosts[Exp].d_handler(exponent),
     reason="EXP: exponent bytes"
     )
   push:
@@ -196,18 +196,18 @@ op sha3, inline = true, startPos, length:
   if pos < 0 or len < 0 or pos > 2147483648:
     raise newException(OutOfBoundsRead, "Out of bounds memory access")
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[Op.Sha3].m_handler(computation.memory.len, pos, len),
+  c.gasMeter.consumeGas(
+    c.gasCosts[Op.Sha3].m_handler(c.memory.len, pos, len),
     reason="SHA3: word gas cost"
     )
 
-  computation.memory.extend(pos, len)
-  let endRange = min(pos + len, computation.memory.len) - 1
-  if endRange == -1 or pos >= computation.memory.len:
+  c.memory.extend(pos, len)
+  let endRange = min(pos + len, c.memory.len) - 1
+  if endRange == -1 or pos >= c.memory.len:
     push(EMPTY_SHA3)
   else:
     push:
-      keccak256.digest computation.memory.bytes.toOpenArray(pos, endRange)
+      keccak256.digest c.memory.bytes.toOpenArray(pos, endRange)
 
 # ##########################################
 # 30s: Environmental Information
@@ -231,45 +231,45 @@ proc writePaddedResult(mem: var Memory,
 
 op address, inline = true:
   ## 0x30, Get address of currently executing account.
-  push: computation.msg.contractAddress
+  push: c.msg.contractAddress
 
 op balance, inline = true:
   ## 0x31, Get balance of the given account.
-  let address = computation.stack.popAddress()
-  push: computation.vmState.readOnlyStateDB.getBalance(address)
+  let address = c.stack.popAddress()
+  push: c.vmState.readOnlyStateDB.getBalance(address)
 
 op origin, inline = true:
   ## 0x32, Get execution origination address.
-  push: computation.msg.origin
+  push: c.msg.origin
 
 op caller, inline = true:
   ## 0x33, Get caller address.
-  push: computation.msg.sender
+  push: c.msg.sender
 
 op callValue, inline = true:
   ## 0x34, Get deposited value by the instruction/transaction
   ##       responsible for this execution
-  push: computation.msg.value
+  push: c.msg.value
 
 op callDataLoad, inline = false, startPos:
   ## 0x35, Get input data of current environment
   let start = startPos.cleanMemRef
-  if start >= computation.msg.data.len:
+  if start >= c.msg.data.len:
     push: 0
     return
 
   # If the data does not take 32 bytes, pad with zeros
-  let endRange = min(computation.msg.data.len - 1, start + 31)
+  let endRange = min(c.msg.data.len - 1, start + 31)
   let presentBytes = endRange - start
   # We rely on value being initialized with 0 by default
   var value: array[32, byte]
-  value[0 .. presentBytes] = computation.msg.data.toOpenArray(start, endRange)
+  value[0 .. presentBytes] = c.msg.data.toOpenArray(start, endRange)
 
   push: value
 
 op callDataSize, inline = true:
   ## 0x36, Get size of input data in current environment.
-  push: computation.msg.data.len.u256
+  push: c.msg.data.len.u256
 
 op callDataCopy, inline = false, memStartPos, copyStartPos, size:
   ## 0x37, Copy input data in current environment to memory.
@@ -277,15 +277,15 @@ op callDataCopy, inline = false, memStartPos, copyStartPos, size:
 
   let (memPos, copyPos, len) = (memStartPos.cleanMemRef, copyStartPos.cleanMemRef, size.cleanMemRef)
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[CallDataCopy].m_handler(computation.memory.len, memPos, len),
+  c.gasMeter.consumeGas(
+    c.gasCosts[CallDataCopy].m_handler(c.memory.len, memPos, len),
     reason="CallDataCopy fee")
 
-  computation.memory.writePaddedResult(computation.msg.data, memPos, copyPos, len)
+  c.memory.writePaddedResult(c.msg.data, memPos, copyPos, len)
 
 op codeSize, inline = true:
   ## 0x38, Get size of code running in current environment.
-  push: computation.code.len
+  push: c.code.len
 
 op codeCopy, inline = false, memStartPos, copyStartPos, size:
   ## 0x39, Copy code running in current environment to memory.
@@ -293,196 +293,196 @@ op codeCopy, inline = false, memStartPos, copyStartPos, size:
 
   let (memPos, copyPos, len) = (memStartPos.cleanMemRef, copyStartPos.cleanMemRef, size.cleanMemRef)
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[CodeCopy].m_handler(computation.memory.len, memPos, len),
+  c.gasMeter.consumeGas(
+    c.gasCosts[CodeCopy].m_handler(c.memory.len, memPos, len),
     reason="CodeCopy fee")
 
-  computation.memory.writePaddedResult(computation.code.bytes, memPos, copyPos, len)
+  c.memory.writePaddedResult(c.code.bytes, memPos, copyPos, len)
 
 op gasprice, inline = true:
   ## 0x3A, Get price of gas in current environment.
-  push: computation.msg.gasPrice
+  push: c.msg.gasPrice
 
 op extCodeSize, inline = true:
   ## 0x3b, Get size of an account's code
-  let account = computation.stack.popAddress()
-  let codeSize = computation.vmState.readOnlyStateDB.getCode(account).len
+  let account = c.stack.popAddress()
+  let codeSize = c.vmState.readOnlyStateDB.getCode(account).len
   push uint(codeSize)
 
 op extCodeCopy, inline = true:
   ## 0x3c, Copy an account's code to memory.
-  let account = computation.stack.popAddress()
-  let (memStartPos, codeStartPos, size) = computation.stack.popInt(3)
+  let account = c.stack.popAddress()
+  let (memStartPos, codeStartPos, size) = c.stack.popInt(3)
   let (memPos, codePos, len) = (memStartPos.cleanMemRef, codeStartPos.cleanMemRef, size.cleanMemRef)
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[ExtCodeCopy].m_handler(computation.memory.len, memPos, len),
+  c.gasMeter.consumeGas(
+    c.gasCosts[ExtCodeCopy].m_handler(c.memory.len, memPos, len),
     reason="ExtCodeCopy fee")
 
-  let codeBytes = computation.vmState.readOnlyStateDB.getCode(account)
-  computation.memory.writePaddedResult(codeBytes.toOpenArray, memPos, codePos, len)
+  let codeBytes = c.vmState.readOnlyStateDB.getCode(account)
+  c.memory.writePaddedResult(codeBytes.toOpenArray, memPos, codePos, len)
 
 op returnDataSize, inline = true:
   ## 0x3d, Get size of output data from the previous call from the current environment.
-  push: computation.returnData.len
+  push: c.returnData.len
 
 op returnDataCopy, inline = false,  memStartPos, copyStartPos, size:
   ## 0x3e, Copy output data from the previous call to memory.
   let (memPos, copyPos, len) = (memStartPos.cleanMemRef, copyStartPos.cleanMemRef, size.cleanMemRef)
-  let gasCost = computation.gasCosts[ReturnDataCopy].m_handler(computation.memory.len, memPos, len)
-  computation.gasMeter.consumeGas(
+  let gasCost = c.gasCosts[ReturnDataCopy].m_handler(c.memory.len, memPos, len)
+  c.gasMeter.consumeGas(
     gasCost,
     reason="returnDataCopy fee")
 
-  if copyPos + len > computation.returnData.len:
+  if copyPos + len > c.returnData.len:
     # TODO Geth additionally checks copyPos + len < 64
     #      Parity uses a saturating addition
     #      Yellow paper mentions  μs[1] + i are not subject to the 2^256 modulo.
     raise newException(OutOfBoundsRead,
       "Return data length is not sufficient to satisfy request.  Asked \n" &
-      &"for data from index {copyStartPos} to {copyStartPos + size}. Return data is {computation.returnData.len} in \n" &
+      &"for data from index {copyStartPos} to {copyStartPos + size}. Return data is {c.returnData.len} in \n" &
       "length")
 
-  computation.memory.writePaddedResult(computation.returnData, memPos, copyPos, len)
+  c.memory.writePaddedResult(c.returnData, memPos, copyPos, len)
 
 # ##########################################
 # 40s: Block Information
 
 op blockhash, inline = true, blockNumber:
   ## 0x40, Get the hash of one of the 256 most recent complete blocks.
-  push: computation.vmState.getAncestorHash(blockNumber.vmWordToBlockNumber)
+  push: c.vmState.getAncestorHash(blockNumber.vmWordToBlockNumber)
 
 op coinbase, inline = true:
   ## 0x41, Get the block's beneficiary address.
-  push: computation.vmState.coinbase
+  push: c.vmState.coinbase
 
 op timestamp, inline = true:
   ## 0x42, Get the block's timestamp.
-  push: computation.vmState.timestamp.toUnix
+  push: c.vmState.timestamp.toUnix
 
 op blocknumber, inline = true:
   ## 0x43, Get the block's number.
-  push: computation.vmState.blockNumber.blockNumberToVmWord
+  push: c.vmState.blockNumber.blockNumberToVmWord
 
 op difficulty, inline = true:
   ## 0x44, Get the block's difficulty
-  push: computation.vmState.difficulty
+  push: c.vmState.difficulty
 
 op gasLimit, inline = true:
   ## 0x45, Get the block's gas limit
-  push: computation.vmState.gasLimit
+  push: c.vmState.gasLimit
 
 op chainId, inline = true:
   ## 0x46, Get current chain’s EIP-155 unique identifier.
   # TODO: this is a stub
-  push: computation.vmState.chaindb.config.chainId
+  push: c.vmState.chaindb.config.chainId
 
 op selfBalance, inline = true:
   ## 0x47, Get current contract's balance.
-  let stateDb = computation.vmState.readOnlyStateDb
-  push: stateDb.getBalance(computation.msg.contractAddress)
+  let stateDb = c.vmState.readOnlyStateDb
+  push: stateDb.getBalance(c.msg.contractAddress)
 
 # ##########################################
 # 50s: Stack, Memory, Storage and Flow Operations
 
 op pop, inline = true:
   ## 0x50, Remove item from stack.
-  discard computation.stack.popInt()
+  discard c.stack.popInt()
 
 op mload, inline = true, memStartPos:
   ## 0x51, Load word from memory
   let memPos = memStartPos.cleanMemRef
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[MLoad].m_handler(computation.memory.len, memPos, 32),
+  c.gasMeter.consumeGas(
+    c.gasCosts[MLoad].m_handler(c.memory.len, memPos, 32),
     reason="MLOAD: GasVeryLow + memory expansion"
     )
-  computation.memory.extend(memPos, 32)
+  c.memory.extend(memPos, 32)
 
-  push: computation.memory.read(memPos, 32) # TODO, should we convert to native endianness?
+  push: c.memory.read(memPos, 32) # TODO, should we convert to native endianness?
 
 op mstore, inline = true, memStartPos, value:
   ## 0x52, Save word to memory
   let memPos = memStartPos.cleanMemRef
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[MStore].m_handler(computation.memory.len, memPos, 32),
+  c.gasMeter.consumeGas(
+    c.gasCosts[MStore].m_handler(c.memory.len, memPos, 32),
     reason="MSTORE: GasVeryLow + memory expansion"
     )
 
-  computation.memory.extend(memPos, 32)
-  computation.memory.write(memPos, value.toByteArrayBE) # is big-endian correct? Parity/Geth do convert
+  c.memory.extend(memPos, 32)
+  c.memory.write(memPos, value.toByteArrayBE) # is big-endian correct? Parity/Geth do convert
 
 op mstore8, inline = true, memStartPos, value:
   ## 0x53, Save byte to memory
   let memPos = memStartPos.cleanMemRef
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[MStore].m_handler(computation.memory.len, memPos, 1),
+  c.gasMeter.consumeGas(
+    c.gasCosts[MStore].m_handler(c.memory.len, memPos, 1),
     reason="MSTORE8: GasVeryLow + memory expansion"
     )
 
-  computation.memory.extend(memPos, 1)
-  computation.memory.write(memPos, [value.toByteArrayBE[31]])
+  c.memory.extend(memPos, 1)
+  c.memory.write(memPos, [value.toByteArrayBE[31]])
 
 op sload, inline = true, slot:
   ## 0x54, Load word from storage.
 
-  let (value, _) = computation.vmState.readOnlyStateDB.getStorage(computation.msg.contractAddress, slot)
+  let (value, _) = c.vmState.readOnlyStateDB.getStorage(c.msg.contractAddress, slot)
   push(value)
 
 op sstore, inline = false, slot, value:
   ## 0x55, Save word to storage.
-  checkInStaticContext(computation)
+  checkInStaticContext(c)
 
-  let (currentValue, existing) = computation.vmState.readOnlyStateDB.getStorage(computation.msg.contractAddress, slot)
+  let (currentValue, existing) = c.vmState.readOnlyStateDB.getStorage(c.msg.contractAddress, slot)
 
   let
     gasParam = GasParams(kind: Op.Sstore, s_isStorageEmpty: currentValue.isZero)
-    (gasCost, gasRefund) = computation.gasCosts[Sstore].c_handler(value, gasParam)
+    (gasCost, gasRefund) = c.gasCosts[Sstore].c_handler(value, gasParam)
 
-  computation.gasMeter.consumeGas(gasCost, &"SSTORE: {computation.msg.contractAddress}[{slot}] -> {value} ({currentValue})")
+  c.gasMeter.consumeGas(gasCost, &"SSTORE: {c.msg.contractAddress}[{slot}] -> {value} ({currentValue})")
 
   if gasRefund > 0:
-    computation.gasMeter.refundGas(gasRefund)
+    c.gasMeter.refundGas(gasRefund)
 
-  computation.vmState.mutateStateDB:
-    db.setStorage(computation.msg.contractAddress, slot, value)
+  c.vmState.mutateStateDB:
+    db.setStorage(c.msg.contractAddress, slot, value)
 
-proc jumpImpl(computation: BaseComputation, jumpTarget: UInt256) =
-  if jumpTarget >= computation.code.len.u256:
+proc jumpImpl(c: Computation, jumpTarget: UInt256) =
+  if jumpTarget >= c.code.len.u256:
     raise newException(InvalidJumpDestination, "Invalid Jump Destination")
 
   let jt = jumpTarget.truncate(int)
-  computation.code.pc = jt
+  c.code.pc = jt
 
-  let nextOpcode = computation.code.peek
+  let nextOpcode = c.code.peek
   if nextOpcode != JUMPDEST:
     raise newException(InvalidJumpDestination, "Invalid Jump Destination")
   # TODO: next check seems redundant
-  if not computation.code.isValidOpcode(jt):
+  if not c.code.isValidOpcode(jt):
     raise newException(InvalidInstruction, "Jump resulted in invalid instruction")
 
 op jump, inline = true, jumpTarget:
   ## 0x56, Alter the program counter
-  jumpImpl(computation, jumpTarget)
+  jumpImpl(c, jumpTarget)
 
 op jumpI, inline = true, jumpTarget, testedValue:
   ## 0x57, Conditionally alter the program counter.
   if testedValue != 0:
-    jumpImpl(computation, jumpTarget)
+    jumpImpl(c, jumpTarget)
 
 op pc, inline = true:
   ## 0x58, Get the value of the program counter prior to the increment corresponding to this instruction.
-  push: max(computation.code.pc - 1, 0)
+  push: max(c.code.pc - 1, 0)
 
 op msize, inline = true:
   ## 0x59, Get the size of active memory in bytes.
-  push: computation.memory.len
+  push: c.memory.len
 
 op gas, inline = true:
   ## 0x5a, Get the amount of available gas, including the corresponding reduction for the cost of this instruction.
-  push: computation.gasMeter.gasRemaining
+  push: c.gasMeter.gasRemaining
 
 op jumpDest, inline = true:
   ## 0x5b, Mark a valid destination for jumps. This operation has no effect on machine state during execution.
@@ -502,53 +502,53 @@ genLog()
 # ##########################################
 # f0s: System operations.
 
-proc canTransfer(computation: BaseComputation, memPos, memLen: int, value: Uint256, opCode: static[Op]): bool =
+proc canTransfer(c: Computation, memPos, memLen: int, value: Uint256, opCode: static[Op]): bool =
   let gasParams = GasParams(kind: Create,
-    cr_currentMemSize: computation.memory.len,
+    cr_currentMemSize: c.memory.len,
     cr_memOffset: memPos,
     cr_memLength: memLen
     )
-  var gasCost = computation.gasCosts[Create].c_handler(1.u256, gasParams).gasCost
+  var gasCost = c.gasCosts[Create].c_handler(1.u256, gasParams).gasCost
   let reason = &"CREATE: GasCreate + {memLen} * memory expansion"
 
   when opCode == Create2:
-    gasCost = gasCost + computation.gasCosts[Create2].m_handler(0, 0, memLen)
+    gasCost = gasCost + c.gasCosts[Create2].m_handler(0, 0, memLen)
 
-  computation.gasMeter.consumeGas(gasCost, reason = reason)
-  computation.memory.extend(memPos, memLen)
+  c.gasMeter.consumeGas(gasCost, reason = reason)
+  c.memory.extend(memPos, memLen)
 
   # the sender is childmsg sender, not parent msg sender
   # perhaps we need to move this code somewhere else
   # to avoid confusion
   let senderBalance =
-    computation.vmState.readOnlyStateDb().
-      getBalance(computation.msg.contractAddress)
+    c.vmState.readOnlyStateDb().
+      getBalance(c.msg.contractAddress)
 
   if senderBalance < value:
-    debug "Computation Failure", reason = "Insufficient funds available to transfer", required = computation.msg.value, balance = senderBalance
+    debug "Computation Failure", reason = "Insufficient funds available to transfer", required = c.msg.value, balance = senderBalance
     return false
 
   # unlike the other MaxCallDepth comparison,
   # this one has not been entered child computation
   # thats why it has `+ 1`
-  if computation.msg.depth + 1 > MaxCallDepth:
-    debug "Computation Failure", reason = "Stack too deep", maximumDepth = MaxCallDepth, depth = computation.msg.depth
+  if c.msg.depth + 1 > MaxCallDepth:
+    debug "Computation Failure", reason = "Stack too deep", maximumDepth = MaxCallDepth, depth = c.msg.depth
     return false
 
   result = true
 
-proc setupCreate(computation: BaseComputation, memPos, len: int, value: Uint256, opCode: static[Op]): BaseComputation =
+proc setupCreate(c: Computation, memPos, len: int, value: Uint256, opCode: static[Op]): Computation =
   let
-    callData = computation.memory.read(memPos, len)
+    callData = c.memory.read(memPos, len)
 
   var
-    createMsgGas = computation.getGasRemaining()
+    createMsgGas = c.getGasRemaining()
 
-  if computation.fork >= FkTangerine:
+  if c.fork >= FkTangerine:
     createMsgGas -= createMsgGas div 64
 
   # Consume gas here that will be passed to child
-  computation.gasMeter.consumeGas(createMsgGas, reason="CREATE")
+  c.gasMeter.consumeGas(createMsgGas, reason="CREATE")
 
   # Generate new address and check for collisions
   var
@@ -557,20 +557,20 @@ proc setupCreate(computation: BaseComputation, memPos, len: int, value: Uint256,
 
   when opCode == Create:
     const callKind = evmcCreate
-    computation.vmState.mutateStateDB:
+    c.vmState.mutateStateDB:
       # Regarding collisions, see: https://github.com/status-im/nimbus/issues/133
       # See: https://github.com/ethereum/EIPs/issues/684
-      let creationNonce = db.getNonce(computation.msg.contractAddress)
-      db.setNonce(computation.msg.contractAddress, creationNonce + 1)
+      let creationNonce = db.getNonce(c.msg.contractAddress)
+      db.setNonce(c.msg.contractAddress, creationNonce + 1)
 
-      contractAddress = generateAddress(computation.msg.contractAddress, creationNonce)
+      contractAddress = generateAddress(c.msg.contractAddress, creationNonce)
       isCollision = db.hasCodeOrNonce(contractAddress)
   else:
     const callKind = evmcCreate2
-    computation.vmState.mutateStateDB:
-      db.incNonce(computation.msg.contractAddress)
-      let salt = computation.stack.popInt()
-      contractAddress = generateSafeAddress(computation.msg.contractAddress, salt, callData)
+    c.vmState.mutateStateDB:
+      db.incNonce(c.msg.contractAddress)
+      let salt = c.stack.popInt()
+      contractAddress = generateSafeAddress(c.msg.contractAddress, salt, callData)
       isCollision = db.hasCodeOrNonce(contractAddress)
 
   if isCollision:
@@ -580,11 +580,11 @@ proc setupCreate(computation: BaseComputation, memPos, len: int, value: Uint256,
 
   let childMsg = Message(
     kind: callKind,
-    depth: computation.msg.depth + 1,
+    depth: c.msg.depth + 1,
     gas: createMsgGas,
-    gasPrice: computation.msg.gasPrice,
-    origin: computation.msg.origin,
-    sender: computation.msg.contractAddress,
+    gasPrice: c.msg.gasPrice,
+    origin: c.msg.origin,
+    sender: c.msg.contractAddress,
     contractAddress: contractAddress,
     codeAddress: CREATE_CONTRACT_ADDRESS,
     value: value,
@@ -592,106 +592,103 @@ proc setupCreate(computation: BaseComputation, memPos, len: int, value: Uint256,
     code: callData
     )
 
-  result = newBaseComputation(
-    computation.vmState,
-    childMsg,
-    some(computation.fork))
+  result = newComputation(c.vmState, childMsg, some(c.fork))
 
 template genCreate(callName: untyped, opCode: Op): untyped =
   op callName, inline = false, val, startPosition, size:
     ## 0xf0, Create a new account with associated code.
     let (memPos, len) = (startPosition.safeInt, size.safeInt)
-    if not computation.canTransfer(memPos, len, val, opCode):
+    if not c.canTransfer(memPos, len, val, opCode):
       push: 0
       return
 
-    var childComp = setupCreate(computation, memPos, len, val, opCode)
-    if childComp.isNil: return
+    var child = setupCreate(c, memPos, len, val, opCode)
+    if child.isNil: return
 
-    continuation(childComp):
-      addChildComputation(computation, childComp)
+    continuation(child):
+      addChildComputation(c, child)
 
-      if childComp.isError:
+      if child.isError:
         push: 0
       else:
-        push: childComp.msg.contractAddress
+        push: child.msg.contractAddress
 
-    checkInStaticContext(computation)
-    childComp.applyMessage(Create)
+    checkInStaticContext(c)
+    child.applyMessage(Create)
 
 genCreate(create, Create)
 genCreate(create2, Create2)
 
-proc callParams(computation: BaseComputation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
-  let gas = computation.stack.popInt()
-  let codeAddress = computation.stack.popAddress()
+proc callParams(c: Computation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
+  let gas = c.stack.popInt()
+  let codeAddress = c.stack.popAddress()
 
   let (value,
        memoryInputStartPosition, memoryInputSize,
-       memoryOutputStartPosition, memoryOutputSize) = computation.stack.popInt(5)
+       memoryOutputStartPosition, memoryOutputSize) = c.stack.popInt(5)
 
   result = (gas,
     value,
     codeAddress, # contractAddress
-    computation.msg.contractAddress, # sender
+    c.msg.contractAddress, # sender
     codeAddress,
     evmcCall,
     memoryInputStartPosition,
     memoryInputSize,
     memoryOutputStartPosition,
     memoryOutputSize,
-    computation.msg.flags)
+    c.msg.flags)
 
-proc callCodeParams(computation: BaseComputation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
-  let gas = computation.stack.popInt()
-  let codeAddress = computation.stack.popAddress()
+proc callCodeParams(c: Computation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
+  let gas = c.stack.popInt()
+  let codeAddress = c.stack.popAddress()
 
   let (value,
        memoryInputStartPosition, memoryInputSize,
-       memoryOutputStartPosition, memoryOutputSize) = computation.stack.popInt(5)
+       memoryOutputStartPosition, memoryOutputSize) = c.stack.popInt(5)
 
   result = (gas,
     value,
-    computation.msg.contractAddress, # contractAddress
-    computation.msg.contractAddress, # sender
+    c.msg.contractAddress, # contractAddress
+    c.msg.contractAddress, # sender
     codeAddress,
     evmcCallCode,
     memoryInputStartPosition,
     memoryInputSize,
     memoryOutputStartPosition,
     memoryOutputSize,
-    computation.msg.flags)
+    c.msg.flags)
 
-proc delegateCallParams(computation: BaseComputation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
-  let gas = computation.stack.popInt()
-  let codeAddress = computation.stack.popAddress()
+proc delegateCallParams(c: Computation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
+  let gas = c.stack.popInt()
+  let codeAddress = c.stack.popAddress()
 
   let (memoryInputStartPosition, memoryInputSize,
-       memoryOutputStartPosition, memoryOutputSize) = computation.stack.popInt(4)
+       memoryOutputStartPosition, memoryOutputSize) = c.stack.popInt(4)
 
   result = (gas,
-    computation.msg.value, # value
-    computation.msg.contractAddress, # contractAddress
-    computation.msg.sender, # sender
+    c.msg.value, # value
+    c.msg.contractAddress, # contractAddress
+    c.msg.sender, # sender
     codeAddress,
     evmcDelegateCall,
     memoryInputStartPosition,
     memoryInputSize,
     memoryOutputStartPosition,
     memoryOutputSize,
-    computation.msg.flags)
+    c.msg.flags)
 
-proc staticCallParams(computation: BaseComputation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
-  let gas = computation.stack.popInt()
-  let codeAddress = computation.stack.popAddress()
+proc staticCallParams(c: Computation): (UInt256, UInt256, EthAddress, EthAddress, EthAddress, CallKind, UInt256, UInt256, UInt256, UInt256, MsgFlags) =
+  let gas = c.stack.popInt()
+  let codeAddress = c.stack.popAddress()
 
   let (memoryInputStartPosition, memoryInputSize,
-       memoryOutputStartPosition, memoryOutputSize) = computation.stack.popInt(4)
+       memoryOutputStartPosition, memoryOutputSize) = c.stack.popInt(4)
 
   result = (gas,
     0.u256, # value
     codeAddress, # contractAddress
-    computation.msg.contractAddress, # sender
+    c.msg.contractAddress, # sender
     codeAddress,
     evmcCall,
     memoryInputStartPosition,
@@ -701,55 +698,55 @@ proc staticCallParams(computation: BaseComputation): (UInt256, UInt256, EthAddre
     emvcStatic) # is_static
 
 template genCall(callName: untyped, opCode: Op): untyped =
-  proc `callName Setup`(computation: BaseComputation, callNameStr: string): BaseComputation =
+  proc `callName Setup`(c: Computation, callNameStr: string): Computation =
     let (gas, value, contractAddress, sender,
           codeAddress, callKind,
           memoryInputStartPosition, memoryInputSize,
           memoryOutputStartPosition, memoryOutputSize,
-          flags) = `callName Params`(computation)
+          flags) = `callName Params`(c)
 
     let (memInPos, memInLen, memOutPos, memOutLen) = (memoryInputStartPosition.cleanMemRef, memoryInputSize.cleanMemRef, memoryOutputStartPosition.cleanMemRef, memoryOutputSize.cleanMemRef)
 
-    let isNewAccount = if computation.fork >= FkSpurious:
-                         computation.vmState.readOnlyStateDb.isDeadAccount(contractAddress)
+    let isNewAccount = if c.fork >= FkSpurious:
+                         c.vmState.readOnlyStateDb.isDeadAccount(contractAddress)
                        else:
-                         not computation.vmState.readOnlyStateDb.accountExists(contractAddress)
+                         not c.vmState.readOnlyStateDb.accountExists(contractAddress)
 
     let (memOffset, memLength) = if calcMemSize(memInPos, memInLen) > calcMemSize(memOutPos, memOutLen):
                                     (memInPos, memInLen)
                                  else:
                                     (memOutPos, memOutLen)
 
-    let (childGasFee, childGasLimit) = computation.gasCosts[opCode].c_handler(
+    let (childGasFee, childGasLimit) = c.gasCosts[opCode].c_handler(
       value,
       GasParams(kind: opCode,
                 c_isNewAccount: isNewAccount,
-                c_gasBalance: computation.gasMeter.gasRemaining,
+                c_gasBalance: c.gasMeter.gasRemaining,
                 c_contractGas: gas,
-                c_currentMemSize: computation.memory.len,
+                c_currentMemSize: c.memory.len,
                 c_memOffset: memOffset,
                 c_memLength: memLength
       ))
 
     if childGasFee >= 0:
-      computation.gasMeter.consumeGas(childGasFee, reason = $opCode)
+      c.gasMeter.consumeGas(childGasFee, reason = $opCode)
 
     if childGasFee < 0 and childGasLimit <= 0:
       raise newException(OutOfGas, "Gas not enough to perform calculation (" & callNameStr & ")")
 
-    computation.memory.extend(memInPos, memInLen)
-    computation.memory.extend(memOutPos, memOutLen)
+    c.memory.extend(memInPos, memInLen)
+    c.memory.extend(memOutPos, memOutLen)
 
     let
-      callData = computation.memory.read(memInPos, memInLen)
-      code = computation.vmState.readOnlyStateDb.getCode(codeAddress)
+      callData = c.memory.read(memInPos, memInLen)
+      code = c.vmState.readOnlyStateDb.getCode(codeAddress)
 
     var childMsg = Message(
       kind: callKind,
-      depth: computation.msg.depth + 1,
+      depth: c.msg.depth + 1,
       gas: childGasLimit,
-      gasPrice: computation.msg.gasPrice,
-      origin: computation.msg.origin,
+      gasPrice: c.msg.gasPrice,
+      origin: c.msg.origin,
       sender: sender,
       contractAddress: contractAddress,
       codeAddress: codeAddress,
@@ -758,41 +755,38 @@ template genCall(callName: untyped, opCode: Op): untyped =
       code: code.toSeq,
       flags: flags)
 
-    var childComp = newBaseComputation(
-      computation.vmState,
-      childMsg,
-      some(computation.fork))
+    var child = newComputation(c.vmState, childMsg, some(c.fork))
 
-    computation.memOutPos = memOutPos
-    computation.memOutLen = memOutLen
-    result = childComp
+    c.memOutPos = memOutPos
+    c.memOutLen = memOutLen
+    result = child
 
   op callName, inline = false:
     ## CALL, 0xf1, Message-Call into an account
     ## CALLCODE, 0xf2, Message-call into this account with an alternative account's code.
     ## DELEGATECALL, 0xf4, Message-call into this account with an alternative account's code, but persisting the current values for sender and value.
     ## STATICCALL, 0xfa, Static message-call into an account.
-    var childComp = `callName Setup`(computation, callName.astToStr)
+    var child = `callName Setup`(c, callName.astToStr)
 
-    continuation(childComp):
-      addChildComputation(computation, childComp)
+    continuation(child):
+      addChildComputation(c, child)
 
-      if childComp.isError:
+      if child.isError:
         push: 0
       else:
         push: 1
 
-      if not childComp.shouldEraseReturnData:
-        let actualOutputSize = min(computation.memOutLen, childComp.output.len)
-        computation.memory.write(
-          computation.memOutPos,
-          childComp.output.toOpenArray(0, actualOutputSize - 1))
+      if not child.shouldEraseReturnData:
+        let actualOutputSize = min(c.memOutLen, child.output.len)
+        c.memory.write(
+          c.memOutPos,
+          child.output.toOpenArray(0, actualOutputSize - 1))
 
     when opCode == Call:
-      if emvcStatic == computation.msg.flags and childComp.msg.value > 0.u256:
+      if emvcStatic == c.msg.flags and child.msg.value > 0.u256:
         raise newException(StaticContextError, "Cannot modify state while inside of a STATICCALL context")
 
-    childComp.applyMessage(opCode)
+    child.applyMessage(opCode)
 
 genCall(call, Call)
 genCall(callCode, CallCode)
@@ -803,35 +797,35 @@ op returnOp, inline = false, startPos, size:
   ## 0xf3, Halt execution returning output data.
   let (pos, len) = (startPos.cleanMemRef, size.cleanMemRef)
 
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[Return].m_handler(computation.memory.len, pos, len),
+  c.gasMeter.consumeGas(
+    c.gasCosts[Return].m_handler(c.memory.len, pos, len),
     reason = "RETURN"
     )
 
-  computation.memory.extend(pos, len)
-  computation.output = computation.memory.read(pos, len)
+  c.memory.extend(pos, len)
+  c.output = c.memory.read(pos, len)
 
 op revert, inline = false, startPos, size:
   ## 0xfd, Halt execution reverting state changes but returning data and remaining gas.
   let (pos, len) = (startPos.cleanMemRef, size.cleanMemRef)
-  computation.gasMeter.consumeGas(
-    computation.gasCosts[Revert].m_handler(computation.memory.len, pos, len),
+  c.gasMeter.consumeGas(
+    c.gasCosts[Revert].m_handler(c.memory.len, pos, len),
     reason = "REVERT"
     )
 
-  computation.memory.extend(pos, len)
-  computation.output = computation.memory.read(pos, len)
+  c.memory.extend(pos, len)
+  c.output = c.memory.read(pos, len)
   # setError(msg, false) will signal cheap revert
-  computation.setError("REVERT opcode executed", false)
+  c.setError("REVERT opcode executed", false)
 
-proc selfDestructImpl(computation: BaseComputation, beneficiary: EthAddress) =
+proc selfDestructImpl(c: Computation, beneficiary: EthAddress) =
   ## 0xff Halt execution and register account for later deletion.
   # TODO: This is the basic implementation of the self destruct op,
   # Other forks have some extra functionality around this call.
   # In particular, EIP150 and EIP161 have extra requirements.
-  computation.vmState.mutateStateDB:
+  c.vmState.mutateStateDB:
     let
-      localBalance = db.getBalance(computation.msg.contractAddress)
+      localBalance = db.getBalance(c.msg.contractAddress)
       beneficiaryBalance = db.getBalance(beneficiary)
 
     # Transfer to beneficiary
@@ -840,47 +834,47 @@ proc selfDestructImpl(computation: BaseComputation, beneficiary: EthAddress) =
     # Zero the balance of the address being deleted.
     # This must come after sending to beneficiary in case the
     # contract named itself as the beneficiary.
-    db.setBalance(computation.msg.contractAddress, 0.u256)
+    db.setBalance(c.msg.contractAddress, 0.u256)
 
     # Register the account to be deleted
-    computation.registerAccountForDeletion(beneficiary)
+    c.registerAccountForDeletion(beneficiary)
 
     trace "SELFDESTRUCT",
-      contractAddress = computation.msg.contractAddress.toHex,
+      contractAddress = c.msg.contractAddress.toHex,
       localBalance = localBalance.toString,
       beneficiary = beneficiary.toHex
 
 op selfDestruct, inline = false:
-  let beneficiary = computation.stack.popAddress()
-  selfDestructImpl(computation, beneficiary)
+  let beneficiary = c.stack.popAddress()
+  selfDestructImpl(c, beneficiary)
 
 op selfDestructEip150, inline = false:
-  let beneficiary = computation.stack.popAddress()
+  let beneficiary = c.stack.popAddress()
 
   let gasParams = GasParams(kind: SelfDestruct,
-    sd_condition: not computation.vmState.readOnlyStateDb.accountExists(beneficiary)
+    sd_condition: not c.vmState.readOnlyStateDb.accountExists(beneficiary)
     )
 
-  let gasCost = computation.gasCosts[SelfDestruct].c_handler(0.u256, gasParams).gasCost
-  computation.gasMeter.consumeGas(gasCost, reason = "SELFDESTRUCT EIP150")
-  selfDestructImpl(computation, beneficiary)
+  let gasCost = c.gasCosts[SelfDestruct].c_handler(0.u256, gasParams).gasCost
+  c.gasMeter.consumeGas(gasCost, reason = "SELFDESTRUCT EIP150")
+  selfDestructImpl(c, beneficiary)
 
 op selfDestructEip161, inline = false:
-  checkInStaticContext(computation)
+  checkInStaticContext(c)
 
   let
-    beneficiary = computation.stack.popAddress()
-    stateDb     = computation.vmState.readOnlyStateDb
+    beneficiary = c.stack.popAddress()
+    stateDb     = c.vmState.readOnlyStateDb
     isDead      = stateDb.isDeadAccount(beneficiary)
-    balance     = stateDb.getBalance(computation.msg.contractAddress)
+    balance     = stateDb.getBalance(c.msg.contractAddress)
 
   let gasParams = GasParams(kind: SelfDestruct,
     sd_condition: isDead and not balance.isZero
     )
 
-  let gasCost = computation.gasCosts[SelfDestruct].c_handler(0.u256, gasParams).gasCost
-  computation.gasMeter.consumeGas(gasCost, reason = "SELFDESTRUCT EIP161")
-  selfDestructImpl(computation, beneficiary)
+  let gasCost = c.gasCosts[SelfDestruct].c_handler(0.u256, gasParams).gasCost
+  c.gasMeter.consumeGas(gasCost, reason = "SELFDESTRUCT EIP161")
+  selfDestructImpl(c, beneficiary)
 
 # Constantinople's new opcodes
 op shlOp, inline = true, shift, num:
@@ -899,8 +893,8 @@ op shrOp, inline = true, shift, num:
     push: num shr shiftLen
 
 op sarOp, inline = true:
-  let shiftLen = computation.stack.popInt().safeInt
-  let num = cast[Int256](computation.stack.popInt())
+  let shiftLen = c.stack.popInt().safeInt
+  let num = cast[Int256](c.stack.popInt())
   if shiftLen >= 256:
     if num.isNegative:
       push: cast[Uint256]((-1).i256)
@@ -912,41 +906,41 @@ op sarOp, inline = true:
     push: cast[Uint256](num shr shiftLen)
 
 op extCodeHash, inline = true:
-  let address = computation.stack.popAddress()
+  let address = c.stack.popAddress()
   # this is very inefficient, it calls underlying
   # database too much, we can reduce it by implementing accounts
   # cache
-  if not computation.vmState.readOnlyStateDB.accountExists(address):
+  if not c.vmState.readOnlyStateDB.accountExists(address):
     push: 0
     return
 
-  if computation.vmState.readOnlyStateDB.isEmptyAccount(address):
+  if c.vmState.readOnlyStateDB.isEmptyAccount(address):
     push: 0
   else:
-    push: computation.vmState.readOnlyStateDB.getCodeHash(address)
+    push: c.vmState.readOnlyStateDB.getCodeHash(address)
 
 op sstoreEIP2200, inline = false, slot, value:
-  checkInStaticContext(computation)
+  checkInStaticContext(c)
   const SentryGasEIP2200   = 2300  # Minimum gas required to be present for an SSTORE call, not consumed
 
-  if computation.gasMeter.gasRemaining <= SentryGasEIP2200:
+  if c.gasMeter.gasRemaining <= SentryGasEIP2200:
     raise newException(OutOfGas, "Gas not enough to perform EIP2200 SSTORE")
 
-  let stateDB = computation.vmState.readOnlyStateDB
-  let (currentValue, existing) = stateDB.getStorage(computation.msg.contractAddress, slot)
+  let stateDB = c.vmState.readOnlyStateDB
+  let (currentValue, existing) = stateDB.getStorage(c.msg.contractAddress, slot)
 
   let
     gasParam = GasParams(kind: Op.Sstore,
       s_isStorageEmpty: currentValue.isZero,
       s_currentValue: currentValue,
-      s_originalValue: stateDB.getCommittedStorage(computation.msg.contractAddress, slot)
+      s_originalValue: stateDB.getCommittedStorage(c.msg.contractAddress, slot)
     )
-    (gasCost, gasRefund) = computation.gasCosts[Sstore].c_handler(value, gasParam)
+    (gasCost, gasRefund) = c.gasCosts[Sstore].c_handler(value, gasParam)
 
-  computation.gasMeter.consumeGas(gasCost, &"SSTORE EIP2200: {computation.msg.contractAddress}[{slot}] -> {value} ({currentValue})")
+  c.gasMeter.consumeGas(gasCost, &"SSTORE EIP2200: {c.msg.contractAddress}[{slot}] -> {value} ({currentValue})")
 
   if gasRefund != 0:
-    computation.gasMeter.refundGas(gasRefund)
+    c.gasMeter.refundGas(gasRefund)
 
-  computation.vmState.mutateStateDB:
-    db.setStorage(computation.msg.contractAddress, slot, value)
+  c.vmState.mutateStateDB:
+    db.setStorage(c.msg.contractAddress, slot, value)

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -597,6 +597,8 @@ proc setupCreate(c: Computation, memPos, len: int, value: Uint256, opCode: stati
 template genCreate(callName: untyped, opCode: Op): untyped =
   op callName, inline = false, val, startPosition, size:
     ## 0xf0, Create a new account with associated code.
+    checkInStaticContext(c)
+    
     let (memPos, len) = (startPosition.safeInt, size.safeInt)
     if not c.canTransfer(memPos, len, val, opCode):
       push: 0
@@ -612,8 +614,7 @@ template genCreate(callName: untyped, opCode: Op): untyped =
         push: 0
       else:
         push: child.msg.contractAddress
-
-    checkInStaticContext(c)
+    
     child.applyMessage(Create)
 
 genCreate(create, Create)

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -598,7 +598,7 @@ template genCreate(callName: untyped, opCode: Op): untyped =
   op callName, inline = false, val, startPosition, size:
     ## 0xf0, Create a new account with associated code.
     checkInStaticContext(c)
-    
+
     let (memPos, len) = (startPosition.safeInt, size.safeInt)
     if not c.canTransfer(memPos, len, val, opCode):
       push: 0
@@ -614,7 +614,7 @@ template genCreate(callName: untyped, opCode: Op): untyped =
         push: 0
       else:
         push: child.msg.contractAddress
-    
+
     child.applyMessage(Create)
 
 genCreate(create, Create)
@@ -777,8 +777,8 @@ template genCall(callName: untyped, opCode: Op): untyped =
       else:
         push: 1
 
-      if not child.shouldEraseReturnData:
-        let actualOutputSize = min(c.memOutLen, child.output.len)
+      let actualOutputSize = min(c.memOutLen, child.output.len)
+      if actualOutputSize > 0:
         c.memory.write(
           c.memOutPos,
           child.output.toOpenArray(0, actualOutputSize - 1))

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -544,7 +544,7 @@ proc setupCreate(computation: BaseComputation, memPos, len: int, value: Uint256,
   var
     createMsgGas = computation.getGasRemaining()
 
-  if getFork(computation) >= FkTangerine:
+  if computation.fork >= FkTangerine:
     createMsgGas -= createMsgGas div 64
 
   # Consume gas here that will be passed to child
@@ -594,9 +594,8 @@ proc setupCreate(computation: BaseComputation, memPos, len: int, value: Uint256,
 
   result = newBaseComputation(
     computation.vmState,
-    computation.vmState.blockNumber,
     childMsg,
-    some(computation.getFork))
+    some(computation.fork))
 
 template genCreate(callName: untyped, opCode: Op): untyped =
   op callName, inline = false, val, startPosition, size:
@@ -711,7 +710,7 @@ template genCall(callName: untyped, opCode: Op): untyped =
 
     let (memInPos, memInLen, memOutPos, memOutLen) = (memoryInputStartPosition.cleanMemRef, memoryInputSize.cleanMemRef, memoryOutputStartPosition.cleanMemRef, memoryOutputSize.cleanMemRef)
 
-    let isNewAccount = if getFork(computation) >= FkSpurious:
+    let isNewAccount = if computation.fork >= FkSpurious:
                          computation.vmState.readOnlyStateDb.isDeadAccount(contractAddress)
                        else:
                          not computation.vmState.readOnlyStateDb.accountExists(contractAddress)
@@ -761,9 +760,8 @@ template genCall(callName: untyped, opCode: Op): untyped =
 
     var childComp = newBaseComputation(
       computation.vmState,
-      computation.vmState.blockNumber,
       childMsg,
-      some(computation.getFork))
+      some(computation.fork))
 
     computation.memOutPos = memOutPos
     computation.memOutLen = memOutLen

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -577,7 +577,7 @@ proc setupCreate(c: Computation, memPos, len: int, value: Uint256, opCode: stati
     code: callData
     )
 
-  result = newComputation(c.vmState, childMsg, some(c.fork))
+  result = newComputation(c.vmState, childMsg)
 
 template genCreate(callName: untyped, opCode: Op): untyped =
   op callName, inline = false, val, startPosition, size:
@@ -755,7 +755,7 @@ template genCall(callName: untyped, opCode: Op): untyped =
       code: code.toSeq,
       flags: flags)
 
-    var child = newComputation(c.vmState, childMsg, some(c.fork))
+    var child = newComputation(c.vmState, childMsg)
 
     c.memOutPos = memOutPos
     c.memOutLen = memOutLen

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -240,7 +240,7 @@ op balance, inline = true:
 
 op origin, inline = true:
   ## 0x32, Get execution origination address.
-  push: c.msg.origin
+  push: c.vmState.txOrigin
 
 op caller, inline = true:
   ## 0x33, Get caller address.
@@ -301,7 +301,7 @@ op codeCopy, inline = false, memStartPos, copyStartPos, size:
 
 op gasprice, inline = true:
   ## 0x3A, Get price of gas in current environment.
-  push: c.msg.gasPrice
+  push: c.vmState.txGasPrice
 
 op extCodeSize, inline = true:
   ## 0x3b, Get size of an account's code
@@ -569,8 +569,6 @@ proc setupCreate(c: Computation, memPos, len: int, value: Uint256, opCode: stati
     kind: callKind,
     depth: c.msg.depth + 1,
     gas: createMsgGas,
-    gasPrice: c.msg.gasPrice,
-    origin: c.msg.origin,
     sender: c.msg.contractAddress,
     contractAddress: contractAddress,
     codeAddress: CREATE_CONTRACT_ADDRESS,
@@ -749,8 +747,6 @@ template genCall(callName: untyped, opCode: Op): untyped =
       kind: callKind,
       depth: c.msg.depth + 1,
       gas: childGasLimit,
-      gasPrice: c.msg.gasPrice,
-      origin: c.msg.origin,
       sender: sender,
       contractAddress: contractAddress,
       codeAddress: codeAddress,

--- a/nimbus/vm/interpreter_dispatch.nim
+++ b/nimbus/vm/interpreter_dispatch.nim
@@ -339,7 +339,7 @@ proc selectVM(computation: BaseComputation, fork: Fork) {.gcsafe.} =
     computation.istanbulVM()
 
 proc executeOpcodes(computation: BaseComputation) =
-  let fork = computation.getFork
+  let fork = computation.fork
 
   block:
     if computation.execPrecompiles(fork):

--- a/nimbus/vm/message.nim
+++ b/nimbus/vm/message.nim
@@ -9,8 +9,5 @@ import
   eth/common,
   ../constants, ../validation, ../vm_types, chronicles
 
-proc isOrigin*(message: Message): bool =
-  message.sender == message.origin
-
 proc isCreate*(message: Message): bool =
   message.kind in {evmcCreate, evmcCreate2}

--- a/nimbus/vm/transaction_tracer.nim
+++ b/nimbus/vm/transaction_tracer.nim
@@ -44,7 +44,7 @@ iterator storage(tracer: TransactionTracer, compDepth: int): Uint256 =
   for key in tracer.storageKeys[compDepth]:
     yield key
 
-proc traceOpCodeStarted*(tracer: var TransactionTracer, c: BaseComputation, op: Op): int =
+proc traceOpCodeStarted*(tracer: var TransactionTracer, c: Computation, op: Op): int =
   if unlikely tracer.trace.isNil:
     tracer.initTracer()
 
@@ -90,7 +90,7 @@ proc traceOpCodeStarted*(tracer: var TransactionTracer, c: BaseComputation, op: 
 
   result = tracer.trace["structLogs"].len - 1
 
-proc traceOpCodeEnded*(tracer: var TransactionTracer, c: BaseComputation, op: Op, lastIndex: int) =
+proc traceOpCodeEnded*(tracer: var TransactionTracer, c: Computation, op: Op, lastIndex: int) =
   let j = tracer.trace["structLogs"].elems[lastIndex]
 
   # TODO: figure out how to get storage
@@ -114,7 +114,7 @@ proc traceOpCodeEnded*(tracer: var TransactionTracer, c: BaseComputation, op: Op
 
   trace "Op", json = j.pretty()
 
-proc traceError*(tracer: var TransactionTracer, c: BaseComputation) =
+proc traceError*(tracer: var TransactionTracer, c: Computation) =
   if tracer.trace["structLogs"].elems.len > 0:
     let j = tracer.trace["structLogs"].elems[^1]
     j["error"] = %(c.error.info)

--- a/nimbus/vm_state.nim
+++ b/nimbus/vm_state.nim
@@ -35,12 +35,18 @@ proc init*(self: BaseVMState, prevStateRoot: Hash256, header: BlockHeader,
   self.tracingEnabled = TracerFlags.EnableTracing in tracerFlags
   self.logEntries = @[]
   self.accountDb = newAccountStateDB(chainDB.db, prevStateRoot, chainDB.pruneTrie)
-  self.touchedAccounts = initHashSet[EthAddress]()  
+  self.touchedAccounts = initHashSet[EthAddress]()
 
 proc newBaseVMState*(prevStateRoot: Hash256, header: BlockHeader,
                      chainDB: BaseChainDB, tracerFlags: set[TracerFlags] = {}): BaseVMState =
   new result
   result.init(prevStateRoot, header, chainDB, tracerFlags)
+
+proc txContext*(vmState: BaseVMState, origin: EthAddress, gasPrice: GasInt) =
+  ## this proc will be called each time a new transaction
+  ## is going to be executed
+  vmState.txOrigin = origin
+  vmState.txGasPrice = gasPrice
 
 method blockhash*(vmState: BaseVMState): Hash256 {.base, gcsafe.} =
   vmState.blockHeader.hash

--- a/nimbus/vm_state_transactions.nim
+++ b/nimbus/vm_state_transactions.nim
@@ -70,9 +70,10 @@ proc execComputation*(c: Computation) =
   if c.fork >= FkSpurious:
     c.collectTouchedAccounts()
 
-  c.refundSelfDestruct()
+  if c.isSuccess:
+    c.refundSelfDestruct()
   c.vmState.suicides = c.getSuicides()
-  
+
   c.vmstate.status = c.isSuccess
   if c.isSuccess:
     c.vmState.addLogs(c.logEntries)

--- a/nimbus/vm_state_transactions.nim
+++ b/nimbus/vm_state_transactions.nim
@@ -67,19 +67,12 @@ proc execComputation*(c: Computation) =
   else:
     c.applyMessage(Call)
 
-  c.vmState.mutateStateDB:
-    var suicidedCount = 0
-    for deletedAccount in c.accountsForDeletion:
-      db.deleteAccount deletedAccount
-      inc suicidedCount
-
-    # FIXME: hook this into actual RefundSelfDestruct
-    const RefundSelfDestruct = 24_000
-    c.gasMeter.refundGas(RefundSelfDestruct * suicidedCount)
-
   if c.fork >= FkSpurious:
     c.collectTouchedAccounts()
 
+  c.refundSelfDestruct()
+  c.vmState.suicides = c.getSuicides()
+  
   c.vmstate.status = c.isSuccess
   if c.isSuccess:
     c.vmState.addLogs(c.logEntries)

--- a/nimbus/vm_state_transactions.nim
+++ b/nimbus/vm_state_transactions.nim
@@ -58,7 +58,7 @@ proc setupComputation*(vmState: BaseVMState, tx: Transaction, sender, recipient:
     code: code
     )
 
-  result = newBaseComputation(vmState, vmState.blockNumber, msg, some(fork))
+  result = newBaseComputation(vmState, msg, some(fork))
   doAssert result.isOriginComputation
 
 proc execComputation*(computation: var BaseComputation) =
@@ -77,7 +77,7 @@ proc execComputation*(computation: var BaseComputation) =
     const RefundSelfDestruct = 24_000
     computation.gasMeter.refundGas(RefundSelfDestruct * suicidedCount)
 
-  if computation.getFork >= FkSpurious:
+  if computation.fork >= FkSpurious:
     computation.collectTouchedAccounts()
 
   computation.vmstate.status = computation.isSuccess

--- a/nimbus/vm_state_transactions.nim
+++ b/nimbus/vm_state_transactions.nim
@@ -46,7 +46,8 @@ proc setupComputation*(vmState: BaseVMState, tx: Transaction, sender, recipient:
 
   vmState.txContext(
     origin = sender,
-    gasPrice = tx.gasPrice
+    gasPrice = tx.gasPrice,
+    forkOverride = some(fork)
   )
 
   let msg = Message(
@@ -61,7 +62,7 @@ proc setupComputation*(vmState: BaseVMState, tx: Transaction, sender, recipient:
     code: code
     )
 
-  result = newComputation(vmState, msg, some(fork))
+  result = newComputation(vmState, msg)
   doAssert result.isOriginComputation
 
 proc execComputation*(c: Computation) =

--- a/nimbus/vm_state_transactions.nim
+++ b/nimbus/vm_state_transactions.nim
@@ -44,12 +44,15 @@ proc setupComputation*(vmState: BaseVMState, tx: Transaction, sender, recipient:
     debug "not enough gas to perform calculation", gas=gas
     return
 
+  vmState.txContext(
+    origin = sender,
+    gasPrice = tx.gasPrice
+  )
+
   let msg = Message(
     kind: if tx.isContractCreation: evmcCreate else: evmcCall,
     depth: 0,
     gas: gas,
-    gasPrice: tx.gasPrice,
-    origin: sender,
     sender: sender,
     contractAddress: recipient,
     codeAddress: tx.to,

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -26,6 +26,7 @@ type
     accountDb*     : AccountStateDB
     cumulativeGasUsed*: GasInt
     touchedAccounts*: HashSet[EthAddress]
+    suicides*      : HashSet[EthAddress]
     status*        : bool
 
   AccessLogs* = ref object

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -51,7 +51,7 @@ type
     transaction*: DbTransaction
     intermediateRoot*: Hash256
 
-  BaseComputation* = ref object of RootObj
+  Computation* = ref object
     # The execution computation
     vmState*:               BaseVMState
     msg*:                   Message

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -62,10 +62,10 @@ type
     rawOutput*:             seq[byte]
     returnData*:            seq[byte]
     error*:                 Error
-    touchedAccounts*:       HashSet[EthAddress]    
+    touchedAccounts*:       HashSet[EthAddress]
     suicides*:              HashSet[EthAddress]
     gasCosts*:              GasCosts # TODO - will be hidden at a lower layer
-    forkOverride*:          Option[Fork]
+    fork*:                  Fork
     logEntries*:            seq[Log]
     dbsnapshot*:            Snapshot
     instr*:                 Op

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -28,6 +28,8 @@ type
     touchedAccounts*: HashSet[EthAddress]
     suicides*      : HashSet[EthAddress]
     status*        : bool
+    txOrigin*      : EthAddress
+    txGasPrice*    : GasInt
 
   AccessLogs* = ref object
     reads*: Table[string, string]
@@ -100,8 +102,6 @@ type
     kind*:             CallKind
     depth*:            int
     gas*:              GasInt
-    gasPrice*:         GasInt
-    origin*:           EthAddress
     sender*:           EthAddress
     contractAddress*:  EthAddress
     codeAddress*:      EthAddress

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -79,7 +79,6 @@ type
   Error* = ref object
     info*:                  string
     burnsGas*:              bool
-    erasesReturnData*:      bool
 
   GasMeter* = object
     gasRefunded*: GasInt

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -30,6 +30,8 @@ type
     status*        : bool
     txOrigin*      : EthAddress
     txGasPrice*    : GasInt
+    gasCosts*      : GasCosts
+    fork*          : Fork
 
   AccessLogs* = ref object
     reads*: Table[string, string]
@@ -67,8 +69,6 @@ type
     error*:                 Error
     touchedAccounts*:       HashSet[EthAddress]
     suicides*:              HashSet[EthAddress]
-    gasCosts*:              GasCosts # TODO - will be hidden at a lower layer
-    fork*:                  Fork
     logEntries*:            seq[Log]
     dbsnapshot*:            Snapshot
     instr*:                 Op

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -194,7 +194,7 @@ proc generateVMProxy(boa: Assembler): NimNode =
 const
   blockFile = "tests" / "fixtures" / "PersistBlockTests" / "block47205.json"
 
-proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, data: seq[byte], forkOverride=none(Fork)) : BaseComputation =
+proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, data: seq[byte], forkOverride=none(Fork)) : Computation =
   doAssert tx.isContractCreation
 
   let fork =
@@ -220,7 +220,7 @@ proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, 
       code: tx.payload
       )
 
-  newBaseComputation(vmState, msg, some(fork))
+  newComputation(vmState, msg, some(fork))
 
 proc initDatabase*(): (Uint256, BaseChainDB) =
   let
@@ -236,7 +236,7 @@ proc initDatabase*(): (Uint256, BaseChainDB) =
 
   result = (blockNumber, newBaseChainDB(memoryDB, false))
 
-proc initComputation(blockNumber: Uint256, chainDB: BaseChainDB, payload, data: seq[byte], fork: Fork): BaseComputation =
+proc initComputation(blockNumber: Uint256, chainDB: BaseChainDB, payload, data: seq[byte], fork: Fork): Computation =
   let
     parentNumber = blockNumber - 1
     parent = chainDB.getBlockHeader(parentNumber)

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -220,7 +220,7 @@ proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, 
       code: tx.payload
       )
 
-  newBaseComputation(vmState, vmState.blockNumber, msg, some(fork))
+  newBaseComputation(vmState, msg, some(fork))
 
 proc initDatabase*(): (Uint256, BaseChainDB) =
   let

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -205,13 +205,16 @@ proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, 
 
   let gasUsed = 0 #tx.payload.intrinsicGas.GasInt + gasFees[fork][GasTXCreate]
 
+  vmState.txContext(
+    origin = sender,
+    gasPrice = tx.gasPrice
+  )
+
   let contractAddress = generateAddress(sender, tx.accountNonce)
   let msg = Message(
       kind: evmcCall,
       depth: 0,
       gas: tx.gasLimit - gasUsed,
-      gasPrice: tx.gasPrice,
-      origin: sender,
       sender: sender,
       contractAddress: contractAddress,
       codeAddress: tx.to,

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -207,7 +207,8 @@ proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, 
 
   vmState.txContext(
     origin = sender,
-    gasPrice = tx.gasPrice
+    gasPrice = tx.gasPrice,
+    forkOverride = some(fork)
   )
 
   let contractAddress = generateAddress(sender, tx.accountNonce)
@@ -223,7 +224,7 @@ proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, 
       code: tx.payload
       )
 
-  newComputation(vmState, msg, some(fork))
+  newComputation(vmState, msg)
 
 proc initDatabase*(): (Uint256, BaseChainDB) =
   let

--- a/tests/test_allowed_to_fail.nim
+++ b/tests/test_allowed_to_fail.nim
@@ -155,12 +155,7 @@ func skipBCTests*(folder: string, name: string): bool =
     "randomStatetest94.json", # pre istanbul
 
     # BC huge memory consumption
-    "DelegateCallSpam.json",
-
-    # pre istanbul failing
-    "SuicidesMixingCoinbase.json",
-    "suicideCoinbase.json",
-    "suicideCoinbaseState.json"
+    "DelegateCallSpam.json"
   ]
 
   result =  name in allowedFailingBCTests

--- a/tests/test_allowed_to_fail.nim
+++ b/tests/test_allowed_to_fail.nim
@@ -89,18 +89,6 @@ func slowGSTTests(folder: string, name: string): bool =
               "CALLBlake2f_MaxRounds.json",
               ]
 
-func failIn32Bits(folder, name: string): bool =
-  return name in @[
-    # crash with OOM
-    "static_Return50000_2.json",
-    "randomStatetest185.json",
-    "randomStatetest159.json",
-    "randomStatetest48.json",
-
-    # OOM in AppVeyor, not on my machine
-    "randomStatetest36.json"
-  ]
-
 func allowedFailingGeneralStateTest(folder, name: string): bool =
   let allowedFailingGeneralStateTests = @[
     # conflicts between native int and big int.
@@ -111,24 +99,14 @@ func allowedFailingGeneralStateTest(folder, name: string): bool =
     # a conflict between balance checker and
     # static call context checker
     "create2noCash.json",
-
-    # Failure once spotted on Travis CI Linux AMD64:
-    # "out of memorysubtest no: 7 failed"
-    # "randomStatetest159.json",
   ]
   result = name in allowedFailingGeneralStateTests
-
-func allowedFailInCurrentBuild(folder, name: string): bool =
-  when sizeof(int) == 4:
-    if failIn32Bits(folder, name):
-      return true
-  return allowedFailingGeneralStateTest(folder, name)
 
 func skipGSTTests*(folder: string, name: string): bool =
   # we skip tests that are slow or expected to fail for now
   if slowGSTTests(folder, name):
     return true
-  result = allowedFailInCurrentBuild(folder, name)
+  result = allowedFailingGeneralStateTest(folder, name)
 
 func skipNewGSTTests*(folder: string, name: string): bool =
   # share the same slow and failing tests
@@ -151,10 +129,8 @@ func skipBCTests*(folder: string, name: string): bool =
     # BlockChain slow tests
     "SuicideIssue.json",
 
-    # BC OOM tests in CI
-    "randomStatetest94.json", # pre istanbul
-
     # BC huge memory consumption
+    "randomStatetest94.json",
     "DelegateCallSpam.json"
   ]
 
@@ -174,15 +150,12 @@ func skipNewBCTests*(folder: string, name: string): bool =
     "RevertInCreateInInitCreate2.json",
     "InitCollision.json",
 
-    # BC OOM tests in CI
-    "randomStatetest94.json",
-    "static_Return50000_2.json", # istanbul
-
     # see allowedFailingGeneralStateTest
     "modexp.json",
     "create2noCash.json",
 
     # BC huge memory consumption
+    "randomStatetest94.json",
     "DelegateCallSpam.json"
   ]
 

--- a/tests/test_allowed_to_fail.nim
+++ b/tests/test_allowed_to_fail.nim
@@ -94,11 +94,7 @@ func allowedFailingGeneralStateTest(folder, name: string): bool =
     # conflicts between native int and big int.
     # gasFee calculation in modexp precompiled
     # contracts
-    "modexp.json",
-    # perhaps a design flaw with create/create2 opcode.
-    # a conflict between balance checker and
-    # static call context checker
-    "create2noCash.json",
+    "modexp.json"
   ]
   result = name in allowedFailingGeneralStateTests
 
@@ -152,7 +148,6 @@ func skipNewBCTests*(folder: string, name: string): bool =
 
     # see allowedFailingGeneralStateTest
     "modexp.json",
-    "create2noCash.json",
 
     # BC huge memory consumption
     "randomStatetest94.json",

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -41,7 +41,7 @@ template doTest(fixture: JsonNode, address: byte, action: untyped): untyped =
         data: data,
         code: @[]
         )
-      computation = newBaseComputation(vmState, message)
+      computation = newComputation(vmState, message)
     echo "Running ", action.astToStr, " - ", test["name"]
     `action`(computation)
     let c = computation.rawOutput == expected

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -41,7 +41,7 @@ template doTest(fixture: JsonNode, address: byte, action: untyped): untyped =
         data: data,
         code: @[]
         )
-      computation = newBaseComputation(vmState, header.blockNumber, message)
+      computation = newBaseComputation(vmState, message)
     echo "Running ", action.astToStr, " - ", test["name"]
     `action`(computation)
     let c = computation.rawOutput == expected

--- a/tests/test_precompiles.nim
+++ b/tests/test_precompiles.nim
@@ -29,11 +29,16 @@ template doTest(fixture: JsonNode, address: byte, action: untyped): untyped =
       gasPrice = 1.GasInt
       sender: EthAddress
       toAddress = initAddress(address)
+
+    vmState.txContext(
+      origin = sender,
+      gasPrice = gasPrice
+    )
+
+    var
       message = Message(
         kind: evmcCall,
         gas: gas,
-        gasPrice: gasPrice,
-        origin: sender,
         sender: sender,
         contractAddress: toAddress,
         codeAddress: toAddress,

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -59,7 +59,7 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     code: code
     )
 
-  var computation = newBaseComputation(vmState, header.blockNumber, message)
+  var computation = newBaseComputation(vmState, message)
   computation.executeOpcodes()
 
   if not fixture{"post"}.isNil:

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -6,11 +6,15 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  unittest2, strformat, strutils, tables, json, os, times,
+  unittest2, strformat, strutils, tables, json, os, times, sequtils,
   stew/byteutils, stew/ranges/typedranges, eth/[rlp, common], eth/trie/db,
   ./test_helpers, ./test_allowed_to_fail, ../nimbus/vm/interpreter,
   ../nimbus/[constants, vm_state, vm_types, utils],
   ../nimbus/db/[db_chain, state_db]
+
+func bytesToHex(x: openarray[byte]): string {.inline.} =
+  ## TODO: use seq[byte] for raw data and delete this proc
+  foldl(x, a & b.int.toHex(2).toLowerAscii, "0x")
 
 proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus)
 
@@ -78,7 +82,7 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
       fail()
 
     let expectedOutput = fixture{"out"}.getStr
-    check(computation.outputHex == expectedOutput)
+    check(computation.output.bytesToHex == expectedOutput)
     let gasMeter = computation.gasMeter
 
     let expectedGasRemaining = fixture{"gas"}.getHexadecimalInt

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -59,7 +59,7 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     code: code
     )
 
-  var computation = newBaseComputation(vmState, message)
+  var computation = newComputation(vmState, message)
   computation.executeOpcodes()
 
   if not fixture{"post"}.isNil:

--- a/tests/test_vm_json.nim
+++ b/tests/test_vm_json.nim
@@ -47,14 +47,17 @@ proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus) =
     let address = fexec{"address"}.getStr.parseAddress
     code = db.getCode(address).toSeq
 
+  vmState.txContext(
+    origin = fexec{"origin"}.getStr.parseAddress,
+    gasPrice = fexec{"gasPrice"}.getHexadecimalInt
+  )
+
   code = fexec{"code"}.getStr.hexToSeqByte
   let toAddress = fexec{"address"}.getStr.parseAddress
   let message = Message(
     kind: if toAddress == ZERO_ADDRESS: evmcCreate else: evmcCall, # assume ZERO_ADDRESS is a contract creation
     depth: 0,
     gas: fexec{"gas"}.getHexadecimalInt,
-    gasPrice: fexec{"gasPrice"}.getHexadecimalInt,
-    origin: fexec{"origin"}.getStr.parseAddress,
     sender: fexec{"caller"}.getStr.parseAddress,
     contractAddress: toAddress,
     codeAddress: toAddress,


### PR DESCRIPTION
summary of this PR:
* because we already departed from python-evm style, there is no point to keep 'BaseComputation' name, simplified to 'Computation'.
* removes more redundant codes from `Computation`.
* `origin`, `gasPrice`, `fork`, and `gasCosts` not replicated anymore each time we spawn new `Computation`. especially `gasCost` is a 4KB fat table.
* fixes long standing bug `create2nocash` along with 3 other bugs related to coinbase suicide.

note: EVMC integration already taken place in 'simplify_computation' branch.