### PR TITLE
implement aleth/geth/parity compatibility mode -- 100% pass test

### DIFF
--- a/newBlockChainTests.md
+++ b/newBlockChainTests.md
@@ -796,7 +796,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + CreateMessageRevertedOOGInInit.json                             OK
 + RevertDepthCreate2OOG.json                                      OK
 + RevertDepthCreateAddressCollision.json                          OK
-  RevertInCreateInInitCreate2.json                                Skip
++ RevertInCreateInInitCreate2.json                                OK
 + RevertOpcodeCreate.json                                         OK
 + RevertOpcodeInCreateReturnsCreate2.json                         OK
 + call_outsize_then_create2_successful_then_returndatasize.json   OK
@@ -822,7 +822,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + returndatacopy_following_successful_create.json                 OK
 + returndatasize_following_successful_create.json                 OK
 ```
-OK: 42/44 Fail: 0/44 Skip: 2/44
+OK: 43/44 Fail: 0/44 Skip: 1/44
 ## stCreateTest
 ```diff
 + CREATE_AcreateB_BSuicide_BStore.json                            OK
@@ -2074,7 +2074,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 + RevertDepthCreateAddressCollision.json                          OK
 + RevertDepthCreateOOG.json                                       OK
 + RevertInCallCode.json                                           OK
-  RevertInCreateInInit.json                                       Skip
++ RevertInCreateInInit.json                                       OK
 + RevertInDelegateCall.json                                       OK
 + RevertInStaticCall.json                                         OK
 + RevertOnEmptyStack.json                                         OK
@@ -2109,7 +2109,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 + TouchToEmptyAccountRevert2.json                                 OK
 + TouchToEmptyAccountRevert3.json                                 OK
 ```
-OK: 39/45 Fail: 0/45 Skip: 6/45
+OK: 40/45 Fail: 0/45 Skip: 5/45
 ## stSLoadTest
 ```diff
 + sloadGasCost.json                                               OK
@@ -2117,7 +2117,7 @@ OK: 39/45 Fail: 0/45 Skip: 6/45
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## stSStoreTest
 ```diff
-  InitCollision.json                                              Skip
++ InitCollision.json                                              OK
 + InitCollisionNonZeroNonce.json                                  OK
 + SstoreCallToSelfSubRefundBelowZero.json                         OK
 + sstore_0to0.json                                                OK
@@ -2145,7 +2145,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + sstore_changeFromExternalCallInInitCode.json                    OK
 + sstore_gasLeft.json                                             OK
 ```
-OK: 26/27 Fail: 0/27 Skip: 1/27
+OK: 27/27 Fail: 0/27 Skip: 0/27
 ## stSelfBalance
 ```diff
 + selfBalance.json                                                OK
@@ -3028,4 +3028,4 @@ OK: 133/133 Fail: 0/133 Skip: 0/133
 OK: 130/130 Fail: 0/130 Skip: 0/130
 
 ---TOTAL---
-OK: 2622/2730 Fail: 0/2730 Skip: 108/2730
+OK: 2625/2730 Fail: 0/2730 Skip: 105/2730

--- a/newGeneralStateTests.md
+++ b/newGeneralStateTests.md
@@ -393,7 +393,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + CreateMessageRevertedOOGInInit.json                             OK
 + RevertDepthCreate2OOG.json                                      OK
 + RevertDepthCreateAddressCollision.json                          OK
-  RevertInCreateInInitCreate2.json                                Skip
++ RevertInCreateInInitCreate2.json                                OK
 + RevertOpcodeCreate.json                                         OK
 + RevertOpcodeInCreateReturnsCreate2.json                         OK
 + call_outsize_then_create2_successful_then_returndatasize.json   OK
@@ -419,7 +419,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + returndatacopy_following_successful_create.json                 OK
 + returndatasize_following_successful_create.json                 OK
 ```
-OK: 42/44 Fail: 0/44 Skip: 2/44
+OK: 43/44 Fail: 0/44 Skip: 1/44
 ## stCreateTest
 ```diff
 + CREATE_AcreateB_BSuicide_BStore.json                            OK
@@ -1671,7 +1671,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 + RevertDepthCreateAddressCollision.json                          OK
 + RevertDepthCreateOOG.json                                       OK
 + RevertInCallCode.json                                           OK
-  RevertInCreateInInit.json                                       Skip
++ RevertInCreateInInit.json                                       OK
 + RevertInDelegateCall.json                                       OK
 + RevertInStaticCall.json                                         OK
 + RevertOnEmptyStack.json                                         OK
@@ -1706,7 +1706,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 + TouchToEmptyAccountRevert2.json                                 OK
 + TouchToEmptyAccountRevert3.json                                 OK
 ```
-OK: 39/45 Fail: 0/45 Skip: 6/45
+OK: 40/45 Fail: 0/45 Skip: 5/45
 ## stSLoadTest
 ```diff
 + sloadGasCost.json                                               OK
@@ -1714,7 +1714,7 @@ OK: 39/45 Fail: 0/45 Skip: 6/45
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## stSStoreTest
 ```diff
-  InitCollision.json                                              Skip
++ InitCollision.json                                              OK
 + InitCollisionNonZeroNonce.json                                  OK
 + SstoreCallToSelfSubRefundBelowZero.json                         OK
 + sstore_0to0.json                                                OK
@@ -1742,7 +1742,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + sstore_changeFromExternalCallInInitCode.json                    OK
 + sstore_gasLeft.json                                             OK
 ```
-OK: 26/27 Fail: 0/27 Skip: 1/27
+OK: 27/27 Fail: 0/27 Skip: 0/27
 ## stSelfBalance
 ```diff
 + selfBalance.json                                                OK
@@ -2625,4 +2625,4 @@ OK: 133/133 Fail: 0/133 Skip: 0/133
 OK: 130/130 Fail: 0/130 Skip: 0/130
 
 ---TOTAL---
-OK: 2305/2411 Fail: 0/2411 Skip: 106/2411
+OK: 2308/2411 Fail: 0/2411 Skip: 103/2411

--- a/tests/test_allowed_to_fail.nim
+++ b/tests/test_allowed_to_fail.nim
@@ -98,14 +98,6 @@ func skipNewGSTTests*(folder: string, name: string): bool =
   if skipGSTTests(folder, name):
     return true
 
-  name in @[
-    # py-evm claims these tests are incorrect
-    # nimbus also agree
-    "RevertInCreateInInit.json",
-    "RevertInCreateInInitCreate2.json",
-    "InitCollision.json"
-  ]
-
 func skipVMTests*(folder: string, name: string): bool =
   result = (folder == "vmPerformance" and "loop" in name)
 
@@ -126,13 +118,6 @@ func skipNewBCTests*(folder: string, name: string): bool =
     return true
 
   name in @[
-    # Istanbul bc tests
-    # py-evm claims these tests are incorrect
-    # nimbus also agree
-    "RevertInCreateInInit.json",
-    "RevertInCreateInInitCreate2.json",
-    "InitCollision.json",
-
     # BC huge memory consumption
     "randomStatetest94.json",
     "DelegateCallSpam.json"


### PR DESCRIPTION
## aleth/geth/parity compatibility mode:

affected test cases both in GST and BCT:
- stSStoreTest\InitCollision.json
- stRevertTest\RevertInCreateInInit.json
- stCreate2\RevertInCreateInInitCreate2.json

pyEVM sided with original Nimbus EVM

implementation difference:
Aleth/geth/parity using accounts cache. When contract creation happened on an existing but 'empty' account with non empty storage will get new empty storage root. Aleth cs. only clear the storage cache while both pyEVM and Nimbus will modify the state trie. 
During the next SSTORE call, aleth cs. calculate gas used based on this cached 'original storage value'. In other hand pyEVM and Nimbus will fetch 'original storage value' from persisted state trie.

Both Yellow Paper and EIP2200 are not clear about this  situation but since aleth/geth/and parity implement this behavior, we perhaps also need to implement it.

initially, parity also does not support this behavior. see paritytech/parity-ethereum#10065

Definitions of terms are as below(from EIP1283):

* Storage slot's original value: This is the value of the storage if a _reversion_ happens on the *current transaction*.
* Storage slot's current value: This is the value of the storage before SSTORE operation happens.
* Storage slot's new value: This is the value of the storage after SSTORE operation happens.

aleth/geth/parity revert to empty cache.
pyEVM and Nimbus revert to 'original state trie'.
