### PR TITLE
toFork reform

### DIFF
--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -5,7 +5,7 @@ import options, sets,
   ../vm_state, ../vm_types, ../vm_state_transactions,
   ../vm/[computation, message],
   ../vm/interpreter/vm_forks,
-  ./dao
+  ./dao, ../config
 
 proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMState, fork: Fork): GasInt =
   ## Process the transaction, write the results to db.
@@ -82,16 +82,13 @@ const
   eth2 = 2.eth
   blockRewards*: array[Fork, Uint256] = [
     eth5, # FkFrontier
-    eth5, # FkThawing
     eth5, # FkHomestead
-    eth5, # FkDao
     eth5, # FkTangerine
     eth5, # FkSpurious
     eth3, # FkByzantium
     eth2, # FkConstantinople
     eth2, # FkPetersburg
-    eth2, # FkIstanbul
-    eth2  # FkMuirGlacier
+    eth2  # FkIstanbul
   ]
 
 proc processBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, vmState: BaseVMState): ValidationResult =
@@ -106,7 +103,7 @@ proc processBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, v
     debug "Mismatched txRoot", blockNumber=header.blockNumber
     return ValidationResult.Error
 
-  let fork = vmState.blockNumber.toFork
+  let fork = chainDB.config.toFork(vmState.blockNumber)
 
   if header.txRoot != BLANK_ROOT_HASH:
     if body.transactions.len == 0:

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -91,7 +91,7 @@ const
     eth2, # FkConstantinople
     eth2, # FkPetersburg
     eth2, # FkIstanbul
-    eth2  # FkGlacierMuir
+    eth2  # FkMuirGlacier
   ]
 
 proc processBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, vmState: BaseVMState): ValidationResult =

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -43,7 +43,7 @@ proc binarySearchGas(vmState: var BaseVMState, transaction: Transaction, sender:
         vmState,
         transaction,
         sender,
-        vmState.blockNumber.toFork)
+        fork)
 
   proc dummyTransaction(gasLimit, gasPrice: GasInt, destination: EthAddress, value: UInt256): Transaction =
     Transaction(

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -37,6 +37,8 @@ template balance(addressDb: ReadOnlyStateDb, address: EthAddress): GasInt =
 proc binarySearchGas(vmState: var BaseVMState, transaction: Transaction, sender: EthAddress, gasPrice: GasInt, tolerance = 1): GasInt =
   proc dummyComputation(vmState: var BaseVMState, transaction: Transaction, sender: EthAddress): Computation =
     # Note that vmState may be altered
+    var chainDB = vmState.chainDB
+    let fork = chainDB.config.toFork(vmState.blockNumber)
     setupComputation(
         vmState,
         transaction,
@@ -52,7 +54,8 @@ proc binarySearchGas(vmState: var BaseVMState, transaction: Transaction, sender:
       value: value
     )
   var
-    fork  = vmState.blockNumber.toFork
+    chainDB = vmState.chainDB
+    fork = chainDB.config.toFork(vmState.blockNumber)
     hiGas = vmState.gasLimit
     loGas = transaction.intrinsicGas(fork)
     gasPrice = transaction.gasPrice # TODO: Or zero?

--- a/nimbus/utils/difficulty.nim
+++ b/nimbus/utils/difficulty.nim
@@ -141,13 +141,13 @@ template calcDifficultyByzantium*(timeStamp: EthTime, parent: BlockHeader): Diff
 template calcDifficultyConstantinople*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
   makeDifficultyCalculator(5_000_000, timeStamp, parent)
 
-template calcDifficultyGlacierMuir*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
+template calcDifficultyMuirGlacier*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
   makeDifficultyCalculator(9_000_000, timeStamp, parent)
 
 func calcDifficulty*(c: ChainConfig, timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
   let next = parent.blockNumber + bigOne
   if next >= c.muirGlacierBlock:
-    result = calcDifficultyGlacierMuir(timeStamp, parent)
+    result = calcDifficultyMuirGlacier(timeStamp, parent)
   elif next >= c.constantinopleBlock:
     result = calcDifficultyConstantinople(timeStamp, parent)
   elif next >= c.byzantiumBlock:

--- a/nimbus/utils/difficulty.nim
+++ b/nimbus/utils/difficulty.nim
@@ -145,7 +145,7 @@ template calcDifficultyGlacierMuir*(timeStamp: EthTime, parent: BlockHeader): Di
 
 func calcDifficulty*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
   let next = parent.blockNumber + bigOne
-  if next >= forkBlocks[FkGlacierMuir]:
+  if next >= forkBlocks[FkMuirGlacier]:
     result = calcDifficultyGlacierMuir(timeStamp, parent)
   elif next >= forkBlocks[FkConstantinople]:
     result = calcDifficultyConstantinople(timeStamp, parent)
@@ -158,7 +158,7 @@ func calcDifficulty*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
 
 func calcDifficulty*(timeStamp: EthTime, parent: BlockHeader, fork: Fork): DifficultyInt =
   case fork
-  of FkGlacierMuir:
+  of FkMuirGlacier:
     result = calcDifficultyGlacierMuir(timeStamp, parent)
   of FkConstantinople..FkPetersburg:
     result = calcDifficultyConstantinople(timeStamp, parent)

--- a/nimbus/utils/difficulty.nim
+++ b/nimbus/utils/difficulty.nim
@@ -1,7 +1,8 @@
 import
   times,
   eth/common, stint,
-  ../constants, ../vm/interpreter/vm_forks
+  ../constants, ../vm/interpreter/vm_forks,
+  ../config
 
 const
   ExpDiffPeriod           = 100000.u256
@@ -143,28 +144,15 @@ template calcDifficultyConstantinople*(timeStamp: EthTime, parent: BlockHeader):
 template calcDifficultyGlacierMuir*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
   makeDifficultyCalculator(9_000_000, timeStamp, parent)
 
-func calcDifficulty*(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
+func calcDifficulty*(c: ChainConfig, timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
   let next = parent.blockNumber + bigOne
-  if next >= forkBlocks[FkMuirGlacier]:
+  if next >= c.muirGlacierBlock:
     result = calcDifficultyGlacierMuir(timeStamp, parent)
-  elif next >= forkBlocks[FkConstantinople]:
+  elif next >= c.constantinopleBlock:
     result = calcDifficultyConstantinople(timeStamp, parent)
-  elif next >= forkBlocks[FkByzantium]:
+  elif next >= c.byzantiumBlock:
     result = calcDifficultyByzantium(timeStamp, parent)
-  elif next >= forkBlocks[FkHomestead]:
-    result = calcDifficultyHomestead(timeStamp, parent)
-  else:
-    result = calcDifficultyFrontier(timeStamp, parent)
-
-func calcDifficulty*(timeStamp: EthTime, parent: BlockHeader, fork: Fork): DifficultyInt =
-  case fork
-  of FkMuirGlacier:
-    result = calcDifficultyGlacierMuir(timeStamp, parent)
-  of FkConstantinople..FkPetersburg:
-    result = calcDifficultyConstantinople(timeStamp, parent)
-  of FkByzantium:
-    result = calcDifficultyByzantium(timeStamp, parent)
-  of FkHomestead..FkSpurious:
+  elif next >= c.homesteadBlock:
     result = calcDifficultyHomestead(timeStamp, parent)
   else:
     result = calcDifficultyFrontier(timeStamp, parent)

--- a/nimbus/utils/header.nim
+++ b/nimbus/utils/header.nim
@@ -9,7 +9,8 @@
 import
   strformat, times, options,
   eth/[common, rlp],
-  ./difficulty, ../vm/interpreter/vm_forks, ../constants
+  ./difficulty, ../vm/interpreter/vm_forks, ../constants,
+  ../config
 
 export BlockHeader
 
@@ -66,8 +67,8 @@ proc computeGasLimit*(parent: BlockHeader, gasLimitFloor: GasInt): GasInt =
   else:
     return gasLimit
 
-proc generateHeaderFromParentHeader*(parent: BlockHeader,
-    coinbase: EthAddress, fork: Fork, timestamp: Option[EthTime],
+proc generateHeaderFromParentHeader*(config: ChainConfig, parent: BlockHeader,
+    coinbase: EthAddress, timestamp: Option[EthTime],
     gasLimit: Option[GasInt], extraData: Blob): BlockHeader =
 
   var lcTimestamp: EthTime
@@ -82,7 +83,7 @@ proc generateHeaderFromParentHeader*(parent: BlockHeader,
   result = BlockHeader(
     timestamp: lcTimestamp,
     blockNumber: (parent.blockNumber + 1),
-    difficulty: calcDifficulty(lcTimestamp, parent, fork),
+    difficulty: config.calcDifficulty(lcTimestamp, parent),
     gasLimit: if gasLimit.isSome: gasLimit.get() else: computeGasLimit(parent, gasLimitFloor = GENESIS_GAS_LIMIT),
     stateRoot: parent.stateRoot,
     coinbase: coinbase,

--- a/nimbus/vm/interpreter/gas_costs.nim
+++ b/nimbus/vm/interpreter/gas_costs.nim
@@ -724,7 +724,7 @@ const
     FkConstantinople: SpuriousGasFees,
     FkPetersburg: SpuriousGasFees,
     FkIstanbul: IstanbulGasFees,
-    FkGlacierMuir: IstanbulGasFees
+    FkMuirGlacier: IstanbulGasFees
   ]
 
 

--- a/nimbus/vm/interpreter/gas_costs.nim
+++ b/nimbus/vm/interpreter/gas_costs.nim
@@ -715,16 +715,13 @@ const
 
   gasFees*: array[Fork, GasFeeSchedule] = [
     FkFrontier: BaseGasFees,
-    FkThawing: BaseGasFees,
     FkHomestead: HomesteadGasFees,
-    FkDao: HomesteadGasFees,
     FkTangerine: TangerineGasFees,
     FkSpurious: SpuriousGasFees,
     FkByzantium: SpuriousGasFees,
     FkConstantinople: SpuriousGasFees,
     FkPetersburg: SpuriousGasFees,
-    FkIstanbul: IstanbulGasFees,
-    FkMuirGlacier: IstanbulGasFees
+    FkIstanbul: IstanbulGasFees
   ]
 
 

--- a/nimbus/vm/interpreter/vm_forks.nim
+++ b/nimbus/vm/interpreter/vm_forks.nim
@@ -19,7 +19,7 @@ type
     FkConstantinople,
     FkPetersburg,
     FkIstanbul,
-    FkGlacierMuir
+    FkMuirGlacier
 
 const
   forkBlocks*: array[Fork, BlockNumber] = [
@@ -33,7 +33,7 @@ const
     FkConstantinople: 7_280_000.toBlockNumber, # Never Occured in MainNet
     FkPetersburg:     7_280_000.toBlockNumber, # 28/02/2019 07:52:04
     FkIstanbul:       9_069_000.toBlockNumber, # 08/12/2019 12:25:09
-    FkGlacierMuir:    9_200_000.toBlockNumber  # 02/01/2020 08:30:49
+    FkMuirGlacier:    9_200_000.toBlockNumber  # 02/01/2020 08:30:49
   ]
 
 proc toFork*(blockNumber: BlockNumber): Fork =
@@ -54,8 +54,8 @@ proc toFork*(blockNumber: BlockNumber): Fork =
   elif blockNumber < forkBlocks[FkByzantium]: FkSpurious
   elif blockNumber < forkBlocks[FkConstantinople]: FkByzantium
   elif blockNumber < forkBlocks[FkIstanbul]: FkPetersburg
-  elif blockNumber < forkBlocks[FkGlacierMuir]: FkIstanbul
-  else: FkGlacierMuir
+  elif blockNumber < forkBlocks[FkMuirGlacier]: FkIstanbul
+  else: FkMuirGlacier
 
 proc `$`*(fork: Fork): string =
   case fork
@@ -69,4 +69,4 @@ proc `$`*(fork: Fork): string =
   of FkConstantinople: result = "Constantinople"
   of FkPetersburg: result = "Petersburg"
   of FkIstanbul: result = "Istanbul"
-  of FkGlacierMuir: result = "Glacier Muir"
+  of FkMuirGlacier: result = "Glacier Muir"

--- a/nimbus/vm/interpreter/vm_forks.nim
+++ b/nimbus/vm/interpreter/vm_forks.nim
@@ -10,63 +10,21 @@ import stint, eth/common/eth_types
 type
   Fork* = enum
     FkFrontier,
-    FkThawing,
     FkHomestead,
-    FkDao,
     FkTangerine,
     FkSpurious,
     FkByzantium,
     FkConstantinople,
     FkPetersburg,
-    FkIstanbul,
-    FkMuirGlacier
-
-const
-  forkBlocks*: array[Fork, BlockNumber] = [
-    FkFrontier:               1.toBlockNumber, # 30/07/2015 19:26:28
-    FkThawing:          200_000.toBlockNumber, # 08/09/2015 01:33:09
-    FkHomestead:      1_150_000.toBlockNumber, # 14/03/2016 20:49:53
-    FkDao:            1_920_000.toBlockNumber, # 20/07/2016 17:20:40
-    FkTangerine:      2_463_000.toBlockNumber, # 18/10/2016 17:19:31
-    FkSpurious:       2_675_000.toBlockNumber, # 22/11/2016 18:15:44
-    FkByzantium:      4_370_000.toBlockNumber, # 16/10/2017 09:22:11
-    FkConstantinople: 7_280_000.toBlockNumber, # Never Occured in MainNet
-    FkPetersburg:     7_280_000.toBlockNumber, # 28/02/2019 07:52:04
-    FkIstanbul:       9_069_000.toBlockNumber, # 08/12/2019 12:25:09
-    FkMuirGlacier:    9_200_000.toBlockNumber  # 02/01/2020 08:30:49
-  ]
-
-proc toFork*(blockNumber: BlockNumber): Fork =
-
-  # TODO: uint256 comparison is probably quite expensive
-  #       hence binary search is probably worth it earlier than
-  #       linear search
-
-  # TODO: all toFork usage currently incurs comparison to get the fork and then another comparison to
-  #       go to the ultimate needed result.
-
-  # Genesis block 0 also uses the Frontier code path
-  if blockNumber < forkBlocks[FkThawing]:     FkFrontier
-  elif blockNumber < forkBlocks[FkHomestead]: FkThawing
-  elif blockNumber < forkBlocks[FkDao]:       FkHomestead
-  elif blockNumber < forkBlocks[FkTangerine]: FkDao
-  elif blockNumber < forkBlocks[FkSpurious]:  FkTangerine
-  elif blockNumber < forkBlocks[FkByzantium]: FkSpurious
-  elif blockNumber < forkBlocks[FkConstantinople]: FkByzantium
-  elif blockNumber < forkBlocks[FkIstanbul]: FkPetersburg
-  elif blockNumber < forkBlocks[FkMuirGlacier]: FkIstanbul
-  else: FkMuirGlacier
+    FkIstanbul
 
 proc `$`*(fork: Fork): string =
   case fork
   of FkFrontier: result = "Frontier"
-  of FkThawing: result = "Thawing"
   of FkHomestead: result = "Homestead"
-  of FkDao: result = "Dao"
   of FkTangerine: result = "Tangerine Whistle"
   of FkSpurious: result = "Spurious Dragon"
   of FkByzantium: result = "Byzantium"
   of FkConstantinople: result = "Constantinople"
   of FkPetersburg: result = "Petersburg"
   of FkIstanbul: result = "Istanbul"
-  of FkMuirGlacier: result = "Glacier Muir"

--- a/nimbus/vm/interpreter_dispatch.nim
+++ b/nimbus/vm/interpreter_dispatch.nim
@@ -336,9 +336,9 @@ proc istanbulVM(c: Computation) {.gcsafe.} =
 proc selectVM(c: Computation, fork: Fork) {.gcsafe.} =
   # TODO: Optimise getting fork and updating opCodeExec only when necessary
   case fork
-  of FkFrontier..FkThawing:
+  of FkFrontier:
     c.frontierVM()
-  of FkHomestead..FkDao:
+  of FkHomestead:
     c.homesteadVM()
   of FkTangerine:
     c.tangerineVM()

--- a/nimbus/vm_state.nim
+++ b/nimbus/vm_state.nim
@@ -10,7 +10,8 @@ import
   eth/common,
   vm/interpreter/[vm_forks, gas_costs],
   ./constants, ./db/[db_chain, state_db],
-  ./utils, json, vm_types, vm/transaction_tracer
+  ./utils, json, vm_types, vm/transaction_tracer,
+  ./config
 
 proc newAccessLogs*: AccessLogs =
   AccessLogs(reads: initTable[string, string](), writes: initTable[string, string]())
@@ -52,7 +53,7 @@ proc setupTxContext*(vmState: BaseVMState, origin: EthAddress, gasPrice: GasInt,
     if forkOverride.isSome:
       forkOverride.get
     else:
-      vmState.blockHeader.blockNumber.toFork
+      vmState.chainDB.config.toFork(vmState.blockHeader.blockNumber)
   vmState.gasCosts = vmState.fork.forkToSchedule
 
 method blockhash*(vmState: BaseVMState): Hash256 {.base, gcsafe.} =

--- a/tests/fixtures/DifficultyTests/difficultyRopsten.json
+++ b/tests/fixtures/DifficultyTests/difficultyRopsten.json
@@ -1,0 +1,20289 @@
+{
+
+ "DifficultyTest1" : {
+		"parentTimestamp" : "0x036ad3ad65",
+		"parentDifficulty" : "0x7cc109c0a0b5320b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x036ad3ad65",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x7cd0a1e1d8c948b1"
+	},
+
+ "DifficultyTest2" : {
+		"parentTimestamp" : "0xb21a6b02",
+		"parentDifficulty" : "0x3b2c7018bab48bdd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb21a6b02",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x3b33d5a6bdcbe26f"
+	},
+
+ "DifficultyTest3" : {
+		"parentTimestamp" : "0xa5045f86",
+		"parentDifficulty" : "0x09c176f9f463b964",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa5045f86",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x09c2af28d3a245dd"
+	},
+
+ "DifficultyTest4" : {
+		"parentTimestamp" : "0x067af76001",
+		"parentDifficulty" : "0x21d864fe0ed6a96f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x067af76001",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x21dca00aae988448"
+	},
+
+ "DifficultyTest5" : {
+		"parentTimestamp" : "0x0491db32cf",
+		"parentDifficulty" : "0x0bfcfa0261151432",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0491db32cf",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x0bfe79a1a16136dc"
+	},
+
+ "DifficultyTest6" : {
+		"parentTimestamp" : "0x27671814",
+		"parentDifficulty" : "0x791566660219f190",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x27671814",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x79248912ceda34de"
+	},
+
+ "DifficultyTest7" : {
+		"parentTimestamp" : "0x027dbff18c",
+		"parentDifficulty" : "0x1f9b2dc5146e3a43",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x027dbff18c",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x1f9f212acd10c82a"
+	},
+
+ "DifficultyTest8" : {
+		"parentTimestamp" : "0x068d63e415",
+		"parentDifficulty" : "0x6519e0037cdbabd9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x068d63e415",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x6526833f7d4b478e"
+	},
+
+ "DifficultyTest9" : {
+		"parentTimestamp" : "0x0469c9d4df",
+		"parentDifficulty" : "0x7f375634eb769c50",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0469c9d4df",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x7f473d1fb2140ba3"
+	},
+
+ "DifficultyTest10" : {
+		"parentTimestamp" : "0x07b8ebdbd6",
+		"parentDifficulty" : "0x26f2d53fa4bacf64",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07b8ebdbd6",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x26f7b39a4caf67bd"
+	},
+
+ "DifficultyTest11" : {
+		"parentTimestamp" : "0x0196ab4484",
+		"parentDifficulty" : "0x7b3da55db00e389f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0196ab4484",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x7b4d0d125bc43c66"
+	},
+
+ "DifficultyTest12" : {
+		"parentTimestamp" : "0xddff8629",
+		"parentDifficulty" : "0x0f3a9be6cb108121",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xddff8629",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x0f3c833a47e9e731"
+	},
+
+ "DifficultyTest13" : {
+		"parentTimestamp" : "0x04b418e376",
+		"parentDifficulty" : "0x1295883760781e6b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b418e376",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x1297dae86764356e"
+	},
+
+ "DifficultyTest14" : {
+		"parentTimestamp" : "0x02e68d969f",
+		"parentDifficulty" : "0x39d4a0f39015d1f8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e68d969f",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x39dbdb87ae87e4b2"
+	},
+
+ "DifficultyTest15" : {
+		"parentTimestamp" : "0xdbe597a5",
+		"parentDifficulty" : "0x75689f32c8bfefea",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xdbe597a5",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x75774c46af1927e7"
+	},
+
+ "DifficultyTest16" : {
+		"parentTimestamp" : "0x8428351e",
+		"parentDifficulty" : "0x17cf00f706e5a621",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x8428351e",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x17d1fad725c6c2d5"
+	},
+
+ "DifficultyTest17" : {
+		"parentTimestamp" : "0x0593b30254",
+		"parentDifficulty" : "0x0c3e3f9855d0c62f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0593b30254",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x0c3fc76048db8047"
+	},
+
+ "DifficultyTest18" : {
+		"parentTimestamp" : "0x021184c585",
+		"parentDifficulty" : "0x4529b84e9c53fef3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x021184c585",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x45325d85a6278972"
+	},
+
+ "DifficultyTest19" : {
+		"parentTimestamp" : "0x0472d40f7b",
+		"parentDifficulty" : "0x4b1e2d12dc7bcb4a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0472d40f7b",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4b2790d87ed75ac3"
+	},
+
+ "DifficultyTest20" : {
+		"parentTimestamp" : "0x6a35979c",
+		"parentDifficulty" : "0x3b17b84e4f3fc0e9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6a35979c",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x3b1f1b455909a8e1"
+	},
+
+ "DifficultyTest21" : {
+		"parentTimestamp" : "0x0786b1f503",
+		"parentDifficulty" : "0x146d964a8b9989ed",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0786b1f503",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x147023fd54eafd1e"
+	},
+
+ "DifficultyTest22" : {
+		"parentTimestamp" : "0x06d57d52a3",
+		"parentDifficulty" : "0x2c2471e74e16cb6a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06d57d52a3",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x2c29f6758b008e43"
+	},
+
+ "DifficultyTest23" : {
+		"parentTimestamp" : "0x0307b140c5",
+		"parentDifficulty" : "0x7d4426502116043a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0307b140c5",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x7d53ced4eb1a26fa"
+	},
+
+ "DifficultyTest24" : {
+		"parentTimestamp" : "0x05d8b355af",
+		"parentDifficulty" : "0x445fe99818025f9f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d8b355af",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x446875954b055fea"
+	},
+
+ "DifficultyTest25" : {
+		"parentTimestamp" : "0x021c0bfbc0",
+		"parentDifficulty" : "0x0c311adc3b4f2658",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x021c0bfbc0",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x0c32a0ff96d6903c"
+	},
+
+ "DifficultyTest26" : {
+		"parentTimestamp" : "0x051482a6ef",
+		"parentDifficulty" : "0x3ebba48fafd817e4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051482a6ef",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x3ec37c0441ce12e6"
+	},
+
+ "DifficultyTest27" : {
+		"parentTimestamp" : "0x06fb1c31db",
+		"parentDifficulty" : "0x6a82c5a3171222fd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06fb1c31db",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x6a9015fbcb750541"
+	},
+
+ "DifficultyTest28" : {
+		"parentTimestamp" : "0x04122e0f87",
+		"parentDifficulty" : "0x659fa0b1ef9c0cc4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04122e0f87",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x65ac54a605da0045"
+	},
+
+ "DifficultyTest29" : {
+		"parentTimestamp" : "0x04f671ba8f",
+		"parentDifficulty" : "0x612d8624b3fa7c2e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f671ba8f",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x6139abd57890fb7d"
+	},
+
+ "DifficultyTest30" : {
+		"parentTimestamp" : "0x024cf6b4f1",
+		"parentDifficulty" : "0x1d66ae45536b43d2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x024cf6b4f1",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x1d6a5b1b1c15b13a"
+	},
+
+ "DifficultyTest31" : {
+		"parentTimestamp" : "0x0166c15ae7",
+		"parentDifficulty" : "0x28fb4683bfbe7565",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0166c15ae7",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x290065ec90366d33"
+	},
+
+ "DifficultyTest32" : {
+		"parentTimestamp" : "0xb365ae0c",
+		"parentDifficulty" : "0x63f724bcfb62d388",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb365ae0c",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x6403a3a193023fe3"
+	},
+
+ "DifficultyTest33" : {
+		"parentTimestamp" : "0x01aebf867b",
+		"parentDifficulty" : "0x74444b9258c0649f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01aebf867b",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x7452d41bcb0b7cad"
+	},
+
+ "DifficultyTest34" : {
+		"parentTimestamp" : "0x01f214ae0f",
+		"parentDifficulty" : "0x2dcd69d09f2f495e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f214ae0f",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x2dd3237dd9432f4b"
+	},
+
+ "DifficultyTest35" : {
+		"parentTimestamp" : "0x0490ec4b43",
+		"parentDifficulty" : "0x316e675a2e85314e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0490ec4b43",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x3174952719cb01fc"
+	},
+
+ "DifficultyTest36" : {
+		"parentTimestamp" : "0x5f1b8a26",
+		"parentDifficulty" : "0x322b47199fcee89a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x5f1b8a26",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x32318c828302e287"
+	},
+
+ "DifficultyTest37" : {
+		"parentTimestamp" : "0x05e1fdab0b",
+		"parentDifficulty" : "0x21c30401528612cb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e1fdab0b",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x21c73c61d2b063ad"
+	},
+
+ "DifficultyTest38" : {
+		"parentTimestamp" : "0x01e3e2ae34",
+		"parentDifficulty" : "0x426859a548b2c48a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01e3e2ae34",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x4270a6b07d5bdb22"
+	},
+
+ "DifficultyTest39" : {
+		"parentTimestamp" : "0x0398fe8e25",
+		"parentDifficulty" : "0x6da929653329a251",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0398fe8e25",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x6db6de8a5fd00805"
+	},
+
+ "DifficultyTest40" : {
+		"parentTimestamp" : "0x483f6388",
+		"parentDifficulty" : "0x1bbd66747ca79377",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x483f6388",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x1bc0de214b372969"
+	},
+
+ "DifficultyTest41" : {
+		"parentTimestamp" : "0x05b7f0a7a1",
+		"parentDifficulty" : "0x44b08370091d1815",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b7f0a7a1",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x44b91980771e3db8"
+	},
+
+ "DifficultyTest42" : {
+		"parentTimestamp" : "0x0175f43fa7",
+		"parentDifficulty" : "0x3dddff82e573d1c0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0175f43fa7",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x3de5bb42d5d0843a"
+	},
+
+ "DifficultyTest43" : {
+		"parentTimestamp" : "0x03392ded59",
+		"parentDifficulty" : "0x1f58c58d4115234a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03392ded59",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x1f5cb0a5f2bd45ee"
+	},
+
+ "DifficultyTest44" : {
+		"parentTimestamp" : "0x83f3a071",
+		"parentDifficulty" : "0x58b9610558e28b98",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x83f3a071",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x58c47831798da7e9"
+	},
+
+ "DifficultyTest45" : {
+		"parentTimestamp" : "0x02bd7616f0",
+		"parentDifficulty" : "0x6467477260d39d5e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02bd7616f0",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x6473d45b4f1fb7d1"
+	},
+
+ "DifficultyTest46" : {
+		"parentTimestamp" : "0x06d6b8a945",
+		"parentDifficulty" : "0x2097596f8dc5e343",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06d6b8a945",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x209b6c5abbb79bff"
+	},
+
+ "DifficultyTest47" : {
+		"parentTimestamp" : "0x04de014114",
+		"parentDifficulty" : "0x0721e3347298c93d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04de014114",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x0722c770d9271c56"
+	},
+
+ "DifficultyTest48" : {
+		"parentTimestamp" : "0x030ce4eea4",
+		"parentDifficulty" : "0x25aa3f5fb0908503",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x030ce4eea4",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x25aef4a79c869713"
+	},
+
+ "DifficultyTest49" : {
+		"parentTimestamp" : "0x0706767d24",
+		"parentDifficulty" : "0x7ea4e897df4a60b9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0706767d24",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x7eb4bd34f2464a05"
+	},
+
+ "DifficultyTest50" : {
+		"parentTimestamp" : "0x03eb1b1156",
+		"parentDifficulty" : "0x641d0437d571d319",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03eb1b1156",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x642987d85c6c8153"
+	},
+
+ "DifficultyTest51" : {
+		"parentTimestamp" : "0x01e2cd7253",
+		"parentDifficulty" : "0x66f35b33a860b503",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e2cd7253",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x6700399f0ed5c11a"
+	},
+
+ "DifficultyTest52" : {
+		"parentTimestamp" : "0x7c7f7505",
+		"parentDifficulty" : "0x47abfa26581c26c2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7c7f7505",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x47b4efa59ce72a48"
+	},
+
+ "DifficultyTest53" : {
+		"parentTimestamp" : "0x014b08a1fa",
+		"parentDifficulty" : "0x2c355d7e9fc0ba6e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x014b08a1fa",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x2c3ae42a4f94b289"
+	},
+
+ "DifficultyTest54" : {
+		"parentTimestamp" : "0x3d900d78",
+		"parentDifficulty" : "0x277c19732131f814",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x3d900d78",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x278108f64f961e5b"
+	},
+
+ "DifficultyTest55" : {
+		"parentTimestamp" : "0x044ba94286",
+		"parentDifficulty" : "0x028a89853e051a51",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x044ba94286",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x028adad66eacdb04"
+	},
+
+ "DifficultyTest56" : {
+		"parentTimestamp" : "0x06f698d86c",
+		"parentDifficulty" : "0x4f48dca592f59dc6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06f698d86c",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x4f52c5c127a7fc99"
+	},
+
+ "DifficultyTest57" : {
+		"parentTimestamp" : "0x05f5cf2bb7",
+		"parentDifficulty" : "0x6248fc266922e12b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05f5cf2bb7",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x62554545edf005c7"
+	},
+
+ "DifficultyTest58" : {
+		"parentTimestamp" : "0x04316515c4",
+		"parentDifficulty" : "0x7eea1b39b2b1fe18",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04316515c4",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x7ef9f87d19e854d7"
+	},
+
+ "DifficultyTest59" : {
+		"parentTimestamp" : "0x079daaad68",
+		"parentDifficulty" : "0x4a07006007814268",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x079daaad68",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x4a10414013823390"
+	},
+
+ "DifficultyTest60" : {
+		"parentTimestamp" : "0x06c48e100c",
+		"parentDifficulty" : "0x54fd388cdd1d0530",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c48e100c",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x5507d833eeb8aad0"
+	},
+
+ "DifficultyTest61" : {
+		"parentTimestamp" : "0x01bb2bba29",
+		"parentDifficulty" : "0x67af67b7b9e4f9b3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01bb2bba29",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x67bc5da4b0dc3a52"
+	},
+
+ "DifficultyTest62" : {
+		"parentTimestamp" : "0x045908ff78",
+		"parentDifficulty" : "0x378852202516e5ef",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045908ff78",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x378f432a691b90cb"
+	},
+
+ "DifficultyTest63" : {
+		"parentTimestamp" : "0x048362648f",
+		"parentDifficulty" : "0x1e23b70ffad403f3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x048362648f",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x1e277b86dcd36e73"
+	},
+
+ "DifficultyTest64" : {
+		"parentTimestamp" : "0x03519c5027",
+		"parentDifficulty" : "0x5f1e396f6efbd73c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03519c5027",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x5f2a1d369ce9d6b6"
+	},
+
+ "DifficultyTest65" : {
+		"parentTimestamp" : "0x01ee2d7138",
+		"parentDifficulty" : "0x180d85b9f33c191e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ee2d7138",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x1810876aaa7ac0a1"
+	},
+
+ "DifficultyTest66" : {
+		"parentTimestamp" : "0x061683c676",
+		"parentDifficulty" : "0x72d86b4f78d502aa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061683c676",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x72f5216a4cb337ea"
+	},
+
+ "DifficultyTest67" : {
+		"parentTimestamp" : "0x03badb5ace",
+		"parentDifficulty" : "0x06a8760cb2f7917f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03badb5ace",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x06aa202a36244f63"
+	},
+
+ "DifficultyTest68" : {
+		"parentTimestamp" : "0x0136fb3e7f",
+		"parentDifficulty" : "0x544578ad34310ec4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0136fb3e7f",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x545a8a0b5f7e1b06"
+	},
+
+ "DifficultyTest69" : {
+		"parentTimestamp" : "0x07bd175b21",
+		"parentDifficulty" : "0x04ce82fc9a4c9bcd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07bd175b21",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x04cfb69d59732ef3"
+	},
+
+ "DifficultyTest70" : {
+		"parentTimestamp" : "0x0777b38e6b",
+		"parentDifficulty" : "0x094322927a0aa918",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0777b38e6b",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x0945735b1ea92bc2"
+	},
+
+ "DifficultyTest71" : {
+		"parentTimestamp" : "0x03c862bf01",
+		"parentDifficulty" : "0x01c03b61b4ebd51a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03c862bf01",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x01c0ab708d59100e"
+	},
+
+ "DifficultyTest72" : {
+		"parentTimestamp" : "0x04bf299b99",
+		"parentDifficulty" : "0x7025f7f56918c9f7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04bf299b99",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x7042017366731029"
+	},
+
+ "DifficultyTest73" : {
+		"parentTimestamp" : "0x032704d54d",
+		"parentDifficulty" : "0x626bb4db17e58064",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x032704d54d",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x62844fc84eab79c4"
+	},
+
+ "DifficultyTest74" : {
+		"parentTimestamp" : "0x0121a5d0e8",
+		"parentDifficulty" : "0x05c56f02e08226ec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0121a5d0e8",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x05c6e05ea13a4774"
+	},
+
+ "DifficultyTest75" : {
+		"parentTimestamp" : "0x042bada693",
+		"parentDifficulty" : "0x28984fa6665887ad",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x042bada693",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x28a275ba4ff21dcd"
+	},
+
+ "DifficultyTest76" : {
+		"parentTimestamp" : "0x03c2ed99a4",
+		"parentDifficulty" : "0x7e26175958dafc32",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03c2ed99a4",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x7e45a0df2f3132f0"
+	},
+
+ "DifficultyTest77" : {
+		"parentTimestamp" : "0x0718c808f3",
+		"parentDifficulty" : "0x208acd6f44a430a1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0718c808f3",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x2092f022a07559ad"
+	},
+
+ "DifficultyTest78" : {
+		"parentTimestamp" : "0x07cac51b44",
+		"parentDifficulty" : "0x5b9ccad87298cb8a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07cac51b44",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x5bb3b20b28b571bc"
+	},
+
+ "DifficultyTest79" : {
+		"parentTimestamp" : "0x022b1220d5",
+		"parentDifficulty" : "0x28a5e8d6f4b69904",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x022b1220d5",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x28b012512a73c6aa"
+	},
+
+ "DifficultyTest80" : {
+		"parentTimestamp" : "0x8e50a5fa",
+		"parentDifficulty" : "0x62496b0bbf96c194",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x8e50a5fa",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x6261fd668286a744"
+	},
+
+ "DifficultyTest81" : {
+		"parentTimestamp" : "0x024961c69c",
+		"parentDifficulty" : "0x794fc5c5ad98fcbe",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x024961c69c",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x796e19b71f0462fd"
+	},
+
+ "DifficultyTest82" : {
+		"parentTimestamp" : "0x1110ad12",
+		"parentDifficulty" : "0x2814f707f42a86a4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1110ad12",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x281efc45b6279146"
+	},
+
+ "DifficultyTest83" : {
+		"parentTimestamp" : "0x057669b673",
+		"parentDifficulty" : "0x5d88d607f229d9f7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x057669b673",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x5da0383d74266471"
+	},
+
+ "DifficultyTest84" : {
+		"parentTimestamp" : "0xb9823bfa",
+		"parentDifficulty" : "0x47698a61ccd15d79",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xb9823bfa",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x477b64c4654491d7"
+	},
+
+ "DifficultyTest85" : {
+		"parentTimestamp" : "0x0364088e44",
+		"parentDifficulty" : "0x6d40cceee3c0100c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0364088e44",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6d5c1d221f790020"
+	},
+
+ "DifficultyTest86" : {
+		"parentTimestamp" : "0x05e783dbd3",
+		"parentDifficulty" : "0x34168f411dfb355e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e783dbd3",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x342394e4ee42b44a"
+	},
+
+ "DifficultyTest87" : {
+		"parentTimestamp" : "0x026d9c9a90",
+		"parentDifficulty" : "0x69bb3dc04c92298d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x026d9c9a90",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x69d5ac8fbca54e57"
+	},
+
+ "DifficultyTest88" : {
+		"parentTimestamp" : "0x076b06e03c",
+		"parentDifficulty" : "0x49f9250341214924",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x076b06e03c",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x4a0ba34c81f191f6"
+	},
+
+ "DifficultyTest89" : {
+		"parentTimestamp" : "0x013290037f",
+		"parentDifficulty" : "0x43331f650b6b6478",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013290037f",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x4343ec2ce4ae4050"
+	},
+
+ "DifficultyTest90" : {
+		"parentTimestamp" : "0x05b802e93b",
+		"parentDifficulty" : "0x60ce5ebdd146c380",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05b802e93b",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x60e6925580bb1730"
+	},
+
+ "DifficultyTest91" : {
+		"parentTimestamp" : "0x039347a5ef",
+		"parentDifficulty" : "0x4abc7686c3ca2728",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039347a5ef",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x4acf25a4657b1db0"
+	},
+
+ "DifficultyTest92" : {
+		"parentTimestamp" : "0x043594eb84",
+		"parentDifficulty" : "0x74fe820b0853a034",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x043594eb84",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x751bc1ab8b15b51c"
+	},
+
+ "DifficultyTest93" : {
+		"parentTimestamp" : "0x039d9115fd",
+		"parentDifficulty" : "0x4c5476344eacf8bc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039d9115fd",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x4c678b51dbc0a3fa"
+	},
+
+ "DifficultyTest94" : {
+		"parentTimestamp" : "0x06e1ae038f",
+		"parentDifficulty" : "0x04bd45e06a10e33c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06e1ae038f",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x04be7531e22b6774"
+	},
+
+ "DifficultyTest95" : {
+		"parentTimestamp" : "0x0618af1684",
+		"parentDifficulty" : "0x3a0c9f28880c2c9d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0618af1684",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x3a1b2250522e2fa7"
+	},
+
+ "DifficultyTest96" : {
+		"parentTimestamp" : "0x06c8dfce18",
+		"parentDifficulty" : "0x308f4190d30a313a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c8dfce18",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x309b6561373ef3c6"
+	},
+
+ "DifficultyTest97" : {
+		"parentTimestamp" : "0x027eea93f8",
+		"parentDifficulty" : "0x209cbf0a7a29c686",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x027eea93f8",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x20a4e63a3cc850f6"
+	},
+
+ "DifficultyTest98" : {
+		"parentTimestamp" : "0x01c4e3a960",
+		"parentDifficulty" : "0x5292424441ea2452",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c4e3a960",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x52a6e6d4d2fa9eda"
+	},
+
+ "DifficultyTest99" : {
+		"parentTimestamp" : "0x012f20e6b9",
+		"parentDifficulty" : "0x71325be91874d8e3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x012f20e6bb",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x714082349597e77e"
+	},
+
+ "DifficultyTest100" : {
+		"parentTimestamp" : "0x051163fd8b",
+		"parentDifficulty" : "0x58b2d0595dda249b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051163fd8d",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x58bde6b36905dfe0"
+	},
+
+ "DifficultyTest101" : {
+		"parentTimestamp" : "0x0551e37135",
+		"parentDifficulty" : "0x75cd6b5a8d6ea3d3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0551e37137",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x75dc2507f8c051a9"
+	},
+
+ "DifficultyTest102" : {
+		"parentTimestamp" : "0x07ab388b60",
+		"parentDifficulty" : "0x6eb62de39fa4d7d4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07ab388b62",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x6ec404a95c18cc72"
+	},
+
+ "DifficultyTest103" : {
+		"parentTimestamp" : "0x05dfb760d6",
+		"parentDifficulty" : "0x51a4ae8b1b913ef8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05dfb760d8",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x51aee320ecf4b127"
+	},
+
+ "DifficultyTest104" : {
+		"parentTimestamp" : "0x0702f8ba36",
+		"parentDifficulty" : "0x75478751337148e8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0702f8ba38",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x755630421d97b721"
+	},
+
+ "DifficultyTest105" : {
+		"parentTimestamp" : "0x045729427f",
+		"parentDifficulty" : "0x73f170660b5f866d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0457294281",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x73ffee941820f27d"
+	},
+
+ "DifficultyTest106" : {
+		"parentTimestamp" : "0x05c02bad27",
+		"parentDifficulty" : "0x186090e6330be39c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05c02bad29",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x18639cf84fd24558"
+	},
+
+ "DifficultyTest107" : {
+		"parentTimestamp" : "0x0702b10394",
+		"parentDifficulty" : "0x4d9eafe4cec846ae",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0702b10396",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x4da863bacb622036"
+	},
+
+ "DifficultyTest108" : {
+		"parentTimestamp" : "0x02cb51d250",
+		"parentDifficulty" : "0x1d79c098adcf5a18",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02cb51d252",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x1d7d6fd0c0e51503"
+	},
+
+ "DifficultyTest109" : {
+		"parentTimestamp" : "0x03996758d2",
+		"parentDifficulty" : "0x75c312f8284ad1a6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03996758d4",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x75d1cb5a874fdd00"
+	},
+
+ "DifficultyTest110" : {
+		"parentTimestamp" : "0x37afd081",
+		"parentDifficulty" : "0x1a296eb94e6e4ffa",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x37afd083",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x1a2cb3e7259821c3"
+	},
+
+ "DifficultyTest111" : {
+		"parentTimestamp" : "0x046ebbe929",
+		"parentDifficulty" : "0x36be821737f3fdeb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046ebbe92b",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x36c559e77adb046a"
+	},
+
+ "DifficultyTest112" : {
+		"parentTimestamp" : "0x03b558b215",
+		"parentDifficulty" : "0x50f178d0eb94e1c8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b558b217",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x50fb970005b26464"
+	},
+
+ "DifficultyTest113" : {
+		"parentTimestamp" : "0x058fa0e984",
+		"parentDifficulty" : "0x3130be2fdf6bdd83",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x058fa0e986",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x3136e447a567eafe"
+	},
+
+ "DifficultyTest114" : {
+		"parentTimestamp" : "0x04c40a3b60",
+		"parentDifficulty" : "0x59b7c49498e373d2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c40a3b62",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x59c2fb8d2b76d040"
+	},
+
+ "DifficultyTest115" : {
+		"parentTimestamp" : "0xfd9ba031",
+		"parentDifficulty" : "0x5d455da6349748ce",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xfd9ba033",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x5d510651e95ddbb7"
+	},
+
+ "DifficultyTest116" : {
+		"parentTimestamp" : "0x0111af9954",
+		"parentDifficulty" : "0x326517e38845a1f2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0111af9956",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x326b648684b6aaa6"
+	},
+
+ "DifficultyTest117" : {
+		"parentTimestamp" : "0x040e7d13f8",
+		"parentDifficulty" : "0x433b90a369e5b686",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x040e7d13fa",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4343f8157e52f33c"
+	},
+
+ "DifficultyTest118" : {
+		"parentTimestamp" : "0x02d61b404f",
+		"parentDifficulty" : "0x7f3683881f0d1039",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d61b4051",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x7f466a589010f1db"
+	},
+
+ "DifficultyTest119" : {
+		"parentTimestamp" : "0x0167910f82",
+		"parentDifficulty" : "0x26cfc7343aa54525",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0167910f84",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x26d4a12d212c99cd"
+	},
+
+ "DifficultyTest120" : {
+		"parentTimestamp" : "0x065e1979b6",
+		"parentDifficulty" : "0x700bb98a838b2eed",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x065e1979b8",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x7019bb01b4dba052"
+	},
+
+ "DifficultyTest121" : {
+		"parentTimestamp" : "0x021fd49dc1",
+		"parentDifficulty" : "0x7e104fa59854af45",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x021fd49dc3",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x7e2011af8d07b9da"
+	},
+
+ "DifficultyTest122" : {
+		"parentTimestamp" : "0x01cecf712d",
+		"parentDifficulty" : "0x279784a7af0ee35d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01cecf712f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x279c77984404c539"
+	},
+
+ "DifficultyTest123" : {
+		"parentTimestamp" : "0x05afc9a0bc",
+		"parentDifficulty" : "0x0892d327c230a2e1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05afc9a0be",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x0893e5822728e8f5"
+	},
+
+ "DifficultyTest124" : {
+		"parentTimestamp" : "0x03d05a943c",
+		"parentDifficulty" : "0x504b37a578deee04",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03d05a943e",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x5055410c6d8e09e1"
+	},
+
+ "DifficultyTest125" : {
+		"parentTimestamp" : "0x02160c7b05",
+		"parentDifficulty" : "0x783d1dacc21eb137",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02160c7b07",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x784c255077b6f50d"
+	},
+
+ "DifficultyTest126" : {
+		"parentTimestamp" : "0x07c217183c",
+		"parentDifficulty" : "0x71340f5112cb3576",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07c217183e",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x714235d2fced8edc"
+	},
+
+ "DifficultyTest127" : {
+		"parentTimestamp" : "0x01159999ad",
+		"parentDifficulty" : "0x048190defbc90948",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01159999af",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x0482211117a88269"
+	},
+
+ "DifficultyTest128" : {
+		"parentTimestamp" : "0x0222f1bfc9",
+		"parentDifficulty" : "0x4cf818a420521d64",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0222f1bfcb",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x4d01b7a734d627a7"
+	},
+
+ "DifficultyTest129" : {
+		"parentTimestamp" : "0x036c7707da",
+		"parentDifficulty" : "0x1b834b7450b8ce5f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x036c7707dc",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x1b86bbddbf42e578"
+	},
+
+ "DifficultyTest130" : {
+		"parentTimestamp" : "0x03773d4b8d",
+		"parentDifficulty" : "0x2cc4795539c47a12",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03773d4b8f",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x2cca11e4646bb2a2"
+	},
+
+ "DifficultyTest131" : {
+		"parentTimestamp" : "0x04147378f3",
+		"parentDifficulty" : "0x58d6d727d6b01247",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04147378f5",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x58e1f202bbaae84b"
+	},
+
+ "DifficultyTest132" : {
+		"parentTimestamp" : "0x02d1555428",
+		"parentDifficulty" : "0x2227b7ffc1322e6b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d155542a",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x222bfcf6c12a54b4"
+	},
+
+ "DifficultyTest133" : {
+		"parentTimestamp" : "0x05d212e372",
+		"parentDifficulty" : "0x7d83ceb761de1d44",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d212e374",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x7d937f3138ca590f"
+	},
+
+ "DifficultyTest134" : {
+		"parentTimestamp" : "0x04817bcff4",
+		"parentDifficulty" : "0x264d0bad7e367a45",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04817bcff6",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x2651d54ef3e64124"
+	},
+
+ "DifficultyTest135" : {
+		"parentTimestamp" : "0x0468275919",
+		"parentDifficulty" : "0x6a69fd09575ea224",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046827591b",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x6a774a48f8898e18"
+	},
+
+ "DifficultyTest136" : {
+		"parentTimestamp" : "0x062780bb7d",
+		"parentDifficulty" : "0x5e31ceaaebbb13a4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x062780bb7f",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x5e3d94e4c1188b46"
+	},
+
+ "DifficultyTest137" : {
+		"parentTimestamp" : "0x056a0857a4",
+		"parentDifficulty" : "0x4733b6d6173e3cd9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x056a0857a6",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x473c9d4cf2012520"
+	},
+
+ "DifficultyTest138" : {
+		"parentTimestamp" : "0x056c0d1520",
+		"parentDifficulty" : "0x69f8e0b372549992",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x056c0d1522",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x6a061fcf88c2e525"
+	},
+
+ "DifficultyTest139" : {
+		"parentTimestamp" : "0x06fea96b5b",
+		"parentDifficulty" : "0x7deba200d98cca9d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06fea96b5d",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x7dfb5f7519a7fe36"
+	},
+
+ "DifficultyTest140" : {
+		"parentTimestamp" : "0x0495e2c3a5",
+		"parentDifficulty" : "0x7f1038ce19dec355",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0495e2c3a7",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x7f201ad533a2032d"
+	},
+
+ "DifficultyTest141" : {
+		"parentTimestamp" : "0x0627a5472a",
+		"parentDifficulty" : "0x29341f242b444179",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0627a5472c",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x293945a80fc9aa01"
+	},
+
+ "DifficultyTest142" : {
+		"parentTimestamp" : "0x01456b0335",
+		"parentDifficulty" : "0x0b27384632d1e38f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01456b0337",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x0b289d2d3b983dcb"
+	},
+
+ "DifficultyTest143" : {
+		"parentTimestamp" : "0x060ac62355",
+		"parentDifficulty" : "0x63e7a0deda3753bc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060ac62357",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x63f41dd2f6129aa6"
+	},
+
+ "DifficultyTest144" : {
+		"parentTimestamp" : "0x067d1d3be1",
+		"parentDifficulty" : "0x26f7cb72f051f0b0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x067d1d3be3",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x26fcaa6c5eaffaee"
+	},
+
+ "DifficultyTest145" : {
+		"parentTimestamp" : "0x04c72fe715",
+		"parentDifficulty" : "0x01ea6814cffa8f80",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c72fe717",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x01eaa561d2948ed1"
+	},
+
+ "DifficultyTest146" : {
+		"parentTimestamp" : "0x04681fc57e",
+		"parentDifficulty" : "0x6fc89a040fbe0fd4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04681fc580",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x6fd6931750400795"
+	},
+
+ "DifficultyTest147" : {
+		"parentTimestamp" : "0x01393f5f07",
+		"parentDifficulty" : "0x5a3bd70219db4783",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01393f5f09",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x5a471e7cfa1e82eb"
+	},
+
+ "DifficultyTest148" : {
+		"parentTimestamp" : "0x02ec3261f7",
+		"parentDifficulty" : "0x2216481792e91631",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ec3261f9",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x221a8ae095db7353"
+	},
+
+ "DifficultyTest149" : {
+		"parentTimestamp" : "0x04f770fb7e",
+		"parentDifficulty" : "0x1ffdfbed6eb0fff9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04f770fb80",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x2001fbacec5ed619"
+	},
+
+ "DifficultyTest150" : {
+		"parentTimestamp" : "0x0717f58be6",
+		"parentDifficulty" : "0x267efcc40636b12f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0717f58be8",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x2683cca39eb77807"
+	},
+
+ "DifficultyTest151" : {
+		"parentTimestamp" : "0x0585dafe83",
+		"parentDifficulty" : "0x616e2e8d40a592a3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0585dafe85",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x617a5c53124da759"
+	},
+
+ "DifficultyTest152" : {
+		"parentTimestamp" : "0x01c1fa88dd",
+		"parentDifficulty" : "0x0e2fb35a539d56c2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c1fa88df",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x0e317950bee7ca74"
+	},
+
+ "DifficultyTest153" : {
+		"parentTimestamp" : "0x07b86cb899",
+		"parentDifficulty" : "0x40bec7a7305c48e5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07b86cb89b",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x40c6df802542547e"
+	},
+
+ "DifficultyTest154" : {
+		"parentTimestamp" : "0x03a236b0ec",
+		"parentDifficulty" : "0x78195bdbab7d41f5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03a236b0ee",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x78285f0726f2b1bd"
+	},
+
+ "DifficultyTest155" : {
+		"parentTimestamp" : "0x045544ea04",
+		"parentDifficulty" : "0x1580a49d068d08cb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045544ea06",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x158354b19a2ddaac"
+	},
+
+ "DifficultyTest156" : {
+		"parentTimestamp" : "0x054d9667c5",
+		"parentDifficulty" : "0x11009d9696754125",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x054d9667c7",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x1102bdaa4948104d"
+	},
+
+ "DifficultyTest157" : {
+		"parentTimestamp" : "0xe74f9aa4",
+		"parentDifficulty" : "0x5b9437d303aa791f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xe74f9aa6",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x5b9faa59fe0aef6e"
+	},
+
+ "DifficultyTest158" : {
+		"parentTimestamp" : "0x03add2cb1e",
+		"parentDifficulty" : "0x6986306aed489f66",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03add2cb20",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x69936130faa64a79"
+	},
+
+ "DifficultyTest159" : {
+		"parentTimestamp" : "0x0653808614",
+		"parentDifficulty" : "0x210a265f83560f66",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0653808616",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x210e47a44f467e27"
+	},
+
+ "DifficultyTest160" : {
+		"parentTimestamp" : "0x015431337c",
+		"parentDifficulty" : "0x11f09447ce457bfa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x015431337e",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x11f2d25a573f4ca9"
+	},
+
+ "DifficultyTest161" : {
+		"parentTimestamp" : "0x03db260c4c",
+		"parentDifficulty" : "0x755ff6c03af35cec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03db260c4e",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x756ea2bf12facb57"
+	},
+
+ "DifficultyTest162" : {
+		"parentTimestamp" : "0x053542073e",
+		"parentDifficulty" : "0x08f2f5a71c0b611f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0535420740",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x08f41405d0ef028b"
+	},
+
+ "DifficultyTest163" : {
+		"parentTimestamp" : "0x07db6bf664",
+		"parentDifficulty" : "0x552770bcfa4c188c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07db6bf666",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x553215ab11eba20f"
+	},
+
+ "DifficultyTest164" : {
+		"parentTimestamp" : "0x035247ca6e",
+		"parentDifficulty" : "0x4e542b7f22f55231",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x035247ca70",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x4e67c08a02be0f85"
+	},
+
+ "DifficultyTest165" : {
+		"parentTimestamp" : "0x029da7caf9",
+		"parentDifficulty" : "0x7700d09ee550e25d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029da7cafb",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x771e90d30d0a3695"
+	},
+
+ "DifficultyTest166" : {
+		"parentTimestamp" : "0x07d62cb732",
+		"parentDifficulty" : "0x10b7468aee400910",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07d62cb734",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x10bb745c90fb9912"
+	},
+
+ "DifficultyTest167" : {
+		"parentTimestamp" : "0x02d34f9b9e",
+		"parentDifficulty" : "0x79ff4793891fac63",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02d34f9ba0",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x7a1dc7656e01f44d"
+	},
+
+ "DifficultyTest168" : {
+		"parentTimestamp" : "0x0256860e6c",
+		"parentDifficulty" : "0x2eabc6b687e4c8b6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0256860e6e",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x2eb771a83586c1e8"
+	},
+
+ "DifficultyTest169" : {
+		"parentTimestamp" : "0x026e422e95",
+		"parentDifficulty" : "0x0f6cdf48ff8300ec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x026e422e97",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x0f70ba80d1c2e1ac"
+	},
+
+ "DifficultyTest170" : {
+		"parentTimestamp" : "0x0756b3cff9",
+		"parentDifficulty" : "0x5be5d98515d02fd3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0756b3cffb",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x5bfcd2fb7715a3dd"
+	},
+
+ "DifficultyTest171" : {
+		"parentTimestamp" : "0x065a06bc7a",
+		"parentDifficulty" : "0x1c1515eabfe069ba",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x065a06bc7c",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x1c1c1b303a9061d4"
+	},
+
+ "DifficultyTest172" : {
+		"parentTimestamp" : "0x02f64a75b2",
+		"parentDifficulty" : "0x6927ed7d2815ffa3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f64a75b4",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x6942377887600521"
+	},
+
+ "DifficultyTest173" : {
+		"parentTimestamp" : "0x01ee7e4b1e",
+		"parentDifficulty" : "0x2c6866d7163c0e0a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ee7e4b20",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x2c7380f0cc019d0c"
+	},
+
+ "DifficultyTest174" : {
+		"parentTimestamp" : "0x071e376b9e",
+		"parentDifficulty" : "0x49354b7ebcd4ff28",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x071e376ba0",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x494798d19c843466"
+	},
+
+ "DifficultyTest175" : {
+		"parentTimestamp" : "0x0694ef1338",
+		"parentDifficulty" : "0x7abd418b76caf874",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0694ef133a",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x7adbf0dbd9a8ab32"
+	},
+
+ "DifficultyTest176" : {
+		"parentTimestamp" : "0x075ceecb46",
+		"parentDifficulty" : "0x5e077a9ddf927a0e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x075ceecb48",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x5e1efc7c870a5eac"
+	},
+
+ "DifficultyTest177" : {
+		"parentTimestamp" : "0x0250630461",
+		"parentDifficulty" : "0x54a4e0bed5a4dab4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0250630463",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x54ba09f7055a43ea"
+	},
+
+ "DifficultyTest178" : {
+		"parentTimestamp" : "0x04c53bd475",
+		"parentDifficulty" : "0x5cdcde7af018b75f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04c53bd477",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x5cf415b28ed4bd8b"
+	},
+
+ "DifficultyTest179" : {
+		"parentTimestamp" : "0x067e092184",
+		"parentDifficulty" : "0x0d0bf77e89cf02f4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x067e092186",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x0d0f3a7c697176b5"
+	},
+
+ "DifficultyTest180" : {
+		"parentTimestamp" : "0x05f10bc64e",
+		"parentDifficulty" : "0x536072cffa7d70c0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05f10bc650",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x53754aecae7c101e"
+	},
+
+ "DifficultyTest181" : {
+		"parentTimestamp" : "0x03ee2c7524",
+		"parentDifficulty" : "0x5b7d8a656858505a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ee2c7526",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x5b9469c801b26672"
+	},
+
+ "DifficultyTest182" : {
+		"parentTimestamp" : "0x01ffe28d39",
+		"parentDifficulty" : "0x1b0382fe21526e42",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ffe28d3b",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x1b0a43dee0dac2e4"
+	},
+
+ "DifficultyTest183" : {
+		"parentTimestamp" : "0x04e436dcf6",
+		"parentDifficulty" : "0x0199e87332e6a7ab",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e436dcf8",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x019a4eed4fb36163"
+	},
+
+ "DifficultyTest184" : {
+		"parentTimestamp" : "0x01fb694008",
+		"parentDifficulty" : "0x71cf182d9929c83b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01fb69400a",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x71eb8bf3a49012cd"
+	},
+
+ "DifficultyTest185" : {
+		"parentTimestamp" : "0x05c5bcfa21",
+		"parentDifficulty" : "0x1f46f23a462b671b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05c5bcfa23",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x1f4ec3f6d4bcf233"
+	},
+
+ "DifficultyTest186" : {
+		"parentTimestamp" : "0x06c33333e7",
+		"parentDifficulty" : "0x14edf397016e656d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c33333e9",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x14f32f13e72ec185"
+	},
+
+ "DifficultyTest187" : {
+		"parentTimestamp" : "0x0131ac41ae",
+		"parentDifficulty" : "0x18f96d08fa5835b8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0131ac41b0",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x18ffab643c96ccc4"
+	},
+
+ "DifficultyTest188" : {
+		"parentTimestamp" : "0x0144fec624",
+		"parentDifficulty" : "0x3eba3e86d92fd542",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0144fec626",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x3ec9ed167ae62336"
+	},
+
+ "DifficultyTest189" : {
+		"parentTimestamp" : "0x0449eeeb51",
+		"parentDifficulty" : "0x1823d8e3e85009ed",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0449eeeb53",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x1829e1da214a21ef"
+	},
+
+ "DifficultyTest190" : {
+		"parentTimestamp" : "0x01bc8dbeb8",
+		"parentDifficulty" : "0x6bacca64632271d3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01bc8dbeba",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x6bc7b596fc3b3a6f"
+	},
+
+ "DifficultyTest191" : {
+		"parentTimestamp" : "0x074c703309",
+		"parentDifficulty" : "0x1b4b16b332dd5960",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x074c70330b",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1b51e978dfaa10b6"
+	},
+
+ "DifficultyTest192" : {
+		"parentTimestamp" : "0x05e0161b07",
+		"parentDifficulty" : "0x635e799aab2b4897",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e0161b09",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x6377513911d61369"
+	},
+
+ "DifficultyTest193" : {
+		"parentTimestamp" : "0x9008b52a",
+		"parentDifficulty" : "0x03aac5a40ed8588e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9008b52c",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x03abb05577dc0ea4"
+	},
+
+ "DifficultyTest194" : {
+		"parentTimestamp" : "0x070f81cf4e",
+		"parentDifficulty" : "0x200c9d5523c1a755",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x070f81cf50",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x2014a07c790a97bd"
+	},
+
+ "DifficultyTest195" : {
+		"parentTimestamp" : "0x01068af6a0",
+		"parentDifficulty" : "0x24d2e7a9a4a395ef",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01068af6a2",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x24dc1c638f0cbed3"
+	},
+
+ "DifficultyTest196" : {
+		"parentTimestamp" : "0x07d8bd8a2f",
+		"parentDifficulty" : "0x45539b60aafd7908",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07d8bd8a31",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x4564f04783283866"
+	},
+
+ "DifficultyTest197" : {
+		"parentTimestamp" : "0x03484990d1",
+		"parentDifficulty" : "0x4985fe95ae1341d9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03484990d5",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x498f2f5580c90441"
+	},
+
+ "DifficultyTest198" : {
+		"parentTimestamp" : "0x0205be26a1",
+		"parentDifficulty" : "0x2aabc3988474ebcc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0205be26a5",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x2ab11910f7857a6a"
+	},
+
+ "DifficultyTest199" : {
+		"parentTimestamp" : "0x05e9c21058",
+		"parentDifficulty" : "0x04013a8a3b344307",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e9c2105c",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x0401bab18c7ba991"
+	},
+
+ "DifficultyTest200" : {
+		"parentTimestamp" : "0x021b7c5f5f",
+		"parentDifficulty" : "0x74d3e3104c88725e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x021b7c5f63",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x74e27d8cae920370"
+	},
+
+ "DifficultyTest201" : {
+		"parentTimestamp" : "0x05b7efee11",
+		"parentDifficulty" : "0x2141f8c0c0857469",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b7efee15",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x214620ffd89d851f"
+	},
+
+ "DifficultyTest202" : {
+		"parentTimestamp" : "0x0128f20407",
+		"parentDifficulty" : "0x1aa33f37efcf875b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0128f2040b",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x1aa6939fd6cd815b"
+	},
+
+ "DifficultyTest203" : {
+		"parentTimestamp" : "0x03e840ad1f",
+		"parentDifficulty" : "0x0c0a3eca39d4fee0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e840ad23",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x0c0bc012131c399f"
+	},
+
+ "DifficultyTest204" : {
+		"parentTimestamp" : "0x39f332ab",
+		"parentDifficulty" : "0x3177691cb60c3ca9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x39f332af",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x317d9809d9a2fe70"
+	},
+
+ "DifficultyTest205" : {
+		"parentTimestamp" : "0x042471240f",
+		"parentDifficulty" : "0x7f70abf6a56d946c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0424712413",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x7f809a0c2442429e"
+	},
+
+ "DifficultyTest206" : {
+		"parentTimestamp" : "0x02ec20791f",
+		"parentDifficulty" : "0x4e4ce334d40c9bba",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ec207923",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x4e56acd13aa71e4d"
+	},
+
+ "DifficultyTest207" : {
+		"parentTimestamp" : "0x0458650c02",
+		"parentDifficulty" : "0x32d3030dba1bb750",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0458650c06",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x32d95d6e1bd2fcc6"
+	},
+
+ "DifficultyTest208" : {
+		"parentTimestamp" : "0x0517029bc2",
+		"parentDifficulty" : "0x53288dc79815ee47",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0517029bc6",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x5332f2d95108f504"
+	},
+
+ "DifficultyTest209" : {
+		"parentTimestamp" : "0x0412b831c2",
+		"parentDifficulty" : "0x2be0f3d5cb19cfaa",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0412b831c6",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x2be66ff445d33ae3"
+	},
+
+ "DifficultyTest210" : {
+		"parentTimestamp" : "0xf5afc4a1",
+		"parentDifficulty" : "0x4cf1630acd6360ae",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xf5afc4a5",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x4cfb01372ebd1d1a"
+	},
+
+ "DifficultyTest211" : {
+		"parentTimestamp" : "0x03dd415ec7",
+		"parentDifficulty" : "0x44fb696d374202e5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03dd415ecb",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x450408da64e90b25"
+	},
+
+ "DifficultyTest212" : {
+		"parentTimestamp" : "0x02cefdced7",
+		"parentDifficulty" : "0x4d024263720f2809",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02cefdcedb",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x4d0be2abbe7da9ee"
+	},
+
+ "DifficultyTest213" : {
+		"parentTimestamp" : "0x025e699a69",
+		"parentDifficulty" : "0x035c1d02786136f3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x025e699a6d",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x035c888618b04319"
+	},
+
+ "DifficultyTest214" : {
+		"parentTimestamp" : "0x077b5d76cf",
+		"parentDifficulty" : "0x75dc05f3620cf223",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x077b5d76d3",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x75eac174207933c1"
+	},
+
+ "DifficultyTest215" : {
+		"parentTimestamp" : "0x05e0c6d58b",
+		"parentDifficulty" : "0x4e5d9f432ab53dfe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e0c6d58f",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4e676af7131a94a5"
+	},
+
+ "DifficultyTest216" : {
+		"parentTimestamp" : "0x026e491010",
+		"parentDifficulty" : "0x2e80c9f047efd480",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x026e491014",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x2e869a0985f8d27a"
+	},
+
+ "DifficultyTest217" : {
+		"parentTimestamp" : "0x042ececced",
+		"parentDifficulty" : "0x1cc545c1529f9b91",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x042ececcf1",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x1cc8de6a0ac9ef84"
+	},
+
+ "DifficultyTest218" : {
+		"parentTimestamp" : "0x81540720",
+		"parentDifficulty" : "0x06a34589d377e416",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x81540724",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x06a419f284b25312"
+	},
+
+ "DifficultyTest219" : {
+		"parentTimestamp" : "0x071312515d",
+		"parentDifficulty" : "0x3b7e1074888f348e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0713125161",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x3b85803697204674"
+	},
+
+ "DifficultyTest220" : {
+		"parentTimestamp" : "0x063a80bdae",
+		"parentDifficulty" : "0x71e707b436614171",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x063a80bdb2",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x71f544952ce80d99"
+	},
+
+ "DifficultyTest221" : {
+		"parentTimestamp" : "0x02c8c00b6c",
+		"parentDifficulty" : "0x567dce852546419e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02c8c00b70",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x56889e3ef5eaea66"
+	},
+
+ "DifficultyTest222" : {
+		"parentTimestamp" : "0x0236dd2a26",
+		"parentDifficulty" : "0x7eae05ddc97e3312",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0236dd2a2a",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x7ebddb9e853762d8"
+	},
+
+ "DifficultyTest223" : {
+		"parentTimestamp" : "0x071f15a9a4",
+		"parentDifficulty" : "0x5559273dab587070",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x071f15a9a8",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x5563d262930ddb7e"
+	},
+
+ "DifficultyTest224" : {
+		"parentTimestamp" : "0x07cde381f7",
+		"parentDifficulty" : "0x3185f934773e0a95",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07cde381fb",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x318c29f39dccf256"
+	},
+
+ "DifficultyTest225" : {
+		"parentTimestamp" : "0x0672eb5f5c",
+		"parentDifficulty" : "0x4f496667f41f4562",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0672eb5f60",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x4f534f94c11dc94a"
+	},
+
+ "DifficultyTest226" : {
+		"parentTimestamp" : "0x0183e4f782",
+		"parentDifficulty" : "0x6c3ab16a53f91141",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0183e4f786",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x6c4838c081439063"
+	},
+
+ "DifficultyTest227" : {
+		"parentTimestamp" : "0x01b8ef8146",
+		"parentDifficulty" : "0x2d40bacedc6d850e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01b8ef814a",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x2d4662e6364912be"
+	},
+
+ "DifficultyTest228" : {
+		"parentTimestamp" : "0x0660d60356",
+		"parentDifficulty" : "0x59edbd6455fb59af",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0660d6035a",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x59f8fb1c0286191b"
+	},
+
+ "DifficultyTest229" : {
+		"parentTimestamp" : "0x79010bdf",
+		"parentDifficulty" : "0x708903001b296d9d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x79010be3",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x709714207b2cd2cc"
+	},
+
+ "DifficultyTest230" : {
+		"parentTimestamp" : "0x020f22a609",
+		"parentDifficulty" : "0x018ce0b201f6b9a6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x020f22a60d",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x018d124e1836f881"
+	},
+
+ "DifficultyTest231" : {
+		"parentTimestamp" : "0x6fcc8096",
+		"parentDifficulty" : "0x6d34566262b99f11",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6fcc809a",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x6d41fced2f05f64c"
+	},
+
+ "DifficultyTest232" : {
+		"parentTimestamp" : "0x0639e92dd7",
+		"parentDifficulty" : "0x26e65ba8db6e4908",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0639e92ddb",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x26eb38745089b6e1"
+	},
+
+ "DifficultyTest233" : {
+		"parentTimestamp" : "0x043c28bfd2",
+		"parentDifficulty" : "0x4effe3303adeff74",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x043c28bfd6",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x4f09c32ca0e65b73"
+	},
+
+ "DifficultyTest234" : {
+		"parentTimestamp" : "0x5c1d688b",
+		"parentDifficulty" : "0x4968db7630ca79dd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x5c1d688f",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x497208919f90936c"
+	},
+
+ "DifficultyTest235" : {
+		"parentTimestamp" : "0x051c7f3d68",
+		"parentDifficulty" : "0x7dbdd353047c7b6d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051c7f3d6c",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x7dcd8b0d6edd0b7c"
+	},
+
+ "DifficultyTest236" : {
+		"parentTimestamp" : "0x03f94c5485",
+		"parentDifficulty" : "0x0de9d478d1070f5e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03f94c5489",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x0deb91b36021313f"
+	},
+
+ "DifficultyTest237" : {
+		"parentTimestamp" : "0x05e55b6e3b",
+		"parentDifficulty" : "0x6209dce30679a541",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e55b6e3f",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x62161e1ea2da7675"
+	},
+
+ "DifficultyTest238" : {
+		"parentTimestamp" : "0x832f631f",
+		"parentDifficulty" : "0x1e2c001c2df1f76f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x832f6323",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x1e2fc59c3177b9ad"
+	},
+
+ "DifficultyTest239" : {
+		"parentTimestamp" : "0x0304d0ff60",
+		"parentDifficulty" : "0x459b26c89861cdc6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0304d0ff64",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x45a3da2d7174d9ff"
+	},
+
+ "DifficultyTest240" : {
+		"parentTimestamp" : "0x0656c1b2c0",
+		"parentDifficulty" : "0x55ca3bf5fbc8cdb9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0656c1b2c4",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x55d4f53d7a8846d2"
+	},
+
+ "DifficultyTest241" : {
+		"parentTimestamp" : "0x01879ce5d7",
+		"parentDifficulty" : "0x749035ebb06a2077",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01879ce5db",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x749ec7f26de02dbb"
+	},
+
+ "DifficultyTest242" : {
+		"parentTimestamp" : "0x02a9bec0b0",
+		"parentDifficulty" : "0x7cbbae7c9f12728f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02a9bec0b4",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x7ccb45f26ea654dd"
+	},
+
+ "DifficultyTest243" : {
+		"parentTimestamp" : "0x01f76c4e32",
+		"parentDifficulty" : "0x2e2c3a84067a00a4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f76c4e36",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x2e32000b56facfe4"
+	},
+
+ "DifficultyTest244" : {
+		"parentTimestamp" : "0x051bc30a53",
+		"parentDifficulty" : "0x5154f75d5898fecd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051bc30a57",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x515f21fc444411ec"
+	},
+
+ "DifficultyTest245" : {
+		"parentTimestamp" : "0x07852bd9e9",
+		"parentDifficulty" : "0x79e01eef19a273cd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07852bd9ed",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x79ef5af2f785a81b"
+	},
+
+ "DifficultyTest246" : {
+		"parentTimestamp" : "0x03d0e810cf",
+		"parentDifficulty" : "0x6cbfc209c4d27db9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03d0e810d3",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x6ccd5a02060b1808"
+	},
+
+ "DifficultyTest247" : {
+		"parentTimestamp" : "0x04949ca062",
+		"parentDifficulty" : "0x7f3117362ad4de1f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04949ca066",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x7f40fd59119a38bb"
+	},
+
+ "DifficultyTest248" : {
+		"parentTimestamp" : "0x013386fd68",
+		"parentDifficulty" : "0x1b268b8a7b0e6239",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013386fd6c",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x1b29f05bec5dc407"
+	},
+
+ "DifficultyTest249" : {
+		"parentTimestamp" : "0x038764037e",
+		"parentDifficulty" : "0x3fe2c3e703b51011",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0387640382",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x3feac03f809586b7"
+	},
+
+ "DifficultyTest250" : {
+		"parentTimestamp" : "0x045103e725",
+		"parentDifficulty" : "0x2b86366b270218fe",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045103e729",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x2b8ba731f466f949"
+	},
+
+ "DifficultyTest251" : {
+		"parentTimestamp" : "0x01abad773b",
+		"parentDifficulty" : "0x04392094b5d7da13",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01abad773f",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x0439a7b8c86e951e"
+	},
+
+ "DifficultyTest252" : {
+		"parentTimestamp" : "0x03a7e5159a",
+		"parentDifficulty" : "0x5d6d6781da5439f7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03a7e5159e",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x5d79152eca8f849e"
+	},
+
+ "DifficultyTest253" : {
+		"parentTimestamp" : "0x06a5928a51",
+		"parentDifficulty" : "0x11eb40fa28507322",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06a5928a55",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x11ed7e6247957d70"
+	},
+
+ "DifficultyTest254" : {
+		"parentTimestamp" : "0xe3662195",
+		"parentDifficulty" : "0x09b16e8325ebbddd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xe3662199",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x09b2a4b0f6507bd4"
+	},
+
+ "DifficultyTest255" : {
+		"parentTimestamp" : "0x069782bf79",
+		"parentDifficulty" : "0x7ffb29792e3e9818",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x069782bf7d",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x800b28de5d6460eb"
+	},
+
+ "DifficultyTest256" : {
+		"parentTimestamp" : "0x0663980767",
+		"parentDifficulty" : "0x5bdfd6562dfa95d2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x066398076b",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x5beb5250f8c05724"
+	},
+
+ "DifficultyTest257" : {
+		"parentTimestamp" : "0x049f4fbf18",
+		"parentDifficulty" : "0x59f9fcbd16159450",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x049f4fbf1c",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x5a053bfcadb85b02"
+	},
+
+ "DifficultyTest258" : {
+		"parentTimestamp" : "0x02175913f6",
+		"parentDifficulty" : "0x1e681587d27250b7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02175913fa",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x1e6be28a836ca701"
+	},
+
+ "DifficultyTest259" : {
+		"parentTimestamp" : "0xb9a36c69",
+		"parentDifficulty" : "0x16264265fbcc1882",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xb9a36c6d",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x1629072e488ba205"
+	},
+
+ "DifficultyTest260" : {
+		"parentTimestamp" : "0x0151b63d3d",
+		"parentDifficulty" : "0x6eb13b784092f0d2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0151b63d41",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x6ebf119faf9b2330"
+	},
+
+ "DifficultyTest261" : {
+		"parentTimestamp" : "0x0646713f09",
+		"parentDifficulty" : "0x03334348f0d5e562",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0646713f0d",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x0333a9b159f4401e"
+	},
+
+ "DifficultyTest262" : {
+		"parentTimestamp" : "0x0793ff5238",
+		"parentDifficulty" : "0x5bc2b3613cfc29c0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0793ff523c",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x5bd9a40e154b68ca"
+	},
+
+ "DifficultyTest263" : {
+		"parentTimestamp" : "0x0610a07402",
+		"parentDifficulty" : "0x47f84b6394fb4f46",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0610a07406",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x480a49766de08e18"
+	},
+
+ "DifficultyTest264" : {
+		"parentTimestamp" : "0x04b4c144da",
+		"parentDifficulty" : "0x4dac96f7f374807d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04b4c144de",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4dc0021db1715d9d"
+	},
+
+ "DifficultyTest265" : {
+		"parentTimestamp" : "0x06c0ceaf02",
+		"parentDifficulty" : "0x769ff66115b6b511",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c0ceaf06",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x76bd9e5eadfc22bd"
+	},
+
+ "DifficultyTest266" : {
+		"parentTimestamp" : "0x01c88c19a5",
+		"parentDifficulty" : "0x3eb43681e1452e22",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c88c19a9",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x3ec3e38f81bd7f6c"
+	},
+
+ "DifficultyTest267" : {
+		"parentTimestamp" : "0x01ad0c0048",
+		"parentDifficulty" : "0x3bed9f1eeb5665c7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ad0c004c",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x3bfc9a86b3113b5f"
+	},
+
+ "DifficultyTest268" : {
+		"parentTimestamp" : "0x7c6bcd97",
+		"parentDifficulty" : "0x5e0d440ded69ba35",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7c6bcd9b",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x5e24c75ef0e514a3"
+	},
+
+ "DifficultyTest269" : {
+		"parentTimestamp" : "0x072ffab43b",
+		"parentDifficulty" : "0x1e1fe65141c4cb70",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x072ffab43f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x1e276e4ad6153ca2"
+	},
+
+ "DifficultyTest270" : {
+		"parentTimestamp" : "0x0234da0e4a",
+		"parentDifficulty" : "0x3ecb7db182d6fd4f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0234da0e4e",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x3edb3090ef37b30d"
+	},
+
+ "DifficultyTest271" : {
+		"parentTimestamp" : "0x062f8b620f",
+		"parentDifficulty" : "0x235d049f5385b480",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x062f8b6213",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x2365dbe07b5a95ec"
+	},
+
+ "DifficultyTest272" : {
+		"parentTimestamp" : "0x2cd54efd",
+		"parentDifficulty" : "0x64fd4a6f4f5f856e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x2cd54f01",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x651689c1eb335d4e"
+	},
+
+ "DifficultyTest273" : {
+		"parentTimestamp" : "0x6c447112",
+		"parentDifficulty" : "0x4e8db4611d7b209c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x6c447116",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x4ea157ce35c27f64"
+	},
+
+ "DifficultyTest274" : {
+		"parentTimestamp" : "0x04fe4b2c79",
+		"parentDifficulty" : "0x4d08e39b2e9a5198",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04fe4b2c7d",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x4d1c25d41565f82c"
+	},
+
+ "DifficultyTest275" : {
+		"parentTimestamp" : "0x044548ea50",
+		"parentDifficulty" : "0x6bfb66fbd3ab6348",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x044548ea54",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x6c1665d592a04e20"
+	},
+
+ "DifficultyTest276" : {
+		"parentTimestamp" : "0x06d8350967",
+		"parentDifficulty" : "0x5f1702d4b8f1a1ec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06d835096b",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x5f2ec8956e1fde54"
+	},
+
+ "DifficultyTest277" : {
+		"parentTimestamp" : "0x0497c2cbe5",
+		"parentDifficulty" : "0x649c129b66cd1445",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0497c2cbe9",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x64b539a00da6c78a"
+	},
+
+ "DifficultyTest278" : {
+		"parentTimestamp" : "0x53f6c1dc",
+		"parentDifficulty" : "0x6e0c7637391e08a6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x53f6c1e0",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x6e27f954c6ec502a"
+	},
+
+ "DifficultyTest279" : {
+		"parentTimestamp" : "0x0326b08493",
+		"parentDifficulty" : "0x59c810e8fb494884",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0326b08497",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x59de82ed35881ada"
+	},
+
+ "DifficultyTest280" : {
+		"parentTimestamp" : "0x07221ac7e0",
+		"parentDifficulty" : "0x6aff4b10065cd20a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07221ac7e4",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x6b1a0ae2ca5e6946"
+	},
+
+ "DifficultyTest281" : {
+		"parentTimestamp" : "0x06e9c1c4ca",
+		"parentDifficulty" : "0x7a7292eeba89f244",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06e9c1c4ce",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x7a912f93763894d0"
+	},
+
+ "DifficultyTest282" : {
+		"parentTimestamp" : "0x06e765e905",
+		"parentDifficulty" : "0x338849b595c88b31",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06e765e909",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x33952bc8032dfd73"
+	},
+
+ "DifficultyTest283" : {
+		"parentTimestamp" : "0x065e6d377c",
+		"parentDifficulty" : "0x601b20861c239473",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x065e6d3780",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x6033274e3daa9d97"
+	},
+
+ "DifficultyTest284" : {
+		"parentTimestamp" : "0x013afa10fc",
+		"parentDifficulty" : "0x7581d99fbfbeb0a6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013afa1100",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x759f3a1627aea0d2"
+	},
+
+ "DifficultyTest285" : {
+		"parentTimestamp" : "0x0377f30f04",
+		"parentDifficulty" : "0x2f2410cd5acc7a3f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0377f30f08",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x2f2fd9d18e232e5d"
+	},
+
+ "DifficultyTest286" : {
+		"parentTimestamp" : "0x056dd33513",
+		"parentDifficulty" : "0x356ac18e1b7177c3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x056dd33517",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x35781c3e7ef8561f"
+	},
+
+ "DifficultyTest287" : {
+		"parentTimestamp" : "0xd5503d90",
+		"parentDifficulty" : "0x5d2c0c861ec677e0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xd5503d94",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x5d435789404e2d7c"
+	},
+
+ "DifficultyTest288" : {
+		"parentTimestamp" : "0x02197a0168",
+		"parentDifficulty" : "0x3aa712e74fb9890d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02197a016c",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x3ab5bcac098d776f"
+	},
+
+ "DifficultyTest289" : {
+		"parentTimestamp" : "0x06e57132b7",
+		"parentDifficulty" : "0x1d1c2b7379f5bf68",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06e57132bb",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1d23727e56d43cd6"
+	},
+
+ "DifficultyTest290" : {
+		"parentTimestamp" : "0x064ab3a369",
+		"parentDifficulty" : "0x5c1578cd951dec59",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x064ab3a36d",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x5c2c7e2bc88333d3"
+	},
+
+ "DifficultyTest291" : {
+		"parentTimestamp" : "0x06d4a766a2",
+		"parentDifficulty" : "0x1b353f32e6f9738b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06d4a766a6",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x1b3c0c82b3b331e7"
+	},
+
+ "DifficultyTest292" : {
+		"parentTimestamp" : "0x04f6cc5d1b",
+		"parentDifficulty" : "0x2933a138ba09a647",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04f6cc5d1f",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x293dee21083828af"
+	},
+
+ "DifficultyTest293" : {
+		"parentTimestamp" : "0x066a7d3e1e",
+		"parentDifficulty" : "0x4cee32b505035f28",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x066a7d3e22",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x4d016e41b2449ffe"
+	},
+
+ "DifficultyTest294" : {
+		"parentTimestamp" : "0x0200d85b17",
+		"parentDifficulty" : "0x577dbdddbaf43009",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0200d85b1b",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x57939d4d3262ed15"
+	},
+
+ "DifficultyTest295" : {
+		"parentTimestamp" : "0xc2c3f940",
+		"parentDifficulty" : "0x75e40d56c5c8213b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xc2c3f946",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x75f2c9d870a0da3f"
+	},
+
+ "DifficultyTest296" : {
+		"parentTimestamp" : "0x070d2d694e",
+		"parentDifficulty" : "0x154d22149bcbf90e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x070d2d6954",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x154fcbb8de5f728e"
+	},
+
+ "DifficultyTest297" : {
+		"parentTimestamp" : "0x0760bc6031",
+		"parentDifficulty" : "0x5a2eea8607e85862",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0760bc6037",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x5a3a306358a9556f"
+	},
+
+ "DifficultyTest298" : {
+		"parentTimestamp" : "0xe953baa5",
+		"parentDifficulty" : "0x1fd84015f52c698b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xe953baab",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x1fdc3b1df7eb0f1c"
+	},
+
+ "DifficultyTest299" : {
+		"parentTimestamp" : "0x027c2c87aa",
+		"parentDifficulty" : "0x1e2d6ed1a0b236ba",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x027c2c87b0",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x1e31347f7ae64d08"
+	},
+
+ "DifficultyTest300" : {
+		"parentTimestamp" : "0x02cad3a047",
+		"parentDifficulty" : "0x7945892f5a85c9f0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02cad3a04d",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x7954b1e080711ab9"
+	},
+
+ "DifficultyTest301" : {
+		"parentTimestamp" : "0x0581976373",
+		"parentDifficulty" : "0x505eeb328bf6f638",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0581976379",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x5068f70ff2487536"
+	},
+
+ "DifficultyTest302" : {
+		"parentTimestamp" : "0x07dca1a45f",
+		"parentDifficulty" : "0x65036cd0c3e65daf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07dca1a465",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x65100d3e5dfedaba"
+	},
+
+ "DifficultyTest303" : {
+		"parentTimestamp" : "0x046dd0ea0e",
+		"parentDifficulty" : "0x22223479e995dd1f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046dd0ea14",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x222678c078d3105a"
+	},
+
+ "DifficultyTest304" : {
+		"parentTimestamp" : "0x032550c47c",
+		"parentDifficulty" : "0x10e9b45abec248b9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x032550c482",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x10ebd1914a1a2202"
+	},
+
+ "DifficultyTest305" : {
+		"parentTimestamp" : "0x0500390de8",
+		"parentDifficulty" : "0x59ff809ed4a8f55c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0500390dee",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x5a0ac08ee8838c7a"
+	},
+
+ "DifficultyTest306" : {
+		"parentTimestamp" : "0x07186d673e",
+		"parentDifficulty" : "0x5e355354185ce0c4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07186d6744",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x5e4119fe82dff060"
+	},
+
+ "DifficultyTest307" : {
+		"parentTimestamp" : "0x013c64a01a",
+		"parentDifficulty" : "0x237477003d09ccbb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x013c64a020",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x2378e58f1d1175f4"
+	},
+
+ "DifficultyTest308" : {
+		"parentTimestamp" : "0x020436d934",
+		"parentDifficulty" : "0x499d9371cc108ce1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x020436d93a",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x49a6c7243a4a1ef2"
+	},
+
+ "DifficultyTest309" : {
+		"parentTimestamp" : "0x06a278b4e8",
+		"parentDifficulty" : "0x1383d044b116f967",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06a278b4ee",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x138640beb9ad3c46"
+	},
+
+ "DifficultyTest310" : {
+		"parentTimestamp" : "0x064776c0ec",
+		"parentDifficulty" : "0x2b6baf4207035b3d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x064776c0f2",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x2b711cb7ef447ba8"
+	},
+
+ "DifficultyTest311" : {
+		"parentTimestamp" : "0x04e5f875d6",
+		"parentDifficulty" : "0x086b1efb8cd6b74f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04e5f875dc",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x086c2c5f6c485225"
+	},
+
+ "DifficultyTest312" : {
+		"parentTimestamp" : "0x0228aee8d3",
+		"parentDifficulty" : "0x21da432463c87909",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0228aee8d9",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x21de7e6cc854f218"
+	},
+
+ "DifficultyTest313" : {
+		"parentTimestamp" : "0x05ca5b695a",
+		"parentDifficulty" : "0x4a161fa5b738ae30",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ca5b6960",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4a1f6269abef9545"
+	},
+
+ "DifficultyTest314" : {
+		"parentTimestamp" : "0x0296ade9d3",
+		"parentDifficulty" : "0x352648c2dcef7f2f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0296ade9d9",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x352ced8bf54b1d1e"
+	},
+
+ "DifficultyTest315" : {
+		"parentTimestamp" : "0x0348118888",
+		"parentDifficulty" : "0x7b7991f4c1cdfc69",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x034811888e",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x7b89012700663628"
+	},
+
+ "DifficultyTest316" : {
+		"parentTimestamp" : "0x04cdf298d1",
+		"parentDifficulty" : "0x0fc23da2ab347217",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04cdf298d7",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x0fc435ea5f89d8a5"
+	},
+
+ "DifficultyTest317" : {
+		"parentTimestamp" : "0x0123b4a414",
+		"parentDifficulty" : "0x5bf39962fe6b79a1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0123b4a41a",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x5bff17d62acb4710"
+	},
+
+ "DifficultyTest318" : {
+		"parentTimestamp" : "0x032295a304",
+		"parentDifficulty" : "0x3d3769f694f47700",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x032295a30a",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x3d3f10e3d3c7158e"
+	},
+
+ "DifficultyTest319" : {
+		"parentTimestamp" : "0x0586044a9b",
+		"parentDifficulty" : "0x3b0c4ae05d05dac0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0586044aa1",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x3b13ac69b9117b7b"
+	},
+
+ "DifficultyTest320" : {
+		"parentTimestamp" : "0x03282a4c5b",
+		"parentDifficulty" : "0x03fe64baf5d479cd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03282a4c61",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x03fee4878d33345c"
+	},
+
+ "DifficultyTest321" : {
+		"parentTimestamp" : "0x0640c1a695",
+		"parentDifficulty" : "0x2c40505ae46e9e0b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0640c1a69b",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x2c45d864efcb2bde"
+	},
+
+ "DifficultyTest322" : {
+		"parentTimestamp" : "0x06e94073af",
+		"parentDifficulty" : "0x32bae68b9d848285",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06e94073b5",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x32c13de86ef83315"
+	},
+
+ "DifficultyTest323" : {
+		"parentTimestamp" : "0x07eb572f0f",
+		"parentDifficulty" : "0x09efc33c4c2ffb07",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07eb572f15",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x09f10134b3b98106"
+	},
+
+ "DifficultyTest324" : {
+		"parentTimestamp" : "0x06a9060672",
+		"parentDifficulty" : "0x792ed0c3912fa691",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06a9060678",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x793df69da9a1cc85"
+	},
+
+ "DifficultyTest325" : {
+		"parentTimestamp" : "0x01a0b79b4a",
+		"parentDifficulty" : "0x325e8e94d303d08b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01a0b79b50",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3264da66a59e3105"
+	},
+
+ "DifficultyTest326" : {
+		"parentTimestamp" : "0xc35995c1",
+		"parentDifficulty" : "0x2200bcddaf5bd3de",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xc35995c7",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x2204fcf54b11bf59"
+	},
+
+ "DifficultyTest327" : {
+		"parentTimestamp" : "0x04776e2a27",
+		"parentDifficulty" : "0x5f2342e3b937dd9b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04776e2a2d",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x5f2f274c15af0498"
+	},
+
+ "DifficultyTest328" : {
+		"parentTimestamp" : "0x0791a2aa38",
+		"parentDifficulty" : "0x184e0691e96a82a2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0791a2aa3e",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x18511052bba7aff6"
+	},
+
+ "DifficultyTest329" : {
+		"parentTimestamp" : "0x06dbb2a16c",
+		"parentDifficulty" : "0x1b8ae4a111a971e6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06dbb2a172",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x1b8e55fda5cba71c"
+	},
+
+ "DifficultyTest330" : {
+		"parentTimestamp" : "0x04ad02f490",
+		"parentDifficulty" : "0x6f83745473bad6d7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04ad02f496",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6f9164c2fe494e41"
+	},
+
+ "DifficultyTest331" : {
+		"parentTimestamp" : "0x03c9d1bfd5",
+		"parentDifficulty" : "0x6c0f6fac7c5c0f0c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03c9d1bfdb",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x6c1cf19a71eb9aad"
+	},
+
+ "DifficultyTest332" : {
+		"parentTimestamp" : "0x021759bf4f",
+		"parentDifficulty" : "0x661064fb323fa142",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x021759bf55",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x661d2707d1a5e976"
+	},
+
+ "DifficultyTest333" : {
+		"parentTimestamp" : "0x0406cfcfc8",
+		"parentDifficulty" : "0x67d7f9aa5054ff8c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0406cfcfce",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x67e4f4a9859f0aab"
+	},
+
+ "DifficultyTest334" : {
+		"parentTimestamp" : "0x05b8a38832",
+		"parentDifficulty" : "0x51896de1ded32f77",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b8a38838",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x51939f0f9b0f0adc"
+	},
+
+ "DifficultyTest335" : {
+		"parentTimestamp" : "0x07514b75ee",
+		"parentDifficulty" : "0x03458039956df7cd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07514b75f4",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x0345e8e99ca0a78b"
+	},
+
+ "DifficultyTest336" : {
+		"parentTimestamp" : "0x0549a7f336",
+		"parentDifficulty" : "0x4382c0d55d855d25",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0549a7f33c",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x438b312d783111d0"
+	},
+
+ "DifficultyTest337" : {
+		"parentTimestamp" : "0x077274f4d0",
+		"parentDifficulty" : "0x7766fd34d7d77648",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x077274f4d6",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x7775ea147e727136"
+	},
+
+ "DifficultyTest338" : {
+		"parentTimestamp" : "0x03e0320ba7",
+		"parentDifficulty" : "0x1494d5529ce41158",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e0320bad",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x149767ed4737adda"
+	},
+
+ "DifficultyTest339" : {
+		"parentTimestamp" : "0x06449be3de",
+		"parentDifficulty" : "0x56363d23b753b128",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06449be3e4",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x564103eb5bca9b9e"
+	},
+
+ "DifficultyTest340" : {
+		"parentTimestamp" : "0x032c1e3cc4",
+		"parentDifficulty" : "0x3c88e61aa88726ac",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x032c1e3cca",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x3c9077376bdc3790"
+	},
+
+ "DifficultyTest341" : {
+		"parentTimestamp" : "0x023d6b2525",
+		"parentDifficulty" : "0x03c9fa2a89e30190",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x023d6b252b",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x03ca7369cf343df0"
+	},
+
+ "DifficultyTest342" : {
+		"parentTimestamp" : "0x02f9003b7d",
+		"parentDifficulty" : "0x48a3c53293f8a338",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02f9003b83",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x48acd9ab3a4b224c"
+	},
+
+ "DifficultyTest343" : {
+		"parentTimestamp" : "0x028212f33e",
+		"parentDifficulty" : "0x7b3d54bece9cb66c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x028212f344",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x7b4cbc6966768a02"
+	},
+
+ "DifficultyTest344" : {
+		"parentTimestamp" : "0x02117e0d22",
+		"parentDifficulty" : "0x65b4426cecdd873a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02117e0d28",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x65c0f8f53a7b22ea"
+	},
+
+ "DifficultyTest345" : {
+		"parentTimestamp" : "0x0564e2b063",
+		"parentDifficulty" : "0x63541adcdf89cf65",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0564e2b069",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x636085603b25c09f"
+	},
+
+ "DifficultyTest346" : {
+		"parentTimestamp" : "0x02a998db4a",
+		"parentDifficulty" : "0x31dc1fe0223a78f1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02a998db50",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x31e25b641e3ec042"
+	},
+
+ "DifficultyTest347" : {
+		"parentTimestamp" : "0x070305ba2c",
+		"parentDifficulty" : "0x28cbc505e6520fea",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x070305ba32",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x28d0de7e870eda2f"
+	},
+
+ "DifficultyTest348" : {
+		"parentTimestamp" : "0x029fbff3c6",
+		"parentDifficulty" : "0x3ac255bb16b03d5c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029fbff3cc",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x3ac9ae05ce13136b"
+	},
+
+ "DifficultyTest349" : {
+		"parentTimestamp" : "0x0446709324",
+		"parentDifficulty" : "0x2f0add5a3084bff8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x044670932a",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x2f10beb5dbcad09f"
+	},
+
+ "DifficultyTest350" : {
+		"parentTimestamp" : "0x06c85a2280",
+		"parentDifficulty" : "0x5c20c08835bc2312",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c85a2286",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x5c2c44a046c2dab6"
+	},
+
+ "DifficultyTest351" : {
+		"parentTimestamp" : "0x04caeb7676",
+		"parentDifficulty" : "0x705eea341d7e64fe",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04caeb767c",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x706cf6116402150a"
+	},
+
+ "DifficultyTest352" : {
+		"parentTimestamp" : "0x0209cf509f",
+		"parentDifficulty" : "0x7c99649b060af3cb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0209cf50a5",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x7ca8f7c7996bb5a9"
+	},
+
+ "DifficultyTest353" : {
+		"parentTimestamp" : "0x02ff762719",
+		"parentDifficulty" : "0x31e0a5f29269d4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ff76271f",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x31e6e20750bd21"
+	},
+
+ "DifficultyTest354" : {
+		"parentTimestamp" : "0x06164f6db7",
+		"parentDifficulty" : "0x19df9540ec4ca608",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06164f6dbd",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x19e2d133946a319c"
+	},
+
+ "DifficultyTest355" : {
+		"parentTimestamp" : "0x0482a85cd7",
+		"parentDifficulty" : "0x3c532ba8eb937a65",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0482a85cdd",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x3c5ab60e60b0f0d4"
+	},
+
+ "DifficultyTest356" : {
+		"parentTimestamp" : "0x0736f61019",
+		"parentDifficulty" : "0x77b71ff3c134d717",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0736f6101f",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x77c616d7bfad05b1"
+	},
+
+ "DifficultyTest357" : {
+		"parentTimestamp" : "0x069c05ca90",
+		"parentDifficulty" : "0x385144062a846a0c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x069c05ca96",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x38584e2eab49ca99"
+	},
+
+ "DifficultyTest358" : {
+		"parentTimestamp" : "0x0408313bc4",
+		"parentDifficulty" : "0x1a4dc210d00ac4dd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0408313bca",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x1a510bc91224e635"
+	},
+
+ "DifficultyTest359" : {
+		"parentTimestamp" : "0x05e78d3c66",
+		"parentDifficulty" : "0x70d5b890a93bf833",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e78d3c6c",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x70e3d347bb515fb2"
+	},
+
+ "DifficultyTest360" : {
+		"parentTimestamp" : "0x018c8f7b31",
+		"parentDifficulty" : "0x5cacebb58364afcd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x018c8f7b37",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x5cc416f070c588f7"
+	},
+
+ "DifficultyTest361" : {
+		"parentTimestamp" : "0x06aaa9dad4",
+		"parentDifficulty" : "0x2573bc67ac708069",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06aaa9dada",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x257d1956c65b9c89"
+	},
+
+ "DifficultyTest362" : {
+		"parentTimestamp" : "0x04d3077457",
+		"parentDifficulty" : "0x4e6786518754d402",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04d307745d",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4e7b20331bb6a936"
+	},
+
+ "DifficultyTest363" : {
+		"parentTimestamp" : "0x0725dce519",
+		"parentDifficulty" : "0x502a6d0b00ffc06a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0725dce51f",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x503e77a643c0005a"
+	},
+
+ "DifficultyTest364" : {
+		"parentTimestamp" : "0x02a45f19e5",
+		"parentDifficulty" : "0x02f6112fc1c99644",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02a45f19eb",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x02f6ceb40dba08a8"
+	},
+
+ "DifficultyTest365" : {
+		"parentTimestamp" : "0x019853d358",
+		"parentDifficulty" : "0x3b95ca97549f85ea",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x019853d35e",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x3ba4b009fa74adca"
+	},
+
+ "DifficultyTest366" : {
+		"parentTimestamp" : "0x0676b26a0f",
+		"parentDifficulty" : "0x1323ad8e877ecd7b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0676b26a15",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x13287679eb20ad2d"
+	},
+
+ "DifficultyTest367" : {
+		"parentTimestamp" : "0x03cf71a12b",
+		"parentDifficulty" : "0x5ea3d76344738480",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03cf71a131",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x5ebb80591d44a160"
+	},
+
+ "DifficultyTest368" : {
+		"parentTimestamp" : "0x066de49092",
+		"parentDifficulty" : "0x2ac7a94660c2fffd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x066de49098",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x2ad25b30b25b30bb"
+	},
+
+ "DifficultyTest369" : {
+		"parentTimestamp" : "0x0716ba392a",
+		"parentDifficulty" : "0x3e5d2a7500c783fc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0716ba3930",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x3e6cc1bf9e07b5dc"
+	},
+
+ "DifficultyTest370" : {
+		"parentTimestamp" : "0x07cc6e93b6",
+		"parentDifficulty" : "0x4f24c2a83ffb3070",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07cc6e93bc",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x4f388bd8ea0b2f3c"
+	},
+
+ "DifficultyTest371" : {
+		"parentTimestamp" : "0x99115658",
+		"parentDifficulty" : "0x571c9a82d1e83ac1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9911565e",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x573261a9729cb4cf"
+	},
+
+ "DifficultyTest372" : {
+		"parentTimestamp" : "0x02cb94d2fb",
+		"parentDifficulty" : "0x32211e7986cd4ea8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cb94d301",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x322da6c1252f01fa"
+	},
+
+ "DifficultyTest373" : {
+		"parentTimestamp" : "0x01e22e5d6f",
+		"parentDifficulty" : "0x183e11d5b0fa04d7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e22e5d75",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x1844215a26664357"
+	},
+
+ "DifficultyTest374" : {
+		"parentTimestamp" : "0x7252f671",
+		"parentDifficulty" : "0x187040f88e53cadf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7252f677",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x18765d08cc775fd1"
+	},
+
+ "DifficultyTest375" : {
+		"parentTimestamp" : "0x03696124be",
+		"parentDifficulty" : "0x2e6b31b6a1c89b44",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03696124c4",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x2e76cc830f710d6b"
+	},
+
+ "DifficultyTest376" : {
+		"parentTimestamp" : "0x06ba8c2f71",
+		"parentDifficulty" : "0x709480846afbe598",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06ba8c2f77",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x70b0a5a48c16a492"
+	},
+
+ "DifficultyTest377" : {
+		"parentTimestamp" : "0x073c5895c6",
+		"parentDifficulty" : "0x5a155dc37a119346",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x073c5895cc",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x5a2be31aeaf017ae"
+	},
+
+ "DifficultyTest378" : {
+		"parentTimestamp" : "0x02ae2cbf95",
+		"parentDifficulty" : "0x36404770a6933ec1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ae2cbf9b",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x364dd78282bce397"
+	},
+
+ "DifficultyTest379" : {
+		"parentTimestamp" : "0xa7b483ce",
+		"parentDifficulty" : "0x38eaf61ce45aeb33",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xa7b483d4",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x38f930da6b9401fd"
+	},
+
+ "DifficultyTest380" : {
+		"parentTimestamp" : "0x06bf0b3261",
+		"parentDifficulty" : "0x079858005df48ca4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06bf0b3267",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x079a3e165e0c09e6"
+	},
+
+ "DifficultyTest381" : {
+		"parentTimestamp" : "0x04fc8ff875",
+		"parentDifficulty" : "0x36b8788e1a0ddf56",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04fc8ff87b",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x36c626ac3d94630c"
+	},
+
+ "DifficultyTest382" : {
+		"parentTimestamp" : "0x01748a0bdb",
+		"parentDifficulty" : "0x0431bb3dc9417b63",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01748a0be1",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x0432c7ac98b3cc41"
+	},
+
+ "DifficultyTest383" : {
+		"parentTimestamp" : "0x05b15ee5a1",
+		"parentDifficulty" : "0x7d998399cb90a7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05b15ee5a7",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x7db8e9fab2048b"
+	},
+
+ "DifficultyTest384" : {
+		"parentTimestamp" : "0x0631916184",
+		"parentDifficulty" : "0x5303bcc70e8fe763",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x063191618a",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x53187db640538d5b"
+	},
+
+ "DifficultyTest385" : {
+		"parentTimestamp" : "0x0474132470",
+		"parentDifficulty" : "0x41ad036c6c4bb634",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0474132476",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x41bd6ead4766cd20"
+	},
+
+ "DifficultyTest386" : {
+		"parentTimestamp" : "0x023b5dbfe2",
+		"parentDifficulty" : "0x44e8703983abe112",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x023b5dbfe8",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x44f9aa55920ccc0a"
+	},
+
+ "DifficultyTest387" : {
+		"parentTimestamp" : "0x059090dd61",
+		"parentDifficulty" : "0x2778620e04480554",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x059090dd67",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x2782402687c91754"
+	},
+
+ "DifficultyTest388" : {
+		"parentTimestamp" : "0x070a413789",
+		"parentDifficulty" : "0x62b1264c1b461e92",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x070a41378f",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x62c9d295ae4cf018"
+	},
+
+ "DifficultyTest389" : {
+		"parentTimestamp" : "0x629bc809",
+		"parentDifficulty" : "0x0ae81a3b23be92cf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x629bc80f",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x0aead441b2878273"
+	},
+
+ "DifficultyTest390" : {
+		"parentTimestamp" : "0x07d166367d",
+		"parentDifficulty" : "0x5df7f2130a5f9943",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07d1663683",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x5e0f700f8f223129"
+	},
+
+ "DifficultyTest391" : {
+		"parentTimestamp" : "0x05c99c6556",
+		"parentDifficulty" : "0x0fffc2dfa2c8ddf1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05c99c655c",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x1003c2d05ab19027"
+	},
+
+ "DifficultyTest392" : {
+		"parentTimestamp" : "0x03ca5732e8",
+		"parentDifficulty" : "0x47aff1072dc82793",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ca5732ee",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x47c1dd036f93999b"
+	},
+
+ "DifficultyTest393" : {
+		"parentTimestamp" : "0x01c1a2a76f",
+		"parentDifficulty" : "0x03e37976d4e4ac60",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01c1a2a777",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x03e3f5e603bf48f5"
+	},
+
+ "DifficultyTest394" : {
+		"parentTimestamp" : "0x04be587f5e",
+		"parentDifficulty" : "0x1d85aa6e9c49cd74",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04be587f66",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x1d895b23ea1d56ae"
+	},
+
+ "DifficultyTest395" : {
+		"parentTimestamp" : "0x0441accf5b",
+		"parentDifficulty" : "0x3fabdc851b0bf383",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0441accf63",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x3fb3d200abaf5503"
+	},
+
+ "DifficultyTest396" : {
+		"parentTimestamp" : "0x039a16b6aa",
+		"parentDifficulty" : "0x51ccdf24a2056fc8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x039a16b6b2",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x51d718c08699b079"
+	},
+
+ "DifficultyTest397" : {
+		"parentTimestamp" : "0x06d055aa29",
+		"parentDifficulty" : "0x44ef725031051671",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06d055aa31",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x44f8103e7b0b371b"
+	},
+
+ "DifficultyTest398" : {
+		"parentTimestamp" : "0x050a0983e2",
+		"parentDifficulty" : "0x064548ad03dd7205",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x050a0983ea",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x06461156197dedc3"
+	},
+
+ "DifficultyTest399" : {
+		"parentTimestamp" : "0x01649ceb1d",
+		"parentDifficulty" : "0x633fbb46a98b66b8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01649ceb25",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x634c233e12609844"
+	},
+
+ "DifficultyTest400" : {
+		"parentTimestamp" : "0x06081578a6",
+		"parentDifficulty" : "0x586b02be82bf5de8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06081578ae",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x5876101eda8fb613"
+	},
+
+ "DifficultyTest401" : {
+		"parentTimestamp" : "0x0397f28253",
+		"parentDifficulty" : "0x1b97a4d511d68bca",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0397f2825b",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x1b9b17c9ac78c71b"
+	},
+
+ "DifficultyTest402" : {
+		"parentTimestamp" : "0x07b93985d5",
+		"parentDifficulty" : "0x44bbc33b59512403",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07b93985dd",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x44c45ab3c0bc4f27"
+	},
+
+ "DifficultyTest403" : {
+		"parentTimestamp" : "0x04c0090ed2",
+		"parentDifficulty" : "0x3be19703aefbc71c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c0090eda",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x3be913368f71a894"
+	},
+
+ "DifficultyTest404" : {
+		"parentTimestamp" : "0x0258823359",
+		"parentDifficulty" : "0x71d028918075f524",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0258823361",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x71de629692a607e2"
+	},
+
+ "DifficultyTest405" : {
+		"parentTimestamp" : "0x04fb71c38d",
+		"parentDifficulty" : "0x3b5c8d713f6f430d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04fb71c395",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x3b63f902ed9738f5"
+	},
+
+ "DifficultyTest406" : {
+		"parentTimestamp" : "0x069630128e",
+		"parentDifficulty" : "0x7cea811a373ff68b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0696301296",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x7cfa1e6a5a86ee89"
+	},
+
+ "DifficultyTest407" : {
+		"parentTimestamp" : "0x06cceb2299",
+		"parentDifficulty" : "0x67e7fe4810f66ce1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06cceb22a1",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x67f4fb47d9f8abae"
+	},
+
+ "DifficultyTest408" : {
+		"parentTimestamp" : "0x01ba7e978a",
+		"parentDifficulty" : "0x16de9665226def95",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01ba7e9792",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x16e17237ef127d52"
+	},
+
+ "DifficultyTest409" : {
+		"parentTimestamp" : "0x022c3419f2",
+		"parentDifficulty" : "0x5680dff1cacdca72",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x022c3419fa",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x568bb00dc907242b"
+	},
+
+ "DifficultyTest410" : {
+		"parentTimestamp" : "0x04831da0a7",
+		"parentDifficulty" : "0x77a2dbbbe47b0041",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04831da0af",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x77b1d0175bf78fa1"
+	},
+
+ "DifficultyTest411" : {
+		"parentTimestamp" : "0x043bae777e",
+		"parentDifficulty" : "0x6dc0319181df178f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x043bae7786",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x6dcde997b40f5371"
+	},
+
+ "DifficultyTest412" : {
+		"parentTimestamp" : "0x044ccf0b6f",
+		"parentDifficulty" : "0x69fad5a7ea99ce0a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044ccf0b77",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6a0815029f972143"
+	},
+
+ "DifficultyTest413" : {
+		"parentTimestamp" : "0x05f65e69ad",
+		"parentDifficulty" : "0x450f702329268a88",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f65e69b5",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x451812112d8baf59"
+	},
+
+ "DifficultyTest414" : {
+		"parentTimestamp" : "0x04852b7a94",
+		"parentDifficulty" : "0x0559a8a3b4f26042",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04852b7a9c",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x055a53d8c968fe8e"
+	},
+
+ "DifficultyTest415" : {
+		"parentTimestamp" : "0x036e7ebdf2",
+		"parentDifficulty" : "0x36470d54f71ce9e4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x036e7ebdfa",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x364dd636a1bbcd81"
+	},
+
+ "DifficultyTest416" : {
+		"parentTimestamp" : "0x06807e37b8",
+		"parentDifficulty" : "0x595ad18d2a136f4f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06807e37c0",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x5965fce75bb8b1bc"
+	},
+
+ "DifficultyTest417" : {
+		"parentTimestamp" : "0x37958853",
+		"parentDifficulty" : "0x6cd799c642bce60e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x3795885b",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x6ce534b97b853daa"
+	},
+
+ "DifficultyTest418" : {
+		"parentTimestamp" : "0x044dea7755",
+		"parentDifficulty" : "0x340d65101cba70c9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044dea775d",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x3413e6bcbebe0817"
+	},
+
+ "DifficultyTest419" : {
+		"parentTimestamp" : "0x041ba0ffef",
+		"parentDifficulty" : "0x5c94927f842d5b80",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x041ba0fff7",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x5ca02511d41de12b"
+	},
+
+ "DifficultyTest420" : {
+		"parentTimestamp" : "0x05d11c82f2",
+		"parentDifficulty" : "0x4ce0c38a8027f38f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d11c82fa",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x4cea5fa2f177f88d"
+	},
+
+ "DifficultyTest421" : {
+		"parentTimestamp" : "0x05ebbf4865",
+		"parentDifficulty" : "0x08ecbfb19e4bb42d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ebbf486d",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x08eddd49947f7da3"
+	},
+
+ "DifficultyTest422" : {
+		"parentTimestamp" : "0x6f8c666a",
+		"parentDifficulty" : "0x1144f39188038314",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6f8c6672",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x11471c2ffa348384"
+	},
+
+ "DifficultyTest423" : {
+		"parentTimestamp" : "0x02e93365e4",
+		"parentDifficulty" : "0x4f9cc80e7fac98a2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e93365ec",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x4fa6bba7817c8e35"
+	},
+
+ "DifficultyTest424" : {
+		"parentTimestamp" : "0x74b79bf9",
+		"parentDifficulty" : "0x26c6da5bf274cdea",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x74b79c01",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x26cbb3373df31c84"
+	},
+
+ "DifficultyTest425" : {
+		"parentTimestamp" : "0x02da8ac48b",
+		"parentDifficulty" : "0x09c95df9ddcd3900",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02da8ac493",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x09ca97259d08f2a9"
+	},
+
+ "DifficultyTest426" : {
+		"parentTimestamp" : "0x01aa74ae3a",
+		"parentDifficulty" : "0x3391b5fd4b30be4c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01aa74ae42",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x339828340ada2467"
+	},
+
+ "DifficultyTest427" : {
+		"parentTimestamp" : "0x03fc49f274",
+		"parentDifficulty" : "0x06bfd8c862896ac2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03fc49f27c",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x06c0b0c37b95bbf7"
+	},
+
+ "DifficultyTest428" : {
+		"parentTimestamp" : "0x05f46b6f6a",
+		"parentDifficulty" : "0x52bf67f3b9ea3c58",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f46b6f72",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x52c9bfe0b86179af"
+	},
+
+ "DifficultyTest429" : {
+		"parentTimestamp" : "0x04e65978ea",
+		"parentDifficulty" : "0x687d0114447f1339",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04e65978f2",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x688a10b46707a33b"
+	},
+
+ "DifficultyTest430" : {
+		"parentTimestamp" : "0x070b10477f",
+		"parentDifficulty" : "0x28d25a06a69648ea",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x070b104787",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x28d77451e76b1bf3"
+	},
+
+ "DifficultyTest431" : {
+		"parentTimestamp" : "0x03e071f14b",
+		"parentDifficulty" : "0x1a06a56f042ddeb8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e071f153",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x1a09e643b20e64f3"
+	},
+
+ "DifficultyTest432" : {
+		"parentTimestamp" : "0x025f0f0530",
+		"parentDifficulty" : "0x0cf8daa9008bd75f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x025f0f0538",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x0cfa79c455abe9d9"
+	},
+
+ "DifficultyTest433" : {
+		"parentTimestamp" : "0x0642c65b3b",
+		"parentDifficulty" : "0x5be1755c3c093fc3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0642c65b43",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x5becf18ae790c2ea"
+	},
+
+ "DifficultyTest434" : {
+		"parentTimestamp" : "0x04ffa8c8ec",
+		"parentDifficulty" : "0x353e03bf9d355a68",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04ffa8c8f4",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x3544ab8015290513"
+	},
+
+ "DifficultyTest435" : {
+		"parentTimestamp" : "0x03869d143f",
+		"parentDifficulty" : "0x22d456fa12944b30",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03869d1447",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x22d8b184f1d69db9"
+	},
+
+ "DifficultyTest436" : {
+		"parentTimestamp" : "0x053bdc37df",
+		"parentDifficulty" : "0x2a4adf09646bbd02",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x053bdc37e7",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x2a50286545984a79"
+	},
+
+ "DifficultyTest437" : {
+		"parentTimestamp" : "0x06ea7a40a4",
+		"parentDifficulty" : "0x6254fcbffb066f9f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ea7a40ac",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x6261475f9305d06c"
+	},
+
+ "DifficultyTest438" : {
+		"parentTimestamp" : "0x049f225783",
+		"parentDifficulty" : "0x2f4e89a293a12d0e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x049f22578b",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x2f547373c7f3a133"
+	},
+
+ "DifficultyTest439" : {
+		"parentTimestamp" : "0x01c76bd671",
+		"parentDifficulty" : "0x48644be28893b3ee",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01c76bd679",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x486d586c04e4c664"
+	},
+
+ "DifficultyTest440" : {
+		"parentTimestamp" : "0x02e97af6e1",
+		"parentDifficulty" : "0x5203661a389e23c3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e97af6e9",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x520da686fbe53787"
+	},
+
+ "DifficultyTest441" : {
+		"parentTimestamp" : "0x051cc8eb2f",
+		"parentDifficulty" : "0x313cfa98c0628831",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051cc8eb37",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x31432238137a9482"
+	},
+
+ "DifficultyTest442" : {
+		"parentTimestamp" : "0x06e09c748d",
+		"parentDifficulty" : "0x2907b696bfa56960",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06e09c7495",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x290cd78d927d5e0d"
+	},
+
+ "DifficultyTest443" : {
+		"parentTimestamp" : "0x05a390b36a",
+		"parentDifficulty" : "0x5e360a9756914e4c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05a390b372",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x5e41d158a97c2076"
+	},
+
+ "DifficultyTest444" : {
+		"parentTimestamp" : "0x059751cd4f",
+		"parentDifficulty" : "0x25e9816b49e21631",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x059751cd57",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x25ee3e9b774b5275"
+	},
+
+ "DifficultyTest445" : {
+		"parentTimestamp" : "0x02ebd0b850",
+		"parentDifficulty" : "0x3451ad9493bfbe6a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ebd0b858",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x345837ca46523665"
+	},
+
+ "DifficultyTest446" : {
+		"parentTimestamp" : "0x4e1b619e",
+		"parentDifficulty" : "0x017506caee786670",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x4e1b61a6",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x0175356bc7d63584"
+	},
+
+ "DifficultyTest447" : {
+		"parentTimestamp" : "0x026e8c9aaa",
+		"parentDifficulty" : "0x68f10e8c3b61fa74",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x026e8c9ab2",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x68fe2cae0ce966c3"
+	},
+
+ "DifficultyTest448" : {
+		"parentTimestamp" : "0x0223991513",
+		"parentDifficulty" : "0xad63ee9a347b90",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x022399151b",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0xad799b1807c23f"
+	},
+
+ "DifficultyTest449" : {
+		"parentTimestamp" : "0x07e74d0b35",
+		"parentDifficulty" : "0x5060deac2a24aff8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e74d0b3d",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x506aeac7ffa9f4cd"
+	},
+
+ "DifficultyTest450" : {
+		"parentTimestamp" : "0x03666d8201",
+		"parentDifficulty" : "0x1febaa719aa9eb2e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03666d8209",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x1fefa7e6e8dd40eb"
+	},
+
+ "DifficultyTest451" : {
+		"parentTimestamp" : "0x061e5e9341",
+		"parentDifficulty" : "0x1be592a5caec34ee",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061e5e9349",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x1be90f581fa59374"
+	},
+
+ "DifficultyTest452" : {
+		"parentTimestamp" : "0x06c3bd6977",
+		"parentDifficulty" : "0x4f35fb2b366e2201",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c3bd697f",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x4f3fe1ea9bd4f1c5"
+	},
+
+ "DifficultyTest453" : {
+		"parentTimestamp" : "0xb6cdfaee",
+		"parentDifficulty" : "0x67ce07c2d43850f8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xb6cdfaf6",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x67db0183cc92dc02"
+	},
+
+ "DifficultyTest454" : {
+		"parentTimestamp" : "0x4ec20664",
+		"parentDifficulty" : "0x4fa7395895fc2507",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x4ec2066c",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x4fb12e3fc10eec8b"
+	},
+
+ "DifficultyTest455" : {
+		"parentTimestamp" : "0xb029971e",
+		"parentDifficulty" : "0x7dfcf9111a360eab",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xb0299726",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x7e0cb8b03c59656c"
+	},
+
+ "DifficultyTest456" : {
+		"parentTimestamp" : "0x0354d00679",
+		"parentDifficulty" : "0x3754b29d3d0fbfbf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0354d00681",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x375b9d3390b781b6"
+	},
+
+ "DifficultyTest457" : {
+		"parentTimestamp" : "0x061835d62a",
+		"parentDifficulty" : "0x3270cc4c8785c6b4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061835d632",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x32771a661116f76c"
+	},
+
+ "DifficultyTest458" : {
+		"parentTimestamp" : "0x07dea6c5a9",
+		"parentDifficulty" : "0x090d89a999f0885c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07dea6c5b1",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x090fcd0c0457047e"
+	},
+
+ "DifficultyTest459" : {
+		"parentTimestamp" : "0x07210fcfb4",
+		"parentDifficulty" : "0x40085cb7f69b8d70",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07210fcfbc",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x40185ecf24993452"
+	},
+
+ "DifficultyTest460" : {
+		"parentTimestamp" : "0x077d693df9",
+		"parentDifficulty" : "0x1564952b699f35ad",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x077d693e01",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x1569ee50b4799d79"
+	},
+
+ "DifficultyTest461" : {
+		"parentTimestamp" : "0x07bfebafb8",
+		"parentDifficulty" : "0x235c8efa2ff06e8b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07bfebafc0",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x2365661dee7c6aa5"
+	},
+
+ "DifficultyTest462" : {
+		"parentTimestamp" : "0x076cf71c33",
+		"parentDifficulty" : "0x44390f007b765270",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x076cf71c3b",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x444a1d443b953004"
+	},
+
+ "DifficultyTest463" : {
+		"parentTimestamp" : "0x03f957e0b5",
+		"parentDifficulty" : "0x06b344c74d45cd3e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03f957e0bd",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x06b4f1987f191eb0"
+	},
+
+ "DifficultyTest464" : {
+		"parentTimestamp" : "0x06bb19fb19",
+		"parentDifficulty" : "0x4893511a8b9efef7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06bb19fb21",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x48a575eed241e6b5"
+	},
+
+ "DifficultyTest465" : {
+		"parentTimestamp" : "0x025a6fbf01",
+		"parentDifficulty" : "0x17498ba35e372c77",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x025a6fbf09",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x174f5e06470eba41"
+	},
+
+ "DifficultyTest466" : {
+		"parentTimestamp" : "0x061b4c5217",
+		"parentDifficulty" : "0x3b2a0457ab9be0da",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061b4c521f",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x3b38ced8c186c7d2"
+	},
+
+ "DifficultyTest467" : {
+		"parentTimestamp" : "0x07a9681b03",
+		"parentDifficulty" : "0x1b20eb6e35201f95",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a9681b0b",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x1b27b3a910ad679b"
+	},
+
+ "DifficultyTest468" : {
+		"parentTimestamp" : "0x03e1ce8553",
+		"parentDifficulty" : "0x3d14e20be62d6632",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03e1ce855b",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x3d2427446926f18a"
+	},
+
+ "DifficultyTest469" : {
+		"parentTimestamp" : "0x02761ef196",
+		"parentDifficulty" : "0x320a23473ae5930a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02761ef19e",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x3216a5d00cb44c6e"
+	},
+
+ "DifficultyTest470" : {
+		"parentTimestamp" : "0x0502b3d964",
+		"parentDifficulty" : "0x793deccf2bb77b2a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0502b3d96c",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x795c3c4a5f826908"
+	},
+
+ "DifficultyTest471" : {
+		"parentTimestamp" : "0x04f581bab5",
+		"parentDifficulty" : "0x1f6acc3c850737c9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04f581babd",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x1f72a6ef94287995"
+	},
+
+ "DifficultyTest472" : {
+		"parentTimestamp" : "0x02a899b52d",
+		"parentDifficulty" : "0x6e14bafc322ef160",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02a899b535",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x6e30402af13b7d1c"
+	},
+
+ "DifficultyTest473" : {
+		"parentTimestamp" : "0x0395c684d4",
+		"parentDifficulty" : "0x7b29cd792e5d7d6b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0395c684dc",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x7b4897ec8ca914ca"
+	},
+
+ "DifficultyTest474" : {
+		"parentTimestamp" : "0x029f3bc9b5",
+		"parentDifficulty" : "0x7c88a1cc8dbe6aed",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029f3bc9bd",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x7ca7c3f500e1da89"
+	},
+
+ "DifficultyTest475" : {
+		"parentTimestamp" : "0x01282f89e4",
+		"parentDifficulty" : "0x3083b8b0c1f1185f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01282f89ec",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x308fd99eee2194a9"
+	},
+
+ "DifficultyTest476" : {
+		"parentTimestamp" : "0x9d1c31fc",
+		"parentDifficulty" : "0x488a7a72cc6a0a32",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9d1c3204",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x489c9d11691d24bc"
+	},
+
+ "DifficultyTest477" : {
+		"parentTimestamp" : "0x059a894c7d",
+		"parentDifficulty" : "0x59a373aaf4c57834",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x059a894c85",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x59b9dc87df82a9a2"
+	},
+
+ "DifficultyTest478" : {
+		"parentTimestamp" : "0x02f1f2a0f9",
+		"parentDifficulty" : "0x3ff2cdf272b112c6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f1f2a101",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x4002caa5ef4dbf2a"
+	},
+
+ "DifficultyTest479" : {
+		"parentTimestamp" : "0x03e0a9c5f7",
+		"parentDifficulty" : "0x4296b83c677d564f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03e0a9c5ff",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x42a75dea769735e3"
+	},
+
+ "DifficultyTest480" : {
+		"parentTimestamp" : "0x01e22fc230",
+		"parentDifficulty" : "0x0efcdcd4455b7e30",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e22fc238",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x0f009c0b7a6cd58e"
+	},
+
+ "DifficultyTest481" : {
+		"parentTimestamp" : "0x02372d3927",
+		"parentDifficulty" : "0x79946f5c37eb2942",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02372d392f",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x79b2d4780ef9250c"
+	},
+
+ "DifficultyTest482" : {
+		"parentTimestamp" : "0x0409d68589",
+		"parentDifficulty" : "0x5a126d209135e6f9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0409d68591",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x5a28f1bbd95a3671"
+	},
+
+ "DifficultyTest483" : {
+		"parentTimestamp" : "0x0232d4bbbf",
+		"parentDifficulty" : "0x048e2b90b7350755",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0232d4bbc7",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x048f4f1b9b62d895"
+	},
+
+ "DifficultyTest484" : {
+		"parentTimestamp" : "0x05bf322285",
+		"parentDifficulty" : "0x3f90198ca0d5014f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05bf32228d",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x3f9ffd9303fd368f"
+	},
+
+ "DifficultyTest485" : {
+		"parentTimestamp" : "0x062b6024e5",
+		"parentDifficulty" : "0x183c6a20528969aa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x062b6024ed",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1842793ada9e0c04"
+	},
+
+ "DifficultyTest486" : {
+		"parentTimestamp" : "0x046e30ed32",
+		"parentDifficulty" : "0x4c823a57d5b59c51",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x046e30ed3a",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x4c955ae66bab09b7"
+	},
+
+ "DifficultyTest487" : {
+		"parentTimestamp" : "0x0135c5ba7a",
+		"parentDifficulty" : "0x592bdc5c9e0c4472",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0135c5ba82",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x59422753b533c782"
+	},
+
+ "DifficultyTest488" : {
+		"parentTimestamp" : "0x043481bc95",
+		"parentDifficulty" : "0x333e9f0388ce1aa2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x043481bc9d",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x334b6eab49b04e28"
+	},
+
+ "DifficultyTest489" : {
+		"parentTimestamp" : "0x0466356d0f",
+		"parentDifficulty" : "0x073db18eda0bf9f0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0466356d17",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x073f80fb3dc27cee"
+	},
+
+ "DifficultyTest490" : {
+		"parentTimestamp" : "0x078b66236e",
+		"parentDifficulty" : "0x6154306c05d30c23",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x078b662376",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x616c857820d480e5"
+	},
+
+ "DifficultyTest491" : {
+		"parentTimestamp" : "0xedd14416",
+		"parentDifficulty" : "0x32054a07e547410e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xedd14420",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x32054a07e547410e"
+	},
+
+ "DifficultyTest492" : {
+		"parentTimestamp" : "0x02e925f4de",
+		"parentDifficulty" : "0x39d36bee20c8015b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e925f4e8",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x39d36bee20c8015c"
+	},
+
+ "DifficultyTest493" : {
+		"parentTimestamp" : "0x882bc06e",
+		"parentDifficulty" : "0x10a2df8b2d6384e1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x882bc078",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x10a2df8b2d6384e3"
+	},
+
+ "DifficultyTest494" : {
+		"parentTimestamp" : "0x04d235c539",
+		"parentDifficulty" : "0x78ea09c6ce5fa657",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04d235c543",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x78ea09c6ce5fa65b"
+	},
+
+ "DifficultyTest495" : {
+		"parentTimestamp" : "0x0389190fcf",
+		"parentDifficulty" : "0x58444cb3c8d7d258",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0389190fd9",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x58444cb3c8d7d260"
+	},
+
+ "DifficultyTest496" : {
+		"parentTimestamp" : "0x7ea6d136",
+		"parentDifficulty" : "0x12058170577c04f0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x7ea6d140",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x12058170577c0500"
+	},
+
+ "DifficultyTest497" : {
+		"parentTimestamp" : "0xcd4ce517",
+		"parentDifficulty" : "0x427d3627b14b81ce",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xcd4ce521",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x427d3627b14b81ee"
+	},
+
+ "DifficultyTest498" : {
+		"parentTimestamp" : "0xc39bd9b3",
+		"parentDifficulty" : "0x6dff50bc0cd51260",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xc39bd9bd",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x6dff50bc0cd512a0"
+	},
+
+ "DifficultyTest499" : {
+		"parentTimestamp" : "0x03b4891589",
+		"parentDifficulty" : "0x596e57cf6554b571",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b4891593",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x596e57cf6554b5f1"
+	},
+
+ "DifficultyTest500" : {
+		"parentTimestamp" : "0x04e93050e1",
+		"parentDifficulty" : "0x26bf6bc7741ca883",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04e93050eb",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x26bf6bc7741ca983"
+	},
+
+ "DifficultyTest501" : {
+		"parentTimestamp" : "0x0503dfe3dc",
+		"parentDifficulty" : "0x26d7a63dacece3a2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0503dfe3e6",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x26d7a63dacece5a2"
+	},
+
+ "DifficultyTest502" : {
+		"parentTimestamp" : "0x069940c653",
+		"parentDifficulty" : "0x73ca0ae80b47bbce",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x069940c65d",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x73ca0ae80b47bfce"
+	},
+
+ "DifficultyTest503" : {
+		"parentTimestamp" : "0x0449159f29",
+		"parentDifficulty" : "0x7ad9215129ca4526",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0449159f33",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x7ad9215129ca4d26"
+	},
+
+ "DifficultyTest504" : {
+		"parentTimestamp" : "0x02c51baf46",
+		"parentDifficulty" : "0x7deb5d7da3864641",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02c51baf50",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x7deb5d7da3865641"
+	},
+
+ "DifficultyTest505" : {
+		"parentTimestamp" : "0x51aa43b4",
+		"parentDifficulty" : "0x636dbe4376a3c9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x51aa43be",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x636dbe4376c3c9"
+	},
+
+ "DifficultyTest506" : {
+		"parentTimestamp" : "0x06e08da6a0",
+		"parentDifficulty" : "0x36bc9f631f74aa90",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06e08da6aa",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x36bc9f631f74ea90"
+	},
+
+ "DifficultyTest507" : {
+		"parentTimestamp" : "0xacb17a34",
+		"parentDifficulty" : "0x0e95c90d8e7404a3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xacb17a3e",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x0e95c90d8e7404a3"
+	},
+
+ "DifficultyTest508" : {
+		"parentTimestamp" : "0x053f5818d8",
+		"parentDifficulty" : "0x5bd18bd551e95a30",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x053f5818e2",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x5bd18bd551e95a30"
+	},
+
+ "DifficultyTest509" : {
+		"parentTimestamp" : "0xb2e907af",
+		"parentDifficulty" : "0x644132c659bd51cd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb2e907b9",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x644132c659bd51cd"
+	},
+
+ "DifficultyTest510" : {
+		"parentTimestamp" : "0x02fac9d7be",
+		"parentDifficulty" : "0x72edff2eee18358d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02fac9d7c8",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x72edff2eee18358d"
+	},
+
+ "DifficultyTest511" : {
+		"parentTimestamp" : "0x07ba2c3f9d",
+		"parentDifficulty" : "0x3945fb867557b2ab",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07ba2c3fa7",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x3945fb867557b2ab"
+	},
+
+ "DifficultyTest512" : {
+		"parentTimestamp" : "0x01f44fc3a5",
+		"parentDifficulty" : "0x2aa2187a2291ee5a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f44fc3af",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x2aa2187a2291ee5a"
+	},
+
+ "DifficultyTest513" : {
+		"parentTimestamp" : "0xfceac7fe",
+		"parentDifficulty" : "0x6ace29ab51755d6f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xfceac808",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x6ace29ab51755d6f"
+	},
+
+ "DifficultyTest514" : {
+		"parentTimestamp" : "0x04b8bd48fa",
+		"parentDifficulty" : "0x0663d5bb44174aad",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b8bd4904",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x0663d5bb44174aad"
+	},
+
+ "DifficultyTest515" : {
+		"parentTimestamp" : "0x016e876f00",
+		"parentDifficulty" : "0x453b2de6085d5069",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x016e876f0a",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x453b2de6085d5069"
+	},
+
+ "DifficultyTest516" : {
+		"parentTimestamp" : "0x01ed59d0f2",
+		"parentDifficulty" : "0x035414cb22484e10",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01ed59d0fc",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x035414cb22484e10"
+	},
+
+ "DifficultyTest517" : {
+		"parentTimestamp" : "0x017d7406cc",
+		"parentDifficulty" : "0x6b4fe7bb29694b9e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x017d7406d6",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x6b4fe7bb29694b9e"
+	},
+
+ "DifficultyTest518" : {
+		"parentTimestamp" : "0x024e9a739f",
+		"parentDifficulty" : "0x55dd1df8e62611b4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x024e9a73a9",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x55dd1df8e62611b4"
+	},
+
+ "DifficultyTest519" : {
+		"parentTimestamp" : "0x02824fd469",
+		"parentDifficulty" : "0x1d71aa314f5bd16e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02824fd473",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x1d71aa314f5bd16e"
+	},
+
+ "DifficultyTest520" : {
+		"parentTimestamp" : "0x0558b03410",
+		"parentDifficulty" : "0x7f404cbfb6cfc1df",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0558b0341a",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x7f404cbfb6cfc1df"
+	},
+
+ "DifficultyTest521" : {
+		"parentTimestamp" : "0x01a635d9e1",
+		"parentDifficulty" : "0x7c3cab96900b96d7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01a635d9eb",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x7c3cab96900b96d7"
+	},
+
+ "DifficultyTest522" : {
+		"parentTimestamp" : "0x05032d8a4c",
+		"parentDifficulty" : "0x1e1ddeae15d9c983",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05032d8a56",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x1e1ddeae15d9c984"
+	},
+
+ "DifficultyTest523" : {
+		"parentTimestamp" : "0x04c5e6ccb9",
+		"parentDifficulty" : "0x719a3a0439e384e1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c5e6ccc3",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x719a3a0439e384e3"
+	},
+
+ "DifficultyTest524" : {
+		"parentTimestamp" : "0x057ca25514",
+		"parentDifficulty" : "0x10b0c257d824b75a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x057ca2551e",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x10b0c257d824b75e"
+	},
+
+ "DifficultyTest525" : {
+		"parentTimestamp" : "0x057c975578",
+		"parentDifficulty" : "0x144437ebbd36ce5a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x057c975582",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x144437ebbd36ce62"
+	},
+
+ "DifficultyTest526" : {
+		"parentTimestamp" : "0x068bbc48c3",
+		"parentDifficulty" : "0x3d32e90b3a2e5696",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x068bbc48cd",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x3d32e90b3a2e56a6"
+	},
+
+ "DifficultyTest527" : {
+		"parentTimestamp" : "0x03b5ad5a4f",
+		"parentDifficulty" : "0x4a0a78707e7550ac",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b5ad5a59",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x4a0a78707e7550cc"
+	},
+
+ "DifficultyTest528" : {
+		"parentTimestamp" : "0xef8664ea",
+		"parentDifficulty" : "0x4357ffea93aaa5fd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xef8664f4",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x4357ffea93aaa63d"
+	},
+
+ "DifficultyTest529" : {
+		"parentTimestamp" : "0x0458dbe0a9",
+		"parentDifficulty" : "0x2d2c9bb2f83c3769",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0458dbe0b3",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x2d2c9bb2f83c37e9"
+	},
+
+ "DifficultyTest530" : {
+		"parentTimestamp" : "0x0367dd53c2",
+		"parentDifficulty" : "0x17874eb561f0fb55",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0367dd53cc",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x17874eb561f0fc55"
+	},
+
+ "DifficultyTest531" : {
+		"parentTimestamp" : "0x04f0d1fd51",
+		"parentDifficulty" : "0x5f14ad1e8ac32bd2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f0d1fd5b",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x5f14ad1e8ac32dd2"
+	},
+
+ "DifficultyTest532" : {
+		"parentTimestamp" : "0x06ab38fb1a",
+		"parentDifficulty" : "0x2f05cc3d9d30743c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ab38fb24",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x2f05cc3d9d30783c"
+	},
+
+ "DifficultyTest533" : {
+		"parentTimestamp" : "0x047201e38c",
+		"parentDifficulty" : "0x257cae5f8e8cc2c1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x047201e396",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x257cae5f8e8cc2c1"
+	},
+
+ "DifficultyTest534" : {
+		"parentTimestamp" : "0x02b2c64285",
+		"parentDifficulty" : "0x1491eba754f34ec7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02b2c6428f",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1491eba754f34ec7"
+	},
+
+ "DifficultyTest535" : {
+		"parentTimestamp" : "0x05f18fa5f6",
+		"parentDifficulty" : "0x22388e3ac8a42613",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f18fa600",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x22388e3ac8a42613"
+	},
+
+ "DifficultyTest536" : {
+		"parentTimestamp" : "0x24a6b732",
+		"parentDifficulty" : "0x1bce27853bc0b09e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x24a6b73c",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x1bce27853bc0b09e"
+	},
+
+ "DifficultyTest537" : {
+		"parentTimestamp" : "0x06ca24f75e",
+		"parentDifficulty" : "0x615d5b9cd853da9c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ca24f768",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x615d5b9cd853da9c"
+	},
+
+ "DifficultyTest538" : {
+		"parentTimestamp" : "0x03d0217dca",
+		"parentDifficulty" : "0x5cbff6cebd796d01",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03d0217dd4",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x5cbff6cebd796d01"
+	},
+
+ "DifficultyTest539" : {
+		"parentTimestamp" : "0x066308ebac",
+		"parentDifficulty" : "0x129990f793b8446d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x066308ebb6",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x129990f793b8446d"
+	},
+
+ "DifficultyTest540" : {
+		"parentTimestamp" : "0x0595a2241b",
+		"parentDifficulty" : "0x65ebdd30223a3055",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0595a22425",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x65ebdd30223a3055"
+	},
+
+ "DifficultyTest541" : {
+		"parentTimestamp" : "0x02de8e7fb6",
+		"parentDifficulty" : "0x7fc70f53adaf1d73",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02de8e7fc0",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x7fc70f53adaf1d74"
+	},
+
+ "DifficultyTest542" : {
+		"parentTimestamp" : "0x1f825304",
+		"parentDifficulty" : "0x7d1b604352ff89bb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1f82530e",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x7d1b604352ff89bd"
+	},
+
+ "DifficultyTest543" : {
+		"parentTimestamp" : "0x070164dc63",
+		"parentDifficulty" : "0x5ce432237c985a50",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x070164dc6d",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x5ce432237c985a54"
+	},
+
+ "DifficultyTest544" : {
+		"parentTimestamp" : "0x06f3062b92",
+		"parentDifficulty" : "0x2fc8791bf1192c85",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06f3062b9c",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x2fc8791bf1192c8d"
+	},
+
+ "DifficultyTest545" : {
+		"parentTimestamp" : "0x0283145fdd",
+		"parentDifficulty" : "0x10bf255d88d9d5e9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0283145fe7",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x10bf255d88d9d5f9"
+	},
+
+ "DifficultyTest546" : {
+		"parentTimestamp" : "0x0288ed2227",
+		"parentDifficulty" : "0x57c56489545f349a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0288ed2231",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x57c56489545f34ba"
+	},
+
+ "DifficultyTest547" : {
+		"parentTimestamp" : "0x0195a8ed43",
+		"parentDifficulty" : "0x6b8ffcce4330fb77",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0195a8ed4d",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x6b8ffcce4330fbb7"
+	},
+
+ "DifficultyTest548" : {
+		"parentTimestamp" : "0x01c5d8298c",
+		"parentDifficulty" : "0x65964fbf07cac40e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c5d82996",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x65964fbf07cac48e"
+	},
+
+ "DifficultyTest549" : {
+		"parentTimestamp" : "0xb03675f2",
+		"parentDifficulty" : "0x484e8503cfc1ddb0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xb03675fc",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x484e8503cfc1deb0"
+	},
+
+ "DifficultyTest550" : {
+		"parentTimestamp" : "0x0371c095fc",
+		"parentDifficulty" : "0x1bced31e1d854203",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0371c09606",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x1bced31e1d854403"
+	},
+
+ "DifficultyTest551" : {
+		"parentTimestamp" : "0x04a77e61d5",
+		"parentDifficulty" : "0x6bd4630ab2cc69ab",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04a77e61df",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x6bd4630ab2cc6dab"
+	},
+
+ "DifficultyTest552" : {
+		"parentTimestamp" : "0x0469de44c4",
+		"parentDifficulty" : "0x607d38629a76a035",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0469de44ce",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x607d38629a76a835"
+	},
+
+ "DifficultyTest553" : {
+		"parentTimestamp" : "0xab55eab2",
+		"parentDifficulty" : "0x3b3d3264e07188eb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xab55eabc",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x3b3d3264e07198eb"
+	},
+
+ "DifficultyTest554" : {
+		"parentTimestamp" : "0x0538d69940",
+		"parentDifficulty" : "0x6060210e81fb9f05",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0538d6994a",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x6060210e81fbbf05"
+	},
+
+ "DifficultyTest555" : {
+		"parentTimestamp" : "0x018d0b37e4",
+		"parentDifficulty" : "0x3f3ee61408ab4b77",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x018d0b37ee",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x3f3ee61408ab8b77"
+	},
+
+ "DifficultyTest556" : {
+		"parentTimestamp" : "0x011a3c96d6",
+		"parentDifficulty" : "0x6c2813dc3f321b92",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x011a3c96e0",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x6c3598debaba01d5"
+	},
+
+ "DifficultyTest557" : {
+		"parentTimestamp" : "0x045fc544f4",
+		"parentDifficulty" : "0x555011cca15ca8f8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045fc544fe",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x555abbcedaf0d48d"
+	},
+
+ "DifficultyTest558" : {
+		"parentTimestamp" : "0x01bf246abb",
+		"parentDifficulty" : "0x791966894a794b1d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01bf246ac5",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x792889b61ba29a46"
+	},
+
+ "DifficultyTest559" : {
+		"parentTimestamp" : "0x06c2cd93e7",
+		"parentDifficulty" : "0x74538865833075ab",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c2cd93f1",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x746212d68fe0dbb9"
+	},
+
+ "DifficultyTest560" : {
+		"parentTimestamp" : "0x05d2a83713",
+		"parentDifficulty" : "0x2fe62de45e42ccb3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05d2a8371d",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x2fec2aaa1ace950c"
+	},
+
+ "DifficultyTest561" : {
+		"parentTimestamp" : "0x07337eecb2",
+		"parentDifficulty" : "0x71573735bef9d83a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07337eecbc",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x7165621ca5b1b775"
+	},
+
+ "DifficultyTest562" : {
+		"parentTimestamp" : "0x699e5bf7",
+		"parentDifficulty" : "0x04737527e81abb4a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x699e5c01",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x047403968d17bea1"
+	},
+
+ "DifficultyTest563" : {
+		"parentTimestamp" : "0x07d50458b7",
+		"parentDifficulty" : "0x3567257eed619419",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07d50458c1",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x356dd2639d3f404b"
+	},
+
+ "DifficultyTest564" : {
+		"parentTimestamp" : "0x079f804f79",
+		"parentDifficulty" : "0x597a64c09f00188a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x079f804f83",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x5985940d3713f88d"
+	},
+
+ "DifficultyTest565" : {
+		"parentTimestamp" : "0x015695607c",
+		"parentDifficulty" : "0x2bdeae8e2ed05613",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0156956086",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x2be42a640096301d"
+	},
+
+ "DifficultyTest566" : {
+		"parentTimestamp" : "0xea8213db",
+		"parentDifficulty" : "0x44285094c09cad9f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xea8213e5",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x4430d59ed334c134"
+	},
+
+ "DifficultyTest567" : {
+		"parentTimestamp" : "0x0517b9e651",
+		"parentDifficulty" : "0x6716aaccac0062cb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0517b9e65b",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x67238da20595e2d7"
+	},
+
+ "DifficultyTest568" : {
+		"parentTimestamp" : "0x06ff993666",
+		"parentDifficulty" : "0x7e460f0272a95eae",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06ff993670",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x7e55d7c452f7b3d9"
+	},
+
+ "DifficultyTest569" : {
+		"parentTimestamp" : "0x0abf449a",
+		"parentDifficulty" : "0x5d72ccf94e872303",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0abf44a4",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x5d7e7b52edb0f3e7"
+	},
+
+ "DifficultyTest570" : {
+		"parentTimestamp" : "0x03b4dbd6ef",
+		"parentDifficulty" : "0x3c7f447269b46694",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03b4dbd6f9",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3c86d45af8019d20"
+	},
+
+ "DifficultyTest571" : {
+		"parentTimestamp" : "0x2818ac3f",
+		"parentDifficulty" : "0x4e5cdf2d74cbf738",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x2818ac49",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x4e66aac95a7a90b7"
+	},
+
+ "DifficultyTest572" : {
+		"parentTimestamp" : "0x5e703554",
+		"parentDifficulty" : "0x1eab27cbce3c24f3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x5e70355e",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x1eaefd30c7b5ec79"
+	},
+
+ "DifficultyTest573" : {
+		"parentTimestamp" : "0x04d6d3abd9",
+		"parentDifficulty" : "0x6613128db1c96205",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04d6d3abe3",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x661fd4f0037f9b35"
+	},
+
+ "DifficultyTest574" : {
+		"parentTimestamp" : "0x050a9ccc04",
+		"parentDifficulty" : "0x3dc7f1570db57920",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x050a9ccc0e",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x3dcfaa5538972fd7"
+	},
+
+ "DifficultyTest575" : {
+		"parentTimestamp" : "0x02bba7de8b",
+		"parentDifficulty" : "0x2ae71476821e156f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02bba7de95",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x2aec715910ee5941"
+	},
+
+ "DifficultyTest576" : {
+		"parentTimestamp" : "0x046c87a3b6",
+		"parentDifficulty" : "0x0921d264d3b6cbb3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x046c87a3c0",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x0922f69f205142ac"
+	},
+
+ "DifficultyTest577" : {
+		"parentTimestamp" : "0x031f0e3e48",
+		"parentDifficulty" : "0x017d39a717ac6864",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x031f0e3e52",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x017d694e4c8f5e31"
+	},
+
+ "DifficultyTest578" : {
+		"parentTimestamp" : "0x0712370c42",
+		"parentDifficulty" : "0x53ef0f658fb5c467",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0712370c4c",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x53f98d477c67bb9f"
+	},
+
+ "DifficultyTest579" : {
+		"parentTimestamp" : "0x030692724a",
+		"parentDifficulty" : "0x25fa55acc174cfdd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0306927254",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x25ff14f7770cff76"
+	},
+
+ "DifficultyTest580" : {
+		"parentTimestamp" : "0x02829dfeae",
+		"parentDifficulty" : "0x26770c7e1a030cf7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02829dfeb8",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x267bdb5fa9c64f58"
+	},
+
+ "DifficultyTest581" : {
+		"parentTimestamp" : "0x05c9229fc9",
+		"parentDifficulty" : "0x5ed21d98b3134238",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05c9229fd3",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x5eddf7dc6629a8a0"
+	},
+
+ "DifficultyTest582" : {
+		"parentTimestamp" : "0x059c38b6bf",
+		"parentDifficulty" : "0x64a8cebadc42b32c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x059c38b6c9",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x64b563d4b39e3b82"
+	},
+
+ "DifficultyTest583" : {
+		"parentTimestamp" : "0x07691bc202",
+		"parentDifficulty" : "0x5ed1b6bdc8976841",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07691bc20c",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x5edd90f4a0507b2e"
+	},
+
+ "DifficultyTest584" : {
+		"parentTimestamp" : "0x01460da846",
+		"parentDifficulty" : "0x352e630d269b2f98",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01460da850",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x353508d9884002fd"
+	},
+
+ "DifficultyTest585" : {
+		"parentTimestamp" : "0x02d865c7da",
+		"parentDifficulty" : "0x57af17439b7e9dfc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02d865c7e4",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x57ba0d2683f20dcf"
+	},
+
+ "DifficultyTest586" : {
+		"parentTimestamp" : "0x01eac67b95",
+		"parentDifficulty" : "0x75da61131c12f750",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01eac67b9f",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x75e91c5f3e7679ae"
+	},
+
+ "DifficultyTest587" : {
+		"parentTimestamp" : "0x038a834cb8",
+		"parentDifficulty" : "0x475c8534fe8f3987",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x038a834cc2",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x476570c5a52f0b6e"
+	},
+
+ "DifficultyTest588" : {
+		"parentTimestamp" : "0x02e1b826af",
+		"parentDifficulty" : "0x785bd73b43177e6a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02e1b826b9",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x786ae2b62a7fe159"
+	},
+
+ "DifficultyTest589" : {
+		"parentTimestamp" : "0x05837ebccd",
+		"parentDifficulty" : "0x154ad67ce7154cf4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05837ebcd9",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x154ad67ce7154cf4"
+	},
+
+ "DifficultyTest590" : {
+		"parentTimestamp" : "0x06f9cc95b8",
+		"parentDifficulty" : "0x18162c8e16237ebe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06f9cc95c4",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x18162c8e16237ebf"
+	},
+
+ "DifficultyTest591" : {
+		"parentTimestamp" : "0x06d5bc2092",
+		"parentDifficulty" : "0x5453fe99514da8f8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06d5bc209e",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x5453fe99514da8fa"
+	},
+
+ "DifficultyTest592" : {
+		"parentTimestamp" : "0x055f5d9eca",
+		"parentDifficulty" : "0x275a0305c1d57054",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x055f5d9ed6",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x275a0305c1d57058"
+	},
+
+ "DifficultyTest593" : {
+		"parentTimestamp" : "0x0648047e7f",
+		"parentDifficulty" : "0x2c5f1f367b564431",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0648047e8b",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x2c5f1f367b564439"
+	},
+
+ "DifficultyTest594" : {
+		"parentTimestamp" : "0x054c667d18",
+		"parentDifficulty" : "0x711ba6205f9fca83",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x054c667d24",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x711ba6205f9fca93"
+	},
+
+ "DifficultyTest595" : {
+		"parentTimestamp" : "0x040189b7a9",
+		"parentDifficulty" : "0x7cfd173bdaf32c53",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x040189b7b5",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x7cfd173bdaf32c73"
+	},
+
+ "DifficultyTest596" : {
+		"parentTimestamp" : "0x05d682a821",
+		"parentDifficulty" : "0x7ee3b1cb29149d2e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d682a82d",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x7ee3b1cb29149d6e"
+	},
+
+ "DifficultyTest597" : {
+		"parentTimestamp" : "0x057fc6511f",
+		"parentDifficulty" : "0x6f8954ae963c64db",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x057fc6512b",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x6f8954ae963c655b"
+	},
+
+ "DifficultyTest598" : {
+		"parentTimestamp" : "0x06f5d5a5a6",
+		"parentDifficulty" : "0x14d774482596339f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06f5d5a5b2",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x14d774482596349f"
+	},
+
+ "DifficultyTest599" : {
+		"parentTimestamp" : "0x0371d14796",
+		"parentDifficulty" : "0x553720877e5f84b6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0371d147a2",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x553720877e5f86b6"
+	},
+
+ "DifficultyTest600" : {
+		"parentTimestamp" : "0x01ab35a060",
+		"parentDifficulty" : "0x1b61edda74eac55f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01ab35a06c",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x1b61edda74eac95f"
+	},
+
+ "DifficultyTest601" : {
+		"parentTimestamp" : "0x045d85baa7",
+		"parentDifficulty" : "0x5141ff1a79ecce67",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x045d85bab3",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x5141ff1a79ecd667"
+	},
+
+ "DifficultyTest602" : {
+		"parentTimestamp" : "0x0328862f59",
+		"parentDifficulty" : "0x69f5fcd3b1ed3638",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0328862f65",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x69f5fcd3b1ed4638"
+	},
+
+ "DifficultyTest603" : {
+		"parentTimestamp" : "0x01ba9dbc6d",
+		"parentDifficulty" : "0x02ec8330e9855066",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01ba9dbc79",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x02ec8330e9857066"
+	},
+
+ "DifficultyTest604" : {
+		"parentTimestamp" : "0xa0af7876",
+		"parentDifficulty" : "0x08378fbc2ad04c6d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa0af7882",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x08378fbc2ad08c6d"
+	},
+
+ "DifficultyTest605" : {
+		"parentTimestamp" : "0x03df72b9a6",
+		"parentDifficulty" : "0x036c377946292426",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03df72b9b2",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x036c377946292426"
+	},
+
+ "DifficultyTest606" : {
+		"parentTimestamp" : "0x04943d7999",
+		"parentDifficulty" : "0x5d247729e4280859",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04943d79a5",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x5d247729e4280859"
+	},
+
+ "DifficultyTest607" : {
+		"parentTimestamp" : "0x1ab06217",
+		"parentDifficulty" : "0x1e8acab915da186c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x1ab06223",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x1e8acab915da186c"
+	},
+
+ "DifficultyTest608" : {
+		"parentTimestamp" : "0x0796e3b9be",
+		"parentDifficulty" : "0x455a3f12044efcda",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0796e3b9ca",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x455a3f12044efcda"
+	},
+
+ "DifficultyTest609" : {
+		"parentTimestamp" : "0x065d86321d",
+		"parentDifficulty" : "0x4649f7dfbce25c19",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x065d863229",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x4649f7dfbce25c19"
+	},
+
+ "DifficultyTest610" : {
+		"parentTimestamp" : "0xdd86bb3a",
+		"parentDifficulty" : "0x4d2951114c9c484e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xdd86bb46",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x4d2951114c9c484e"
+	},
+
+ "DifficultyTest611" : {
+		"parentTimestamp" : "0x061728ebc0",
+		"parentDifficulty" : "0x5b993c33f0f2aa5b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x061728ebcc",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x5b993c33f0f2aa5b"
+	},
+
+ "DifficultyTest612" : {
+		"parentTimestamp" : "0x06f393a81c",
+		"parentDifficulty" : "0x4b757f60d93b95ff",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06f393a828",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x4b757f60d93b95ff"
+	},
+
+ "DifficultyTest613" : {
+		"parentTimestamp" : "0x03ce5f45c1",
+		"parentDifficulty" : "0x44a6256b2db1bee8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03ce5f45cd",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x44a6256b2db1bee8"
+	},
+
+ "DifficultyTest614" : {
+		"parentTimestamp" : "0x3e47fd98",
+		"parentDifficulty" : "0x67d8559e03c6e1bd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x3e47fda4",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x67d8559e03c6e1bd"
+	},
+
+ "DifficultyTest615" : {
+		"parentTimestamp" : "0x033c17b66e",
+		"parentDifficulty" : "0x49ed08dae31b791e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x033c17b67a",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x49ed08dae31b791e"
+	},
+
+ "DifficultyTest616" : {
+		"parentTimestamp" : "0x074b78c4c1",
+		"parentDifficulty" : "0x16c9073f1db13a44",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x074b78c4cd",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x16c9073f1db13a44"
+	},
+
+ "DifficultyTest617" : {
+		"parentTimestamp" : "0x0109d659ef",
+		"parentDifficulty" : "0x2e19a487c734474e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0109d659fb",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x2e19a487c734474e"
+	},
+
+ "DifficultyTest618" : {
+		"parentTimestamp" : "0x06a1c422e8",
+		"parentDifficulty" : "0x559976b1a118cffe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06a1c422f4",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x559976b1a118cffe"
+	},
+
+ "DifficultyTest619" : {
+		"parentTimestamp" : "0x072fa66188",
+		"parentDifficulty" : "0x789302f9e451ef1c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x072fa66194",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x789302f9e451ef1c"
+	},
+
+ "DifficultyTest620" : {
+		"parentTimestamp" : "0x02824a51ca",
+		"parentDifficulty" : "0x5e7d38dfcb01c57a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02824a51d6",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x5e7d38dfcb01c57b"
+	},
+
+ "DifficultyTest621" : {
+		"parentTimestamp" : "0x0147b33c75",
+		"parentDifficulty" : "0x0afd8f86a135c322",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0147b33c81",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x0afd8f86a135c324"
+	},
+
+ "DifficultyTest622" : {
+		"parentTimestamp" : "0x02cf2ee4ec",
+		"parentDifficulty" : "0x2db23d16491dd84c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02cf2ee4f8",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x2db23d16491dd850"
+	},
+
+ "DifficultyTest623" : {
+		"parentTimestamp" : "0x035251802b",
+		"parentDifficulty" : "0x20d5323411e0e5af",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0352518037",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x20d5323411e0e5b7"
+	},
+
+ "DifficultyTest624" : {
+		"parentTimestamp" : "0x360b1e1e",
+		"parentDifficulty" : "0x09337688a50289e7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x360b1e2a",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x09337688a50289f7"
+	},
+
+ "DifficultyTest625" : {
+		"parentTimestamp" : "0x0494d79d5b",
+		"parentDifficulty" : "0x36351803cc7f2af7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0494d79d67",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x36351803cc7f2b17"
+	},
+
+ "DifficultyTest626" : {
+		"parentTimestamp" : "0x074f7fd3b4",
+		"parentDifficulty" : "0x2bd8a51fb3d11aa9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x074f7fd3c0",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2bd8a51fb3d11ae9"
+	},
+
+ "DifficultyTest627" : {
+		"parentTimestamp" : "0x058bc8896d",
+		"parentDifficulty" : "0x709003d42b9afe4e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x058bc88979",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x709003d42b9afece"
+	},
+
+ "DifficultyTest628" : {
+		"parentTimestamp" : "0x063831e586",
+		"parentDifficulty" : "0x054fd62cf6a70240",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x063831e592",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x054fd62cf6a70340"
+	},
+
+ "DifficultyTest629" : {
+		"parentTimestamp" : "0x03e6e2e343",
+		"parentDifficulty" : "0x4ea3e305fa52f901",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e6e2e34f",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x4ea3e305fa52fb01"
+	},
+
+ "DifficultyTest630" : {
+		"parentTimestamp" : "0x0308e014ef",
+		"parentDifficulty" : "0x1b9c56a917e0f2e2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0308e014fb",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x1b9c56a917e0f6e2"
+	},
+
+ "DifficultyTest631" : {
+		"parentTimestamp" : "0x07079eedd2",
+		"parentDifficulty" : "0x0ed051709e8586ef",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07079eedde",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x0ed051709e8586ef"
+	},
+
+ "DifficultyTest632" : {
+		"parentTimestamp" : "0x044eba03f3",
+		"parentDifficulty" : "0x61b57eacf3d2f808",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044eba03ff",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x61b57eacf3d2f808"
+	},
+
+ "DifficultyTest633" : {
+		"parentTimestamp" : "0x0336142660",
+		"parentDifficulty" : "0x6bcbd325203a851e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x033614266c",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x6bcbd325203a851e"
+	},
+
+ "DifficultyTest634" : {
+		"parentTimestamp" : "0x05cc635f22",
+		"parentDifficulty" : "0x637b8cfa0abc3aea",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05cc635f2e",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x637b8cfa0abc3aea"
+	},
+
+ "DifficultyTest635" : {
+		"parentTimestamp" : "0x024913fce4",
+		"parentDifficulty" : "0x6f4e1c717a335138",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x024913fcf0",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x6f4e1c717a335138"
+	},
+
+ "DifficultyTest636" : {
+		"parentTimestamp" : "0x0226487d5f",
+		"parentDifficulty" : "0x09824fa811653b98",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0226487d6b",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x09824fa811653b98"
+	},
+
+ "DifficultyTest637" : {
+		"parentTimestamp" : "0x06873ef01b",
+		"parentDifficulty" : "0x03cd97ac2897da22",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06873ef027",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x03cd97ac2897da22"
+	},
+
+ "DifficultyTest638" : {
+		"parentTimestamp" : "0x03b6652bbe",
+		"parentDifficulty" : "0x2888f93a1fcef67b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03b6652bca",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x2888f93a1fcef67b"
+	},
+
+ "DifficultyTest639" : {
+		"parentTimestamp" : "0x034fe8e80c",
+		"parentDifficulty" : "0x5f30c8011962c311",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x034fe8e818",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x5f30c8011962c312"
+	},
+
+ "DifficultyTest640" : {
+		"parentTimestamp" : "0x06315f9cf5",
+		"parentDifficulty" : "0x6678bdee89d8a5dd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06315f9d01",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x6678bdee89d8a5df"
+	},
+
+ "DifficultyTest641" : {
+		"parentTimestamp" : "0x0119c74617",
+		"parentDifficulty" : "0x377ef4d28568cc50",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0119c74623",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x377ef4d28568cc54"
+	},
+
+ "DifficultyTest642" : {
+		"parentTimestamp" : "0x0fc88df2",
+		"parentDifficulty" : "0x1a4e4d03b5c82a83",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0fc88dfe",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x1a4e4d03b5c82a8b"
+	},
+
+ "DifficultyTest643" : {
+		"parentTimestamp" : "0xd7631632",
+		"parentDifficulty" : "0x3a04e59d431ea1b4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xd763163e",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x3a04e59d431ea1c4"
+	},
+
+ "DifficultyTest644" : {
+		"parentTimestamp" : "0x5ad6b147",
+		"parentDifficulty" : "0x72504e6ffb88be95",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x5ad6b153",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x72504e6ffb88beb5"
+	},
+
+ "DifficultyTest645" : {
+		"parentTimestamp" : "0x02e0fd08bf",
+		"parentDifficulty" : "0x3d5be31e4fc0ab49",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02e0fd08cb",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x3d5be31e4fc0ab89"
+	},
+
+ "DifficultyTest646" : {
+		"parentTimestamp" : "0x07df72a3b3",
+		"parentDifficulty" : "0x183c35e602fd02e6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07df72a3bf",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x183c35e602fd0366"
+	},
+
+ "DifficultyTest647" : {
+		"parentTimestamp" : "0x0683eb0ff3",
+		"parentDifficulty" : "0x5a2fc660f8c4cf59",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0683eb0fff",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x5a2fc660f8c4d059"
+	},
+
+ "DifficultyTest648" : {
+		"parentTimestamp" : "0x069a67d6d7",
+		"parentDifficulty" : "0x757874a0256c2f22",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x069a67d6e3",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x757874a0256c3122"
+	},
+
+ "DifficultyTest649" : {
+		"parentTimestamp" : "0x05868480f4",
+		"parentDifficulty" : "0x5126ef2e9ff5493c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0586848100",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x5126ef2e9ff54d3c"
+	},
+
+ "DifficultyTest650" : {
+		"parentTimestamp" : "0x5c5aca66",
+		"parentDifficulty" : "0x60f993f5386f3540",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x5c5aca72",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x60f993f5386f3d40"
+	},
+
+ "DifficultyTest651" : {
+		"parentTimestamp" : "0xbe027fe0",
+		"parentDifficulty" : "0x15e589347d06876e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xbe027fec",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x15e589347d06976e"
+	},
+
+ "DifficultyTest652" : {
+		"parentTimestamp" : "0x05186f8cd0",
+		"parentDifficulty" : "0x3b460581b86ef3ef",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05186f8cdc",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x3b460581b86f13ef"
+	},
+
+ "DifficultyTest653" : {
+		"parentTimestamp" : "0x733ea0ad",
+		"parentDifficulty" : "0x2e96ab06d39c7575",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x733ea0b9",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x2e96ab06d39cb575"
+	},
+
+ "DifficultyTest654" : {
+		"parentTimestamp" : "0x04e3f58f75",
+		"parentDifficulty" : "0x0e5c67a22b2acafd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e3f58f81",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x0e5e332f1f703056"
+	},
+
+ "DifficultyTest655" : {
+		"parentTimestamp" : "0x0411c80ae2",
+		"parentDifficulty" : "0x6bba5317bf7dee64",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0411c80aee",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x6bc7ca622275de21"
+	},
+
+ "DifficultyTest656" : {
+		"parentTimestamp" : "0x0393176d88",
+		"parentDifficulty" : "0x1e2c7e5bb95d1e7c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0393176d94",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x1e3043eb84d44a1f"
+	},
+
+ "DifficultyTest657" : {
+		"parentTimestamp" : "0x07cf6a395f",
+		"parentDifficulty" : "0x2e29e265c5dd601d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07cf6a396b",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x2e2fa7a212961bc9"
+	},
+
+ "DifficultyTest658" : {
+		"parentTimestamp" : "0x052355e52c",
+		"parentDifficulty" : "0x4eb8dfcd3c0fc9c8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x052355e538",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x4ec2b6e935b74bc1"
+	},
+
+ "DifficultyTest659" : {
+		"parentTimestamp" : "0x0758f8de58",
+		"parentDifficulty" : "0x7796796b4b1d6962",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0758f8de64",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x77a56c3a7886cd0f"
+	},
+
+ "DifficultyTest660" : {
+		"parentTimestamp" : "0x054a7c6fac",
+		"parentDifficulty" : "0x56515acff5e122ab",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x054a7c6fb8",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x565c24fb4fdfdecf"
+	},
+
+ "DifficultyTest661" : {
+		"parentTimestamp" : "0x0617657343",
+		"parentDifficulty" : "0x504c69d81950165a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061765734f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x505673655453405c"
+	},
+
+ "DifficultyTest662" : {
+		"parentTimestamp" : "0x0422d336d6",
+		"parentDifficulty" : "0x188b8198628923b0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0422d336e2",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x188e9308959574d4"
+	},
+
+ "DifficultyTest663" : {
+		"parentTimestamp" : "0x027fb0b750",
+		"parentDifficulty" : "0x0bd122970ad76de3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x027fb0b75c",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x0bd29cbb5db8c8d0"
+	},
+
+ "DifficultyTest664" : {
+		"parentTimestamp" : "0xe94dc8a0",
+		"parentDifficulty" : "0x64ea10f9035eef5b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xe94dc8ac",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x64f6ae3b227f5b38"
+	},
+
+ "DifficultyTest665" : {
+		"parentTimestamp" : "0x056786bdfe",
+		"parentDifficulty" : "0x6e6c7ed89b6ab2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x056786be0a",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x6e7a4c68767e1f"
+	},
+
+ "DifficultyTest666" : {
+		"parentTimestamp" : "0x01a7c38fde",
+		"parentDifficulty" : "0x2391695e4c26235b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01a7c38fea",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x2395db8b77efa81f"
+	},
+
+ "DifficultyTest667" : {
+		"parentTimestamp" : "0x019a79ec3c",
+		"parentDifficulty" : "0x789273322d4ec12c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x019a79ec48",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x78a1858093946b04"
+	},
+
+ "DifficultyTest668" : {
+		"parentTimestamp" : "0x9432ef65",
+		"parentDifficulty" : "0x0f38d57cf9618148",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9432ef71",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x0f3abc97a900ad78"
+	},
+
+ "DifficultyTest669" : {
+		"parentTimestamp" : "0x04e10d55ff",
+		"parentDifficulty" : "0x77c156d1ba364ed6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e10d560b",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x77d04efc946d95a0"
+	},
+
+ "DifficultyTest670" : {
+		"parentTimestamp" : "0x03bdc79a70",
+		"parentDifficulty" : "0x2c5fbb12eefb7099",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03bdc79a7c",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x2c65470a51595009"
+	},
+
+ "DifficultyTest671" : {
+		"parentTimestamp" : "0x02a436d9d9",
+		"parentDifficulty" : "0x0b5001b14954d2d9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02a436d9e5",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x0b516bb17f7dfd77"
+	},
+
+ "DifficultyTest672" : {
+		"parentTimestamp" : "0x062e578986",
+		"parentDifficulty" : "0x39410432c2edced9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x062e578992",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x39482c5349462c9a"
+	},
+
+ "DifficultyTest673" : {
+		"parentTimestamp" : "0x13a0a826",
+		"parentDifficulty" : "0x43a1bf66d010c538",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x13a0a832",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x43aa339ebceac760"
+	},
+
+ "DifficultyTest674" : {
+		"parentTimestamp" : "0x018b2fa4f6",
+		"parentDifficulty" : "0x5d8b8041f13e7b7c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x018b2fa502",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x5d9731b1f97ca36b"
+	},
+
+ "DifficultyTest675" : {
+		"parentTimestamp" : "0x030c0070d4",
+		"parentDifficulty" : "0x12b794fbab2e1737",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x030c0070e0",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x12b9ebee4aa37d39"
+	},
+
+ "DifficultyTest676" : {
+		"parentTimestamp" : "0x042db5d1ba",
+		"parentDifficulty" : "0x7ce0f223e01655b4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x042db5d1c6",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x7cf08e42249258fe"
+	},
+
+ "DifficultyTest677" : {
+		"parentTimestamp" : "0x060d03a3bd",
+		"parentDifficulty" : "0x44b8c4a2480731ed",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x060d03a3c9",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x44c15bbadc5033d3"
+	},
+
+ "DifficultyTest678" : {
+		"parentTimestamp" : "0x045cd73003",
+		"parentDifficulty" : "0x58f2cda0ed170cec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045cd7300f",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x58fdebfaa134b1cd"
+	},
+
+ "DifficultyTest679" : {
+		"parentTimestamp" : "0x01d98a3266",
+		"parentDifficulty" : "0x71c7978d27c4f7d4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01d98a3272",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x71d5d0801969f472"
+	},
+
+ "DifficultyTest680" : {
+		"parentTimestamp" : "0x04ecdc244a",
+		"parentDifficulty" : "0x5649ff07141672d5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04ecdc2456",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x5654c846f4f8f5a3"
+	},
+
+ "DifficultyTest681" : {
+		"parentTimestamp" : "0x06c812cf71",
+		"parentDifficulty" : "0x0c4728bfb562e3a3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c812cf7d",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x0c48b1a4cd598fff"
+	},
+
+ "DifficultyTest682" : {
+		"parentTimestamp" : "0x023fb30680",
+		"parentDifficulty" : "0x08499173b33a130f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x023fb3068c",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x084a9aa5e1b07a51"
+	},
+
+ "DifficultyTest683" : {
+		"parentTimestamp" : "0x01813b36d3",
+		"parentDifficulty" : "0x2e79768b2b0b1d2e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01813b36df",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x2e7f45b9fc707e91"
+	},
+
+ "DifficultyTest684" : {
+		"parentTimestamp" : "0x06375e9560",
+		"parentDifficulty" : "0x65f4f17cc32cb44a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06375e956c",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x6601b01af2c519e0"
+	},
+
+ "DifficultyTest685" : {
+		"parentTimestamp" : "0x03ca1e0180",
+		"parentDifficulty" : "0x094e601a70a207f2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ca1e018c",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x094f89e673f01c32"
+	},
+
+ "DifficultyTest686" : {
+		"parentTimestamp" : "0x05eb4400bb",
+		"parentDifficulty" : "0x4ed92f5832ac144a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05eb4400c7",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x4ee30a7e1db269cc"
+	},
+
+ "DifficultyTest687" : {
+		"parentTimestamp" : "0x036cc6a77e",
+		"parentDifficulty" : "0x3f818d8e7a16d915",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x036cc6a78c",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x3f818d8e7a16d915"
+	},
+
+ "DifficultyTest688" : {
+		"parentTimestamp" : "0x0165d777d5",
+		"parentDifficulty" : "0x36add5298370700b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0165d777e3",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x36add5298370700c"
+	},
+
+ "DifficultyTest689" : {
+		"parentTimestamp" : "0x05ab99a996",
+		"parentDifficulty" : "0x0fcda87dd9cb384a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ab99a9a4",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x0fcda87dd9cb384c"
+	},
+
+ "DifficultyTest690" : {
+		"parentTimestamp" : "0x0335d92da0",
+		"parentDifficulty" : "0x36b916dbeb842753",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0335d92dae",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x36b916dbeb842757"
+	},
+
+ "DifficultyTest691" : {
+		"parentTimestamp" : "0x04feed3215",
+		"parentDifficulty" : "0x5eca7313bdf0b2bb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04feed3223",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x5eca7313bdf0b2c3"
+	},
+
+ "DifficultyTest692" : {
+		"parentTimestamp" : "0x0101a6665b",
+		"parentDifficulty" : "0x55df89beb58661b5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0101a66669",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x55df89beb58661c5"
+	},
+
+ "DifficultyTest693" : {
+		"parentTimestamp" : "0x05af0e67fb",
+		"parentDifficulty" : "0x29da464c1cd0f162",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05af0e6809",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x29da464c1cd0f182"
+	},
+
+ "DifficultyTest694" : {
+		"parentTimestamp" : "0x07ea73a573",
+		"parentDifficulty" : "0x771972add1207b41",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07ea73a581",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x771972add1207b81"
+	},
+
+ "DifficultyTest695" : {
+		"parentTimestamp" : "0x8aae2954",
+		"parentDifficulty" : "0x34ed083e5676eb6c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x8aae2962",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x34ed083e5676ebec"
+	},
+
+ "DifficultyTest696" : {
+		"parentTimestamp" : "0x2b8c82d8",
+		"parentDifficulty" : "0x44c7af157860e033",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2b8c82e6",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x44c7af157860e133"
+	},
+
+ "DifficultyTest697" : {
+		"parentTimestamp" : "0x05973b82ea",
+		"parentDifficulty" : "0x55562a65f61dd019",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05973b82f8",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x55562a65f61dd219"
+	},
+
+ "DifficultyTest698" : {
+		"parentTimestamp" : "0x05b65a6a76",
+		"parentDifficulty" : "0x282fc4fdca39880d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b65a6a84",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x282fc4fdca398c0d"
+	},
+
+ "DifficultyTest699" : {
+		"parentTimestamp" : "0xc9abf86b",
+		"parentDifficulty" : "0x4f4a4d862b5628fe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xc9abf879",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x4f4a4d862b5630fe"
+	},
+
+ "DifficultyTest700" : {
+		"parentTimestamp" : "0x01c3b0346e",
+		"parentDifficulty" : "0x03b65b16a21040eb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01c3b0347c",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x03b65b16a21050eb"
+	},
+
+ "DifficultyTest701" : {
+		"parentTimestamp" : "0x0304caf4a7",
+		"parentDifficulty" : "0x4f5a03bc28fe61b7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0304caf4b5",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x4f5a03bc28fe81b7"
+	},
+
+ "DifficultyTest702" : {
+		"parentTimestamp" : "0x06dd95c994",
+		"parentDifficulty" : "0x78f8a49735be0ea7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06dd95c9a2",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x78f8a49735be4ea7"
+	},
+
+ "DifficultyTest703" : {
+		"parentTimestamp" : "0x0592b51dc7",
+		"parentDifficulty" : "0x145bd502ec6db035",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0592b51dd5",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x145bd502ec6db035"
+	},
+
+ "DifficultyTest704" : {
+		"parentTimestamp" : "0x03f6459eea",
+		"parentDifficulty" : "0x4919b7cf5f9a60a6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03f6459ef8",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x4919b7cf5f9a60a6"
+	},
+
+ "DifficultyTest705" : {
+		"parentTimestamp" : "0x075ed77f6a",
+		"parentDifficulty" : "0x543076f0a7521901",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x075ed77f78",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x543076f0a7521901"
+	},
+
+ "DifficultyTest706" : {
+		"parentTimestamp" : "0x02dd181987",
+		"parentDifficulty" : "0x6cb97a09b5006c05",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02dd181995",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6cb97a09b5006c05"
+	},
+
+ "DifficultyTest707" : {
+		"parentTimestamp" : "0x07536deaa4",
+		"parentDifficulty" : "0x2d2c19e9e0f8bf92",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07536deab2",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x2d2c19e9e0f8bf92"
+	},
+
+ "DifficultyTest708" : {
+		"parentTimestamp" : "0x01fff440cc",
+		"parentDifficulty" : "0x40219e7a56be91b2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01fff440da",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x40219e7a56be91b2"
+	},
+
+ "DifficultyTest709" : {
+		"parentTimestamp" : "0x834ceb3a",
+		"parentDifficulty" : "0x6f38070d555873ef",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x834ceb48",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x6f38070d555873ef"
+	},
+
+ "DifficultyTest710" : {
+		"parentTimestamp" : "0x06ebde7fc2",
+		"parentDifficulty" : "0x5dfb6337ab0d3087",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ebde7fd0",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x5dfb6337ab0d3087"
+	},
+
+ "DifficultyTest711" : {
+		"parentTimestamp" : "0x043cade31e",
+		"parentDifficulty" : "0x258cda9734f2c1f8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x043cade32c",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x258cda9734f2c1f8"
+	},
+
+ "DifficultyTest712" : {
+		"parentTimestamp" : "0x0563bef5a4",
+		"parentDifficulty" : "0x6f64e8e9deeb54a6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0563bef5b2",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x6f64e8e9deeb54a6"
+	},
+
+ "DifficultyTest713" : {
+		"parentTimestamp" : "0x05dfa1b1bb",
+		"parentDifficulty" : "0x03bb0e9f539a94fe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05dfa1b1c9",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x03bb0e9f539a94fe"
+	},
+
+ "DifficultyTest714" : {
+		"parentTimestamp" : "0x025cd5b722",
+		"parentDifficulty" : "0x04689747acf85bf5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x025cd5b730",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x04689747acf85bf5"
+	},
+
+ "DifficultyTest715" : {
+		"parentTimestamp" : "0x047a2043b0",
+		"parentDifficulty" : "0x0d4edc9675c03091",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x047a2043be",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x0d4edc9675c03091"
+	},
+
+ "DifficultyTest716" : {
+		"parentTimestamp" : "0x07837a1650",
+		"parentDifficulty" : "0x768b826055dcff6c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07837a165e",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x768b826055dcff6c"
+	},
+
+ "DifficultyTest717" : {
+		"parentTimestamp" : "0x2556d1e5",
+		"parentDifficulty" : "0x71d47af842ee5e1f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2556d1f3",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x71d47af842ee5e1f"
+	},
+
+ "DifficultyTest718" : {
+		"parentTimestamp" : "0x011405c4b7",
+		"parentDifficulty" : "0x5a0fdcf42020cd2b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x011405c4c5",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x5a0fdcf42020cd2c"
+	},
+
+ "DifficultyTest719" : {
+		"parentTimestamp" : "0xbd79879d",
+		"parentDifficulty" : "0x2f79d58c1ae98727",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xbd7987ab",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x2f79d58c1ae98729"
+	},
+
+ "DifficultyTest720" : {
+		"parentTimestamp" : "0x049f158d67",
+		"parentDifficulty" : "0x3777093fed38060c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x049f158d75",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x3777093fed380610"
+	},
+
+ "DifficultyTest721" : {
+		"parentTimestamp" : "0x024ad644b8",
+		"parentDifficulty" : "0x2a20a3c129259976",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x024ad644c6",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x2a20a3c12925997e"
+	},
+
+ "DifficultyTest722" : {
+		"parentTimestamp" : "0xb8e66068",
+		"parentDifficulty" : "0x28f860e082048c6b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb8e66076",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x28f860e082048c7b"
+	},
+
+ "DifficultyTest723" : {
+		"parentTimestamp" : "0x04b8ef3488",
+		"parentDifficulty" : "0x7b4732be627a1d5c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b8ef3496",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x7b4732be627a1d7c"
+	},
+
+ "DifficultyTest724" : {
+		"parentTimestamp" : "0x0370839715",
+		"parentDifficulty" : "0x5d7f33fc5c24faa6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0370839723",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x5d7f33fc5c24fae6"
+	},
+
+ "DifficultyTest725" : {
+		"parentTimestamp" : "0x0521539e6d",
+		"parentDifficulty" : "0x1281090267def34b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0521539e7b",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x1281090267def3cb"
+	},
+
+ "DifficultyTest726" : {
+		"parentTimestamp" : "0x0322fb04a1",
+		"parentDifficulty" : "0x489d648c54ec2a62",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0322fb04af",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x489d648c54ec2b62"
+	},
+
+ "DifficultyTest727" : {
+		"parentTimestamp" : "0x02ea00eaf3",
+		"parentDifficulty" : "0x494e1c5a4d518464",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ea00eb01",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x494e1c5a4d518664"
+	},
+
+ "DifficultyTest728" : {
+		"parentTimestamp" : "0x046f9c2db0",
+		"parentDifficulty" : "0x4eee099625136edd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046f9c2dbe",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x4eee0996251372dd"
+	},
+
+ "DifficultyTest729" : {
+		"parentTimestamp" : "0x07183d2fc4",
+		"parentDifficulty" : "0x7a9e488f4267cbc0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07183d2fd2",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x7a9e488f4267cbc0"
+	},
+
+ "DifficultyTest730" : {
+		"parentTimestamp" : "0x073cec6a0d",
+		"parentDifficulty" : "0x5bf113b82c6c4002",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x073cec6a1b",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x5bf113b82c6c4002"
+	},
+
+ "DifficultyTest731" : {
+		"parentTimestamp" : "0x06f1bbc6ff",
+		"parentDifficulty" : "0x648056690d461a9f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06f1bbc70d",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x648056690d461a9f"
+	},
+
+ "DifficultyTest732" : {
+		"parentTimestamp" : "0x0310cd9f35",
+		"parentDifficulty" : "0x1b587bd0203e6210",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0310cd9f43",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x1b587bd0203e6210"
+	},
+
+ "DifficultyTest733" : {
+		"parentTimestamp" : "0x078efc176c",
+		"parentDifficulty" : "0x7eb27e905d30f2d7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x078efc177a",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x7eb27e905d30f2d7"
+	},
+
+ "DifficultyTest734" : {
+		"parentTimestamp" : "0x022ad2bc31",
+		"parentDifficulty" : "0x04658c4e80282be6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x022ad2bc3f",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x04658c4e80282be6"
+	},
+
+ "DifficultyTest735" : {
+		"parentTimestamp" : "0x05b8873317",
+		"parentDifficulty" : "0x7da3873ed65910f8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b8873325",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x7da3873ed65910f8"
+	},
+
+ "DifficultyTest736" : {
+		"parentTimestamp" : "0x0317bdc33c",
+		"parentDifficulty" : "0x56d6d7aa4878c136",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0317bdc34a",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x56d6d7aa4878c136"
+	},
+
+ "DifficultyTest737" : {
+		"parentTimestamp" : "0x0514c5d935",
+		"parentDifficulty" : "0x0b434569833f8715",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0514c5d943",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x0b434569833f8716"
+	},
+
+ "DifficultyTest738" : {
+		"parentTimestamp" : "0x05ff1afbfe",
+		"parentDifficulty" : "0x458ad58817bcb4df",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05ff1afc0c",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x458ad58817bcb4e1"
+	},
+
+ "DifficultyTest739" : {
+		"parentTimestamp" : "0x012d375991",
+		"parentDifficulty" : "0x5b948573230716a5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x012d37599f",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x5b948573230716a9"
+	},
+
+ "DifficultyTest740" : {
+		"parentTimestamp" : "0x21149ec3",
+		"parentDifficulty" : "0x31271b3e553e2d8e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x21149ed1",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x31271b3e553e2d96"
+	},
+
+ "DifficultyTest741" : {
+		"parentTimestamp" : "0x068f1fedb6",
+		"parentDifficulty" : "0x7116921212df5a2d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x068f1fedc4",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x7116921212df5a3d"
+	},
+
+ "DifficultyTest742" : {
+		"parentTimestamp" : "0x01de119c77",
+		"parentDifficulty" : "0x58e5f23df21de66c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01de119c85",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x58e5f23df21de68c"
+	},
+
+ "DifficultyTest743" : {
+		"parentTimestamp" : "0x02f68ab518",
+		"parentDifficulty" : "0x66582337f6dcde17",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f68ab526",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x66582337f6dcde57"
+	},
+
+ "DifficultyTest744" : {
+		"parentTimestamp" : "0x02dd860336",
+		"parentDifficulty" : "0x2a62186f840da8a1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02dd860344",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x2a62186f840da921"
+	},
+
+ "DifficultyTest745" : {
+		"parentTimestamp" : "0x0630108967",
+		"parentDifficulty" : "0x66304b63ae265423",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0630108975",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x66304b63ae265523"
+	},
+
+ "DifficultyTest746" : {
+		"parentTimestamp" : "0x0169e72fa7",
+		"parentDifficulty" : "0x7fd4fab213d18a3b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0169e72fb5",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x7fd4fab213d18c3b"
+	},
+
+ "DifficultyTest747" : {
+		"parentTimestamp" : "0x02cfd6f8f9",
+		"parentDifficulty" : "0x5cf6e194a299d041",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cfd6f907",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x5cf6e194a299d441"
+	},
+
+ "DifficultyTest748" : {
+		"parentTimestamp" : "0x03cbb0e1c8",
+		"parentDifficulty" : "0x49785dd351fa3c04",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03cbb0e1d6",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x49785dd351fa4404"
+	},
+
+ "DifficultyTest749" : {
+		"parentTimestamp" : "0x02dc91c612",
+		"parentDifficulty" : "0x41ef5793d0585eac",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02dc91c620",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x41ef5793d0586eac"
+	},
+
+ "DifficultyTest750" : {
+		"parentTimestamp" : "0x01eb6cce2b",
+		"parentDifficulty" : "0x200cd5c3ff058b1a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01eb6cce39",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x200cd5c3ff05ab1a"
+	},
+
+ "DifficultyTest751" : {
+		"parentTimestamp" : "0x0704b715b9",
+		"parentDifficulty" : "0x69f2711921c39ce1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0704b715c7",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x69f2711921c3dce1"
+	},
+
+ "DifficultyTest752" : {
+		"parentTimestamp" : "0x0382809098",
+		"parentDifficulty" : "0x1a24770d5f10e78e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03828090a6",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x1a27bb9c40bcc9aa"
+	},
+
+ "DifficultyTest753" : {
+		"parentTimestamp" : "0x041a533e2e",
+		"parentDifficulty" : "0x2b5144b2556d39a7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x041a533e3c",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x2b56aedaebb7e74e"
+	},
+
+ "DifficultyTest754" : {
+		"parentTimestamp" : "0x07032bca87",
+		"parentDifficulty" : "0x12a5ce07e8c41707",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07032bca95",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x12a822c1a9c12f89"
+	},
+
+ "DifficultyTest755" : {
+		"parentTimestamp" : "0x012dc12486",
+		"parentDifficulty" : "0x492d24559c45692d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x012dc12494",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x493649fa26f8f1da"
+	},
+
+ "DifficultyTest756" : {
+		"parentTimestamp" : "0x01bb628165",
+		"parentDifficulty" : "0x48e9874cf3d4fc4d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01bb628173",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x48f2a47ddd7376ec"
+	},
+
+ "DifficultyTest757" : {
+		"parentTimestamp" : "0x05fd6cbc55",
+		"parentDifficulty" : "0x4a8906c8cedbe455",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05fd6cbc63",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x4a9257e9a7f5bfd1"
+	},
+
+ "DifficultyTest758" : {
+		"parentTimestamp" : "0x0124ca8bc8",
+		"parentDifficulty" : "0x607ec382fcbf67fb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0124ca8bd6",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x608ad35b6d1effe7"
+	},
+
+ "DifficultyTest759" : {
+		"parentTimestamp" : "0x033ba09baf",
+		"parentDifficulty" : "0x4476baad31baccfa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x033ba09bbd",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x447f498487610453"
+	},
+
+ "DifficultyTest760" : {
+		"parentTimestamp" : "0x03581440eb",
+		"parentDifficulty" : "0x7deee5807cf5d711",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03581440f9",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x7dfea35d2d0575cb"
+	},
+
+ "DifficultyTest761" : {
+		"parentTimestamp" : "0x01f2a68726",
+		"parentDifficulty" : "0x1da78906a6ef7c9f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01f2a68734",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x1dab3df7c7c45a8e"
+	},
+
+ "DifficultyTest762" : {
+		"parentTimestamp" : "0x075aaac1f1",
+		"parentDifficulty" : "0x256f7e301e555e9f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x075aaac1ff",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x25742c1fe459294a"
+	},
+
+ "DifficultyTest763" : {
+		"parentTimestamp" : "0x24ee676c",
+		"parentDifficulty" : "0x71c81ed827e6c8f2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x24ee677a",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x71d657dc02ebc5cb"
+	},
+
+ "DifficultyTest764" : {
+		"parentTimestamp" : "0x025471cc9c",
+		"parentDifficulty" : "0x7b0ca7a0487b91e6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x025471ccaa",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x7b1c09353c84a158"
+	},
+
+ "DifficultyTest765" : {
+		"parentTimestamp" : "0x05178bee2e",
+		"parentDifficulty" : "0x099f42dc3495c3bf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05178bee3c",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x09a076c4901c5677"
+	},
+
+ "DifficultyTest766" : {
+		"parentTimestamp" : "0x45e90af8",
+		"parentDifficulty" : "0x14696e755f059d45",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x45e90b06",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x146bfba32db17df8"
+	},
+
+ "DifficultyTest767" : {
+		"parentTimestamp" : "0x02f1fca0e1",
+		"parentDifficulty" : "0x0d3b6313d8ce3a0a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f1fca0ef",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x0d3d0a803b4953d2"
+	},
+
+ "DifficultyTest768" : {
+		"parentTimestamp" : "0x0182c3e7ab",
+		"parentDifficulty" : "0x38e876995003847e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0182c3e7b9",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x38ef93a8232d84f0"
+	},
+
+ "DifficultyTest769" : {
+		"parentTimestamp" : "0x06467d0979",
+		"parentDifficulty" : "0x2fb5fd99168766e1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06467d0987",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x2fbbf458c9aa37d1"
+	},
+
+ "DifficultyTest770" : {
+		"parentTimestamp" : "0x018355585d",
+		"parentDifficulty" : "0x33174321c5b313b9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x018355586b",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x331da60a29ebca23"
+	},
+
+ "DifficultyTest771" : {
+		"parentTimestamp" : "0x03c5688005",
+		"parentDifficulty" : "0x30021ed838eb7f0c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03c5688013",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x30081f1c13f29c8b"
+	},
+
+ "DifficultyTest772" : {
+		"parentTimestamp" : "0x06a8a443b4",
+		"parentDifficulty" : "0x613dfb751159cc2e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06a8a443c2",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x614a23347ffbf787"
+	},
+
+ "DifficultyTest773" : {
+		"parentTimestamp" : "0x02cf5ae9f5",
+		"parentDifficulty" : "0x506ca6c79b533118",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cf5aea03",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x5076b45c74469bbe"
+	},
+
+ "DifficultyTest774" : {
+		"parentTimestamp" : "0x9253e04d",
+		"parentDifficulty" : "0x6ab3c845d7a5bd6f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9253e05b",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x6ac11ebee060b2a6"
+	},
+
+ "DifficultyTest775" : {
+		"parentTimestamp" : "0x02e7ab1b2f",
+		"parentDifficulty" : "0x4df3af2de51ef97f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02e7ab1b3d",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x4dfd6da3cadb9e5e"
+	},
+
+ "DifficultyTest776" : {
+		"parentTimestamp" : "0x02f3e81760",
+		"parentDifficulty" : "0x55d75701464899da",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f3e8176e",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x55e211ec267164ed"
+	},
+
+ "DifficultyTest777" : {
+		"parentTimestamp" : "0x0246a5e432",
+		"parentDifficulty" : "0x2c043cf6659d61c1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0246a5e440",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x2c09bd7e046a196d"
+	},
+
+ "DifficultyTest778" : {
+		"parentTimestamp" : "0x04edeb6a52",
+		"parentDifficulty" : "0x079b68ef5937839e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04edeb6a60",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x079c5c5c7722aa8e"
+	},
+
+ "DifficultyTest779" : {
+		"parentTimestamp" : "0x07e8ebda55",
+		"parentDifficulty" : "0x253186445f89e1b4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e8ebda63",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x25362c752815d2f0"
+	},
+
+ "DifficultyTest780" : {
+		"parentTimestamp" : "0x0764b2e550",
+		"parentDifficulty" : "0x2b31e92256baad6b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0764b2e55e",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x2b374f5f7b0584c0"
+	},
+
+ "DifficultyTest781" : {
+		"parentTimestamp" : "0x063186195f",
+		"parentDifficulty" : "0x1278074b79dd6882",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x063186196d",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x127a564c634ca42f"
+	},
+
+ "DifficultyTest782" : {
+		"parentTimestamp" : "0x0401cd018a",
+		"parentDifficulty" : "0x3cc06bca925b0f52",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0401cd0198",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x3cc803d80bad5ab3"
+	},
+
+ "DifficultyTest783" : {
+		"parentTimestamp" : "0x047be64bb4",
+		"parentDifficulty" : "0x2e6e08fe63eabd6c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x047be64bc2",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x2e73d6bf83b73ac3"
+	},
+
+ "DifficultyTest784" : {
+		"parentTimestamp" : "0xc61741c2",
+		"parentDifficulty" : "0x1fa25479e599043b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xc61741d0",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x1fa648c474d5b75b"
+	},
+
+ "DifficultyTest785" : {
+		"parentTimestamp" : "0x0581f0610d",
+		"parentDifficulty" : "0x193b0c89510924ff",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0581f0611d",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x193b0c89510924ff"
+	},
+
+ "DifficultyTest786" : {
+		"parentTimestamp" : "0x0678078edf",
+		"parentDifficulty" : "0x42518c66da175d10",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0678078eef",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x42518c66da175d11"
+	},
+
+ "DifficultyTest787" : {
+		"parentTimestamp" : "0x01b90c9bc8",
+		"parentDifficulty" : "0x3f381f0208b3bc6d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01b90c9bd8",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x3f381f0208b3bc6f"
+	},
+
+ "DifficultyTest788" : {
+		"parentTimestamp" : "0x04378e4c02",
+		"parentDifficulty" : "0x0e5ce623f1f20228",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04378e4c12",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x0e5ce623f1f2022c"
+	},
+
+ "DifficultyTest789" : {
+		"parentTimestamp" : "0x0307d23091",
+		"parentDifficulty" : "0x03d3acc56b14b0c8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0307d230a1",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x03d3acc56b14b0d0"
+	},
+
+ "DifficultyTest790" : {
+		"parentTimestamp" : "0x2f6c2c28",
+		"parentDifficulty" : "0x1741313d5db169d9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2f6c2c38",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x1741313d5db169e9"
+	},
+
+ "DifficultyTest791" : {
+		"parentTimestamp" : "0x026838c8c4",
+		"parentDifficulty" : "0x73e6a4ffbb81e5a5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x026838c8d4",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x73e6a4ffbb81e5c5"
+	},
+
+ "DifficultyTest792" : {
+		"parentTimestamp" : "0x010589dce6",
+		"parentDifficulty" : "0x51aab45355b43c25",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x010589dcf6",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x51aab45355b43c65"
+	},
+
+ "DifficultyTest793" : {
+		"parentTimestamp" : "0xd3f1ac9e",
+		"parentDifficulty" : "0x3a59e33afa62d59b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xd3f1acae",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x3a59e33afa62d61b"
+	},
+
+ "DifficultyTest794" : {
+		"parentTimestamp" : "0x0de38ace",
+		"parentDifficulty" : "0x30dd8c7ea98c9d34",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0de38ade",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x30dd8c7ea98c9e34"
+	},
+
+ "DifficultyTest795" : {
+		"parentTimestamp" : "0x03bd4f0bd4",
+		"parentDifficulty" : "0x1c782a83380e439b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03bd4f0be4",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x1c782a83380e459b"
+	},
+
+ "DifficultyTest796" : {
+		"parentTimestamp" : "0x03b3b3e9a3",
+		"parentDifficulty" : "0x29382c4b76948217",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b3b3e9b3",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x29382c4b76948617"
+	},
+
+ "DifficultyTest797" : {
+		"parentTimestamp" : "0x0787a6c584",
+		"parentDifficulty" : "0x7e263ae5a203b8f4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0787a6c594",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x7e263ae5a203c0f4"
+	},
+
+ "DifficultyTest798" : {
+		"parentTimestamp" : "0x06bb176f4e",
+		"parentDifficulty" : "0x675a4635ff3709ae",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06bb176f5e",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x675a4635ff3719ae"
+	},
+
+ "DifficultyTest799" : {
+		"parentTimestamp" : "0x018bc8c260",
+		"parentDifficulty" : "0x6c745a0b4b4ea4af",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x018bc8c270",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x6c745a0b4b4ec4af"
+	},
+
+ "DifficultyTest800" : {
+		"parentTimestamp" : "0x07dc5ee6cf",
+		"parentDifficulty" : "0x7a2ca49306cb3b2a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07dc5ee6df",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x7a2ca49306cb7b2a"
+	},
+
+ "DifficultyTest801" : {
+		"parentTimestamp" : "0x01b1d6f175",
+		"parentDifficulty" : "0x787d4467493c8671",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01b1d6f185",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x787d4467493c8671"
+	},
+
+ "DifficultyTest802" : {
+		"parentTimestamp" : "0x023eb94f5b",
+		"parentDifficulty" : "0x1754a1223e1f6238",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x023eb94f6b",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x1754a1223e1f6238"
+	},
+
+ "DifficultyTest803" : {
+		"parentTimestamp" : "0x0795bd4281",
+		"parentDifficulty" : "0x48a682e8816f9949",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0795bd4291",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x48a682e8816f9949"
+	},
+
+ "DifficultyTest804" : {
+		"parentTimestamp" : "0x06e6238481",
+		"parentDifficulty" : "0x6c26ecced3cc2831",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06e6238491",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6c26ecced3cc2831"
+	},
+
+ "DifficultyTest805" : {
+		"parentTimestamp" : "0x05522ed17b",
+		"parentDifficulty" : "0x6a3590a745884971",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05522ed18b",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x6a3590a745884971"
+	},
+
+ "DifficultyTest806" : {
+		"parentTimestamp" : "0x0108152efe",
+		"parentDifficulty" : "0x2fa2fb1e1aca38a8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0108152f0e",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x2fa2fb1e1aca38a8"
+	},
+
+ "DifficultyTest807" : {
+		"parentTimestamp" : "0x03fdeced16",
+		"parentDifficulty" : "0x4512dc65666dd432",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03fdeced26",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x4512dc65666dd432"
+	},
+
+ "DifficultyTest808" : {
+		"parentTimestamp" : "0x049dcaee13",
+		"parentDifficulty" : "0x1915a2d5e6eb4e09",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x049dcaee23",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x1915a2d5e6eb4e09"
+	},
+
+ "DifficultyTest809" : {
+		"parentTimestamp" : "0x029ec8154f",
+		"parentDifficulty" : "0x1ad61b4c27c44317",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x029ec8155f",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x1ad61b4c27c44317"
+	},
+
+ "DifficultyTest810" : {
+		"parentTimestamp" : "0x03aebb161f",
+		"parentDifficulty" : "0x10f6721902b2e46d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03aebb162f",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x10f6721902b2e46d"
+	},
+
+ "DifficultyTest811" : {
+		"parentTimestamp" : "0x03faad277b",
+		"parentDifficulty" : "0x314d868a042577f5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03faad278b",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x314d868a042577f5"
+	},
+
+ "DifficultyTest812" : {
+		"parentTimestamp" : "0x022ac9efc9",
+		"parentDifficulty" : "0x6f466bafeff3bc27",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x022ac9efd9",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x6f466bafeff3bc27"
+	},
+
+ "DifficultyTest813" : {
+		"parentTimestamp" : "0x024bc0b0d4",
+		"parentDifficulty" : "0x066a41c476a9916b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x024bc0b0e4",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x066a41c476a9916b"
+	},
+
+ "DifficultyTest814" : {
+		"parentTimestamp" : "0x02dc471a29",
+		"parentDifficulty" : "0x0d3249d9ed847f04",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02dc471a39",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x0d3249d9ed847f04"
+	},
+
+ "DifficultyTest815" : {
+		"parentTimestamp" : "0x01e2500f14",
+		"parentDifficulty" : "0x5d1bb9e96fc91efc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01e2500f24",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x5d1bb9e96fc91efc"
+	},
+
+ "DifficultyTest816" : {
+		"parentTimestamp" : "0x0473bfca6e",
+		"parentDifficulty" : "0x25b09effbe21b03c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0473bfca7e",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x25b09effbe21b03d"
+	},
+
+ "DifficultyTest817" : {
+		"parentTimestamp" : "0x071c52f248",
+		"parentDifficulty" : "0x51b6c605e4eb7fa3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x071c52f258",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x51b6c605e4eb7fa5"
+	},
+
+ "DifficultyTest818" : {
+		"parentTimestamp" : "0x040f6772ae",
+		"parentDifficulty" : "0x7935953a7650bc57",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x040f6772be",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x7935953a7650bc5b"
+	},
+
+ "DifficultyTest819" : {
+		"parentTimestamp" : "0x03539cf73d",
+		"parentDifficulty" : "0x579daa7502ab65cd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03539cf74d",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x579daa7502ab65d5"
+	},
+
+ "DifficultyTest820" : {
+		"parentTimestamp" : "0x260e2d0c",
+		"parentDifficulty" : "0x3a6c53b7bd6e8015",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x260e2d1c",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x3a6c53b7bd6e8025"
+	},
+
+ "DifficultyTest821" : {
+		"parentTimestamp" : "0x0344b10a5b",
+		"parentDifficulty" : "0x6bb3da9e9b9b87bb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0344b10a6b",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x6bb3da9e9b9b87db"
+	},
+
+ "DifficultyTest822" : {
+		"parentTimestamp" : "0x0666f7c5e4",
+		"parentDifficulty" : "0x716dff2b24011a5d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0666f7c5f4",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x716dff2b24011a9d"
+	},
+
+ "DifficultyTest823" : {
+		"parentTimestamp" : "0x01ec1c8ed0",
+		"parentDifficulty" : "0x4a96b7a28d716e3d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01ec1c8ee0",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x4a96b7a28d716ebd"
+	},
+
+ "DifficultyTest824" : {
+		"parentTimestamp" : "0x02adf6fe7e",
+		"parentDifficulty" : "0x2e01b9543efcfabd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02adf6fe8e",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x2e01b9543efcfbbd"
+	},
+
+ "DifficultyTest825" : {
+		"parentTimestamp" : "0x03fab616e5",
+		"parentDifficulty" : "0x11039df099012b90",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03fab616f5",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x11039df099012d90"
+	},
+
+ "DifficultyTest826" : {
+		"parentTimestamp" : "0x04f5ddf831",
+		"parentDifficulty" : "0x229d57f3177f5106",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f5ddf841",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x229d57f3177f5506"
+	},
+
+ "DifficultyTest827" : {
+		"parentTimestamp" : "0x05e208afd2",
+		"parentDifficulty" : "0x27d33e932bab467b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e208afe2",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x27d33e932bab467b"
+	},
+
+ "DifficultyTest828" : {
+		"parentTimestamp" : "0x018c9c2a5c",
+		"parentDifficulty" : "0x34544d38b501284c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x018c9c2a6c",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x34544d38b501284c"
+	},
+
+ "DifficultyTest829" : {
+		"parentTimestamp" : "0x01989ae218",
+		"parentDifficulty" : "0x55d00b56d852bc73",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01989ae228",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x55d00b56d852bc73"
+	},
+
+ "DifficultyTest830" : {
+		"parentTimestamp" : "0x0662a82466",
+		"parentDifficulty" : "0x07bf9e669c5a6377",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0662a82476",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x07bf9e669c5a6377"
+	},
+
+ "DifficultyTest831" : {
+		"parentTimestamp" : "0x05d0df1d5c",
+		"parentDifficulty" : "0x793a50de914926",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d0df1d6c",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x793a50de914926"
+	},
+
+ "DifficultyTest832" : {
+		"parentTimestamp" : "0x0200b65fff",
+		"parentDifficulty" : "0x34b511f4b41fc6a5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0200b6600f",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x34b511f4b41fc6a5"
+	},
+
+ "DifficultyTest833" : {
+		"parentTimestamp" : "0x012c483bac",
+		"parentDifficulty" : "0x7f913fd2f1cf1745",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x012c483bbc",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x7f913fd2f1cf1745"
+	},
+
+ "DifficultyTest834" : {
+		"parentTimestamp" : "0x024202398c",
+		"parentDifficulty" : "0x63c5a115b0184b03",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x024202399c",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x63c5a115b0184b03"
+	},
+
+ "DifficultyTest835" : {
+		"parentTimestamp" : "0x04b5f877ea",
+		"parentDifficulty" : "0x117cfaed0035ddb7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04b5f877fa",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x117cfaed0035ddb8"
+	},
+
+ "DifficultyTest836" : {
+		"parentTimestamp" : "0x02157f9e49",
+		"parentDifficulty" : "0x793426f8bc144165",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02157f9e59",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x793426f8bc144167"
+	},
+
+ "DifficultyTest837" : {
+		"parentTimestamp" : "0x04bc7e52cb",
+		"parentDifficulty" : "0x05f08488b72fbd21",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04bc7e52db",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x05f08488b72fbd25"
+	},
+
+ "DifficultyTest838" : {
+		"parentTimestamp" : "0x072ee937d6",
+		"parentDifficulty" : "0x303beaf42453c4dc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x072ee937e6",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x303beaf42453c4e4"
+	},
+
+ "DifficultyTest839" : {
+		"parentTimestamp" : "0x90804ebe",
+		"parentDifficulty" : "0x677c2eee7d7c16b6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x90804ece",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x677c2eee7d7c16c6"
+	},
+
+ "DifficultyTest840" : {
+		"parentTimestamp" : "0x01692f3827",
+		"parentDifficulty" : "0x79e7e8f9c9980f7d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01692f3837",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x79e7e8f9c9980f9d"
+	},
+
+ "DifficultyTest841" : {
+		"parentTimestamp" : "0x0196781101",
+		"parentDifficulty" : "0x103ee45b29f5ef15",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0196781111",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x103ee45b29f5ef55"
+	},
+
+ "DifficultyTest842" : {
+		"parentTimestamp" : "0x7a957942",
+		"parentDifficulty" : "0x160e70ba85267da7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7a957952",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x160e70ba85267e27"
+	},
+
+ "DifficultyTest843" : {
+		"parentTimestamp" : "0x078027cfc6",
+		"parentDifficulty" : "0x56f7ed3ecbc2cb4e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x078027cfd6",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x56f7ed3ecbc2cc4e"
+	},
+
+ "DifficultyTest844" : {
+		"parentTimestamp" : "0x03b7ce1b53",
+		"parentDifficulty" : "0x23021792a3c88fe7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03b7ce1b63",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x23021792a3c891e7"
+	},
+
+ "DifficultyTest845" : {
+		"parentTimestamp" : "0x06e93dff35",
+		"parentDifficulty" : "0x78d79d52ebb5a5c3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06e93dff45",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x78d79d52ebb5a9c3"
+	},
+
+ "DifficultyTest846" : {
+		"parentTimestamp" : "0x04b5245330",
+		"parentDifficulty" : "0x1ef45b4e6d492a13",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04b5245340",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x1ef45b4e6d493213"
+	},
+
+ "DifficultyTest847" : {
+		"parentTimestamp" : "0x02a2edf839",
+		"parentDifficulty" : "0x47f3a460cb2a6b73",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02a2edf849",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x47f3a460cb2a7b73"
+	},
+
+ "DifficultyTest848" : {
+		"parentTimestamp" : "0x0782f1679a",
+		"parentDifficulty" : "0x5a1297345b7e6503",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0782f167aa",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x5a1297345b7e8503"
+	},
+
+ "DifficultyTest849" : {
+		"parentTimestamp" : "0x013e22f122",
+		"parentDifficulty" : "0x5c46b5f5b34864f5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013e22f132",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x5c46b5f5b348a4f5"
+	},
+
+ "DifficultyTest850" : {
+		"parentTimestamp" : "0x02df1b6423",
+		"parentDifficulty" : "0x30d71c193bebdfb6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02df1b6433",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x30dd36fcbf135d31"
+	},
+
+ "DifficultyTest851" : {
+		"parentTimestamp" : "0x0558ce36f0",
+		"parentDifficulty" : "0x3f6b475471cca001",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0558ce3700",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x3f7334bd5c5ad995"
+	},
+
+ "DifficultyTest852" : {
+		"parentTimestamp" : "0x01227cdf93",
+		"parentDifficulty" : "0x3698160e64685f48",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01227cdfa3",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x369ee9112634ec53"
+	},
+
+ "DifficultyTest853" : {
+		"parentTimestamp" : "0x03b4e2fbc5",
+		"parentDifficulty" : "0x74d5e75befbae369",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03b4e2fbd5",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x74e48218db38dac5"
+	},
+
+ "DifficultyTest854" : {
+		"parentTimestamp" : "0x073f50de82",
+		"parentDifficulty" : "0x2ddcb680f744de27",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x073f50de92",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x2de27217c763c6c2"
+	},
+
+ "DifficultyTest855" : {
+		"parentTimestamp" : "0x03ce764580",
+		"parentDifficulty" : "0x37afe75fcd991891",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ce764590",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x37b6dd5cb992cbb4"
+	},
+
+ "DifficultyTest856" : {
+		"parentTimestamp" : "0x22610e59",
+		"parentDifficulty" : "0x5f7319b5d0fcedc8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x22610e69",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x5f7f081907b70d65"
+	},
+
+ "DifficultyTest857" : {
+		"parentTimestamp" : "0x049045a0e1",
+		"parentDifficulty" : "0x7148c641c75350fa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x049045a0f1",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x7156ef5a8f8c3b64"
+	},
+
+ "DifficultyTest858" : {
+		"parentTimestamp" : "0x07caa173f9",
+		"parentDifficulty" : "0x7ce4cb0efd757ec5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07caa17409",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x7cf467a85f552d74"
+	},
+
+ "DifficultyTest859" : {
+		"parentTimestamp" : "0x0420a2bc",
+		"parentDifficulty" : "0x7393069826e14c37",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0420a2cc",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x73a178f8f9e62860"
+	},
+
+ "DifficultyTest860" : {
+		"parentTimestamp" : "0x04e3dd3cd2",
+		"parentDifficulty" : "0x5ebcf4f3c7b078ef",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e3dd3ce2",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x5ec8cc9266296efe"
+	},
+
+ "DifficultyTest861" : {
+		"parentTimestamp" : "0x058bc14517",
+		"parentDifficulty" : "0x12160ac839c7d629",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x058bc14527",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x12184d8992cf0f23"
+	},
+
+ "DifficultyTest862" : {
+		"parentTimestamp" : "0x05ae7957c6",
+		"parentDifficulty" : "0x61ed7a052c248ff5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05ae7957d6",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x61f9b7b46cca1486"
+	},
+
+ "DifficultyTest863" : {
+		"parentTimestamp" : "0x056bc22ccc",
+		"parentDifficulty" : "0x11e64e9ca98d01df",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x056bc22cdc",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x11e88b667d22337f"
+	},
+
+ "DifficultyTest864" : {
+		"parentTimestamp" : "0x0187f4a12b",
+		"parentDifficulty" : "0x4bfc62695d2581da",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0187f4a13b",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x4c05e1f5aa51268a"
+	},
+
+ "DifficultyTest865" : {
+		"parentTimestamp" : "0x212863",
+		"parentDifficulty" : "0x02863db6e04fb1ba",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x212873",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x02868e7e972bbbb1"
+	},
+
+ "DifficultyTest866" : {
+		"parentTimestamp" : "0x0249d8df6d",
+		"parentDifficulty" : "0x5a8b68752ba22c19",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0249d8df7d",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x5a96b9e23a47a060"
+	},
+
+ "DifficultyTest867" : {
+		"parentTimestamp" : "0x01e507eadd",
+		"parentDifficulty" : "0x17724d52bc32788a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e507eaed",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x17753b9c6689fedd"
+	},
+
+ "DifficultyTest868" : {
+		"parentTimestamp" : "0x019bc85fc1",
+		"parentDifficulty" : "0x0222844c83ce3535",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x019bc85fd1",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x0222c89d0d5eaf03"
+	},
+
+ "DifficultyTest869" : {
+		"parentTimestamp" : "0x06ce34d6de",
+		"parentDifficulty" : "0x17f9eddfe57e12f5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06ce34d6ee",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x17fced1da17ac2c7"
+	},
+
+ "DifficultyTest870" : {
+		"parentTimestamp" : "0x014767514a",
+		"parentDifficulty" : "0x275ef775a2384a33",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x014767515a",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x2763e35490ec915c"
+	},
+
+ "DifficultyTest871" : {
+		"parentTimestamp" : "0x0356c2a35f",
+		"parentDifficulty" : "0x03a88ab5461bbdfe",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0356c2a36f",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x03a8ffc69cc481b5"
+	},
+
+ "DifficultyTest872" : {
+		"parentTimestamp" : "0x1c88c86d",
+		"parentDifficulty" : "0x0dff64703a65f5b3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1c88c87d",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x0e01245cc86d42f1"
+	},
+
+ "DifficultyTest873" : {
+		"parentTimestamp" : "0x01d9509193",
+		"parentDifficulty" : "0x49bda7c7ee4c4789",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01d95091a3",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x49c6df7ce74a1211"
+	},
+
+ "DifficultyTest874" : {
+		"parentTimestamp" : "0x067e096e56",
+		"parentDifficulty" : "0x5d302002d256a1ff",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x067e096e66",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x5d3bc606d2b0eed3"
+	},
+
+ "DifficultyTest875" : {
+		"parentTimestamp" : "0x05206d272e",
+		"parentDifficulty" : "0x09eb3b79ba7919cf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05206d273e",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x09ec78e129b06cf2"
+	},
+
+ "DifficultyTest876" : {
+		"parentTimestamp" : "0x0187e152bb",
+		"parentDifficulty" : "0x66e03c806531277e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0187e152cb",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x66ed1887f53dcda2"
+	},
+
+ "DifficultyTest877" : {
+		"parentTimestamp" : "0x073685a070",
+		"parentDifficulty" : "0x69ca5cf121132f47",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x073685a080",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x69d7963cbf3751ac"
+	},
+
+ "DifficultyTest878" : {
+		"parentTimestamp" : "0x03d9beac33",
+		"parentDifficulty" : "0x11f231f8650f049b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03d9beac43",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x11f4703ea41ba67b"
+	},
+
+ "DifficultyTest879" : {
+		"parentTimestamp" : "0x079fc87fd3",
+		"parentDifficulty" : "0x4fb00b5b44433365",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x079fc87fe3",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x4fba015cafabbbcb"
+	},
+
+ "DifficultyTest880" : {
+		"parentTimestamp" : "0x052eda8cde",
+		"parentDifficulty" : "0x15ec6a3ed045476c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x052eda8cee",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x15ef27cc181f5014"
+	},
+
+ "DifficultyTest881" : {
+		"parentTimestamp" : "0x02b18e7d8d",
+		"parentDifficulty" : "0x30690e20890b004d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02b18e7d9d",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x306f1b424d1c21ad"
+	},
+
+ "DifficultyTest882" : {
+		"parentTimestamp" : "0x02d98a0d8b",
+		"parentDifficulty" : "0x0a3f479d12946df8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02d98a0d9b",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x0a408f860636c085"
+	},
+
+ "DifficultyTest883" : {
+		"parentTimestamp" : "0x0608379538",
+		"parentDifficulty" : "0x196f4f0776a9308f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060837954a",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x196f4f0776a9308f"
+	},
+
+ "DifficultyTest884" : {
+		"parentTimestamp" : "0x038e13419b",
+		"parentDifficulty" : "0x25aa6146657cf7f1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x038e1341ad",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x25aa6146657cf7f2"
+	},
+
+ "DifficultyTest885" : {
+		"parentTimestamp" : "0x061cafb51e",
+		"parentDifficulty" : "0x59c6f1423c571824",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x061cafb530",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x59c6f1423c571826"
+	},
+
+ "DifficultyTest886" : {
+		"parentTimestamp" : "0x041a8c96e1",
+		"parentDifficulty" : "0x1f9659be95824bdf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x041a8c96f3",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x1f9659be95824be3"
+	},
+
+ "DifficultyTest887" : {
+		"parentTimestamp" : "0x0776bb1cce",
+		"parentDifficulty" : "0x1d4566cd56c79d90",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0776bb1ce0",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x1d4566cd56c79d98"
+	},
+
+ "DifficultyTest888" : {
+		"parentTimestamp" : "0x07db696e55",
+		"parentDifficulty" : "0x78bdb64b42fad6fd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07db696e67",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x78bdb64b42fad70d"
+	},
+
+ "DifficultyTest889" : {
+		"parentTimestamp" : "0x06d3f95736",
+		"parentDifficulty" : "0x0a2d1894728557a8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06d3f95748",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x0a2d1894728557c8"
+	},
+
+ "DifficultyTest890" : {
+		"parentTimestamp" : "0x0614310d19",
+		"parentDifficulty" : "0x17333630947b04e7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0614310d2b",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x17333630947b0527"
+	},
+
+ "DifficultyTest891" : {
+		"parentTimestamp" : "0x06b00cfabf",
+		"parentDifficulty" : "0x4dec0b68b071f56f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06b00cfad1",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x4dec0b68b071f5ef"
+	},
+
+ "DifficultyTest892" : {
+		"parentTimestamp" : "0x04a850c5b2",
+		"parentDifficulty" : "0x4233b04a5c97e661",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04a850c5c4",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x4233b04a5c97e761"
+	},
+
+ "DifficultyTest893" : {
+		"parentTimestamp" : "0x05c0b3a380",
+		"parentDifficulty" : "0x45a62463f7889fde",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05c0b3a392",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x45a62463f788a1de"
+	},
+
+ "DifficultyTest894" : {
+		"parentTimestamp" : "0x03cc83cbe5",
+		"parentDifficulty" : "0x41e1a782c583d995",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03cc83cbf7",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x41e1a782c583dd95"
+	},
+
+ "DifficultyTest895" : {
+		"parentTimestamp" : "0x060bcc57f4",
+		"parentDifficulty" : "0x5de67f3df34cfb73",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060bcc5806",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x5de67f3df34d0373"
+	},
+
+ "DifficultyTest896" : {
+		"parentTimestamp" : "0x069cd738fd",
+		"parentDifficulty" : "0x3a26c93def6d1e4d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x069cd7390f",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x3a26c93def6d2e4d"
+	},
+
+ "DifficultyTest897" : {
+		"parentTimestamp" : "0x07ddbade23",
+		"parentDifficulty" : "0x7f3d02144b0f41eb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07ddbade35",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x7f3d02144b0f61eb"
+	},
+
+ "DifficultyTest898" : {
+		"parentTimestamp" : "0x01422dad9d",
+		"parentDifficulty" : "0x084069a351bd0fe0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01422dadaf",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x084069a351bd4fe0"
+	},
+
+ "DifficultyTest899" : {
+		"parentTimestamp" : "0x075d3c91b2",
+		"parentDifficulty" : "0x29f4a35d093967dc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x075d3c91c4",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x29ef64c89d9840b0"
+	},
+
+ "DifficultyTest900" : {
+		"parentTimestamp" : "0x054febd93b",
+		"parentDifficulty" : "0x67a04cba8241f475",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x054febd94d",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x679358b0eaf1ac37"
+	},
+
+ "DifficultyTest901" : {
+		"parentTimestamp" : "0x031c934387",
+		"parentDifficulty" : "0x5f78a4f5e100ebcd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x031c934399",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x5f6cb5e14244cbb0"
+	},
+
+ "DifficultyTest902" : {
+		"parentTimestamp" : "0x02d6e8f056",
+		"parentDifficulty" : "0x2953242c2bba0e85",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d6e8f068",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x294df9c7a6349744"
+	},
+
+ "DifficultyTest903" : {
+		"parentTimestamp" : "0x04030b03c2",
+		"parentDifficulty" : "0x7e08a2870206fd15",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04030b03d4",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x7df8e172b126bc36"
+	},
+
+ "DifficultyTest904" : {
+		"parentTimestamp" : "0x0134562508",
+		"parentDifficulty" : "0x1372910bb80e0246",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x013456251a",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x137022b996970086"
+	},
+
+ "DifficultyTest905" : {
+		"parentTimestamp" : "0x03462219ec",
+		"parentDifficulty" : "0x6b72d769eae1abd7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03462219fe",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x6b65690efda44fa2"
+	},
+
+ "DifficultyTest906" : {
+		"parentTimestamp" : "0xae0ee4f8",
+		"parentDifficulty" : "0x29601c62edd75b2d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xae0ee50a",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x295af05f6179a042"
+	},
+
+ "DifficultyTest907" : {
+		"parentTimestamp" : "0x044b636b99",
+		"parentDifficulty" : "0x5a0fba30032c6254",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044b636bab",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x5a047838bd2bfcc8"
+	},
+
+ "DifficultyTest908" : {
+		"parentTimestamp" : "0x02c9217a5b",
+		"parentDifficulty" : "0x6da5f7bad5db32c9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02c9217a6d",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x6d9842fbde807763"
+	},
+
+ "DifficultyTest909" : {
+		"parentTimestamp" : "0x027744d809",
+		"parentDifficulty" : "0x04dd561154a5b320",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x027744d81b",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x04dcba66927b1e6a"
+	},
+
+ "DifficultyTest910" : {
+		"parentTimestamp" : "0xbe2de469",
+		"parentDifficulty" : "0x5f37887b03776ccc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xbe2de47b",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x5f2ba189f416fddf"
+	},
+
+ "DifficultyTest911" : {
+		"parentTimestamp" : "0x846c9d9b",
+		"parentDifficulty" : "0x620d7475b54f2fda",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x846c9dad",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x620132c7269885f5"
+	},
+
+ "DifficultyTest912" : {
+		"parentTimestamp" : "0x50ce8d8c",
+		"parentDifficulty" : "0x6e5f612a56e0934b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x50ce8d9e",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x6e51953e3195b739"
+	},
+
+ "DifficultyTest913" : {
+		"parentTimestamp" : "0x03a8e2e994",
+		"parentDifficulty" : "0x03fb89420bdc1088",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03a8e2e9a6",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x03fb09d0e39a9506"
+	},
+
+ "DifficultyTest914" : {
+		"parentTimestamp" : "0x03a9ef47aa",
+		"parentDifficulty" : "0x21d701196f6381",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03a9ef47bc",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x21d2c6394c3596"
+	},
+
+ "DifficultyTest915" : {
+		"parentTimestamp" : "0x02da171595",
+		"parentDifficulty" : "0x051472fa92f96654",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02da1715a7",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x0513d06c33a7072a"
+	},
+
+ "DifficultyTest916" : {
+		"parentTimestamp" : "0x03b5bd8cf9",
+		"parentDifficulty" : "0x305b7b2f78b633cb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b5bd8d0b",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x30556fc012c71d09"
+	},
+
+ "DifficultyTest917" : {
+		"parentTimestamp" : "0x0444ffc1f3",
+		"parentDifficulty" : "0x3ab612ba00c9fc36",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0444ffc205",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x3aaebbf7a989e2ff"
+	},
+
+ "DifficultyTest918" : {
+		"parentTimestamp" : "0x0214f7611b",
+		"parentDifficulty" : "0x1e1881a2fb1ec735",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0214f7612d",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x1e14be92c6bf636d"
+	},
+
+ "DifficultyTest919" : {
+		"parentTimestamp" : "0x033d91e991",
+		"parentDifficulty" : "0x4a6517f9947ab9b8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x033d91e9a3",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x4a5bcb5695482a81"
+	},
+
+ "DifficultyTest920" : {
+		"parentTimestamp" : "0x02513934a2",
+		"parentDifficulty" : "0x71aa5d1a0cb568e0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02513934b4",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x719c27ce6973d273"
+	},
+
+ "DifficultyTest921" : {
+		"parentTimestamp" : "0x04dd03f9df",
+		"parentDifficulty" : "0x02bd3e445d16c8b9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04dd03f9f1",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x02bce69c948b2660"
+	},
+
+ "DifficultyTest922" : {
+		"parentTimestamp" : "0x07aa102643",
+		"parentDifficulty" : "0x41e973fd1b485e4d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07aa102655",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x41e136ce9ba4f642"
+	},
+
+ "DifficultyTest923" : {
+		"parentTimestamp" : "0x04ca828c9d",
+		"parentDifficulty" : "0x0250e7059f593ce7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04ca828caf",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x02509ce8bea553c0"
+	},
+
+ "DifficultyTest924" : {
+		"parentTimestamp" : "0x038dab05f3",
+		"parentDifficulty" : "0x2ad5efc3ae4fdd1d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x038dab0605",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x2ad09505b5da1722"
+	},
+
+ "DifficultyTest925" : {
+		"parentTimestamp" : "0x01dc8bc95e",
+		"parentDifficulty" : "0x12b71421e71909f2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01dc8bc970",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x12b4bd3f62dc26d1"
+	},
+
+ "DifficultyTest926" : {
+		"parentTimestamp" : "0x0732642e08",
+		"parentDifficulty" : "0x12e7e4aa560bedda",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0732642e1a",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x12e587adc0c12c5d"
+	},
+
+ "DifficultyTest927" : {
+		"parentTimestamp" : "0x0304d2870d",
+		"parentDifficulty" : "0x2addcc445615d92b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0304d2871f",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x2ad8708acd8b1670"
+	},
+
+ "DifficultyTest928" : {
+		"parentTimestamp" : "0x05e343592c",
+		"parentDifficulty" : "0x443076d5636d999a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e343593e",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x4427f0c688c12be7"
+	},
+
+ "DifficultyTest929" : {
+		"parentTimestamp" : "0x05e12b2656",
+		"parentDifficulty" : "0x3eb759969126fcba",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e12b2668",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x3eaf82ab5e54d7db"
+	},
+
+ "DifficultyTest930" : {
+		"parentTimestamp" : "0x044b449a0b",
+		"parentDifficulty" : "0x4dc0e013c19be905",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044b449a1d",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x4db727f7bf23b588"
+	},
+
+ "DifficultyTest931" : {
+		"parentTimestamp" : "0x744d608c",
+		"parentDifficulty" : "0x3d077ac8e60939ac",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x744d609e",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x3cffd9d98cec7885"
+	},
+
+ "DifficultyTest932" : {
+		"parentTimestamp" : "0x041f99d719",
+		"parentDifficulty" : "0x2c3bdc79745181",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x041f99d72b",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x2c3bdc79745181"
+	},
+
+ "DifficultyTest933" : {
+		"parentTimestamp" : "0x05e4f7d4ff",
+		"parentDifficulty" : "0x0ecc26f430796212",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e4f7d511",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x0ecc26f430796213"
+	},
+
+ "DifficultyTest934" : {
+		"parentTimestamp" : "0x03a8beaa86",
+		"parentDifficulty" : "0x35b1763abf3b784b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03a8beaa98",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x35b1763abf3b784d"
+	},
+
+ "DifficultyTest935" : {
+		"parentTimestamp" : "0x05e312caf3",
+		"parentDifficulty" : "0x6b828a2c78c4cd3d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e312cb05",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x6b828a2c78c4cd41"
+	},
+
+ "DifficultyTest936" : {
+		"parentTimestamp" : "0x05313bfa45",
+		"parentDifficulty" : "0x4dd7654a4b110efb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05313bfa57",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x4dd7654a4b110f03"
+	},
+
+ "DifficultyTest937" : {
+		"parentTimestamp" : "0x0648ed69cc",
+		"parentDifficulty" : "0x227c7de5d9a7702c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0648ed69de",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x227c7de5d9a7703c"
+	},
+
+ "DifficultyTest938" : {
+		"parentTimestamp" : "0x037d2c25e5",
+		"parentDifficulty" : "0x4830f4b39e936b45",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x037d2c25f7",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x4830f4b39e936b65"
+	},
+
+ "DifficultyTest939" : {
+		"parentTimestamp" : "0x03b4b35372",
+		"parentDifficulty" : "0x421b33bdd37f4d69",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03b4b35384",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x421b33bdd37f4da9"
+	},
+
+ "DifficultyTest940" : {
+		"parentTimestamp" : "0x053f5e8ba9",
+		"parentDifficulty" : "0x7e0e315e294e3ba8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x053f5e8bbb",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x7e0e315e294e3c28"
+	},
+
+ "DifficultyTest941" : {
+		"parentTimestamp" : "0x05ace72da2",
+		"parentDifficulty" : "0x2b2eaa20e8b55aa5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05ace72db4",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x2b2eaa20e8b55ba5"
+	},
+
+ "DifficultyTest942" : {
+		"parentTimestamp" : "0x023e32cbef",
+		"parentDifficulty" : "0x7a085148db879106",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x023e32cc01",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x7a085148db879306"
+	},
+
+ "DifficultyTest943" : {
+		"parentTimestamp" : "0x079c7e02fb",
+		"parentDifficulty" : "0x66ac74a5e2b93952",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x079c7e030d",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x66ac74a5e2b93d52"
+	},
+
+ "DifficultyTest944" : {
+		"parentTimestamp" : "0x053f4ab2f8",
+		"parentDifficulty" : "0x380116f3766aab31",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x053f4ab30a",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x380116f3766ab331"
+	},
+
+ "DifficultyTest945" : {
+		"parentTimestamp" : "0x031e62e164",
+		"parentDifficulty" : "0x4378e11c7b0da4a0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x031e62e176",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x4378e11c7b0db4a0"
+	},
+
+ "DifficultyTest946" : {
+		"parentTimestamp" : "0x07092a53",
+		"parentDifficulty" : "0x68180da9be0fb120",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07092a65",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x68180da9be0fd120"
+	},
+
+ "DifficultyTest947" : {
+		"parentTimestamp" : "0x0712730971",
+		"parentDifficulty" : "0x3f57c824235af136",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0712730983",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x3f57c824235b3136"
+	},
+
+ "DifficultyTest948" : {
+		"parentTimestamp" : "0x07de8ba211",
+		"parentDifficulty" : "0x4b090b9e37ea195e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07de8ba223",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x4b090b9e37ea195e"
+	},
+
+ "DifficultyTest949" : {
+		"parentTimestamp" : "0x0591cd5b55",
+		"parentDifficulty" : "0x08659d60dbc7bfc1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0591cd5b67",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x08659d60dbc7bfc1"
+	},
+
+ "DifficultyTest950" : {
+		"parentTimestamp" : "0x073a6ebfe1",
+		"parentDifficulty" : "0x4e142911d07c8c1f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x073a6ebff3",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4e142911d07c8c1f"
+	},
+
+ "DifficultyTest951" : {
+		"parentTimestamp" : "0x01a93b8b21",
+		"parentDifficulty" : "0x6f4cb53b6f40f65e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01a93b8b33",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6f4cb53b6f40f65e"
+	},
+
+ "DifficultyTest952" : {
+		"parentTimestamp" : "0x072f2c50e0",
+		"parentDifficulty" : "0x026000654e6e795e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x072f2c50f2",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x026000654e6e795e"
+	},
+
+ "DifficultyTest953" : {
+		"parentTimestamp" : "0x0162b16991",
+		"parentDifficulty" : "0x28d9ea7fbbcab73d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0162b169a3",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x28d9ea7fbbcab73d"
+	},
+
+ "DifficultyTest954" : {
+		"parentTimestamp" : "0x04846b26be",
+		"parentDifficulty" : "0x54553cac6af2104c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04846b26d0",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x54553cac6af2104c"
+	},
+
+ "DifficultyTest955" : {
+		"parentTimestamp" : "0x01a28e48df",
+		"parentDifficulty" : "0x097f9954061af9a2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01a28e48f1",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x097f9954061af9a2"
+	},
+
+ "DifficultyTest956" : {
+		"parentTimestamp" : "0x02d30fd425",
+		"parentDifficulty" : "0x4bfc9b801c62c428",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02d30fd437",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x4bfc9b801c62c428"
+	},
+
+ "DifficultyTest957" : {
+		"parentTimestamp" : "0x0667581cf2",
+		"parentDifficulty" : "0x7152f281fa92ea6e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0667581d04",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x7152f281fa92ea6e"
+	},
+
+ "DifficultyTest958" : {
+		"parentTimestamp" : "0x0360e883d3",
+		"parentDifficulty" : "0x0b5d659edc8cd5f7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0360e883e5",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x0b5d659edc8cd5f7"
+	},
+
+ "DifficultyTest959" : {
+		"parentTimestamp" : "0x02c59cfd77",
+		"parentDifficulty" : "0x43f0eaf024248b36",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02c59cfd89",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x43f0eaf024248b36"
+	},
+
+ "DifficultyTest960" : {
+		"parentTimestamp" : "0x06c62f1a82",
+		"parentDifficulty" : "0x3e3be16f136aed15",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c62f1a94",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x3e3be16f136aed15"
+	},
+
+ "DifficultyTest961" : {
+		"parentTimestamp" : "0x02205c7d3e",
+		"parentDifficulty" : "0x2a15a83ce72a13a1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02205c7d50",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x2a15a83ce72a13a1"
+	},
+
+ "DifficultyTest962" : {
+		"parentTimestamp" : "0x04728c7367",
+		"parentDifficulty" : "0x15140ec65d27259a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04728c7379",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x15140ec65d27259a"
+	},
+
+ "DifficultyTest963" : {
+		"parentTimestamp" : "0x053a05913d",
+		"parentDifficulty" : "0x06aa80b895bd8d48",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x053a05914f",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x06aa80b895bd8d49"
+	},
+
+ "DifficultyTest964" : {
+		"parentTimestamp" : "0x01fcde1933",
+		"parentDifficulty" : "0x35caa3a908a82c5d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01fcde1945",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x35caa3a908a82c5f"
+	},
+
+ "DifficultyTest965" : {
+		"parentTimestamp" : "0x031c65fba8",
+		"parentDifficulty" : "0x7e3c72846c18cf47",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x031c65fbba",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x7e3c72846c18cf4b"
+	},
+
+ "DifficultyTest966" : {
+		"parentTimestamp" : "0x06c669b557",
+		"parentDifficulty" : "0x1cd9de79608e1e7a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c669b569",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x1cd9de79608e1e82"
+	},
+
+ "DifficultyTest967" : {
+		"parentTimestamp" : "0x03849d78c1",
+		"parentDifficulty" : "0x5e722e784ea0fe08",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03849d78d3",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x5e722e784ea0fe18"
+	},
+
+ "DifficultyTest968" : {
+		"parentTimestamp" : "0x01c2bf3b01",
+		"parentDifficulty" : "0x61d97b6fb8e4c391",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c2bf3b13",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x61d97b6fb8e4c3b1"
+	},
+
+ "DifficultyTest969" : {
+		"parentTimestamp" : "0x07bd5db439",
+		"parentDifficulty" : "0x2b1742a1e24674dc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07bd5db44b",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2b1742a1e246751c"
+	},
+
+ "DifficultyTest970" : {
+		"parentTimestamp" : "0x068ff0651d",
+		"parentDifficulty" : "0x55ca552ae69d42ec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x068ff0652f",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x55ca552ae69d436c"
+	},
+
+ "DifficultyTest971" : {
+		"parentTimestamp" : "0x370e2792",
+		"parentDifficulty" : "0x4f457fcf3e776a45",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x370e27a4",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x4f457fcf3e776b45"
+	},
+
+ "DifficultyTest972" : {
+		"parentTimestamp" : "0x0795f94e8e",
+		"parentDifficulty" : "0x4fbda2f2af00bb84",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0795f94ea0",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x4fbda2f2af00bd84"
+	},
+
+ "DifficultyTest973" : {
+		"parentTimestamp" : "0xaad2c8c1",
+		"parentDifficulty" : "0x1597be25590daed0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xaad2c8d3",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x1597be25590db2d0"
+	},
+
+ "DifficultyTest974" : {
+		"parentTimestamp" : "0x09ea42f0",
+		"parentDifficulty" : "0x48b30a436a65c1ce",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x09ea4302",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x48b30a436a65c1ce"
+	},
+
+ "DifficultyTest975" : {
+		"parentTimestamp" : "0x07203b6770",
+		"parentDifficulty" : "0x061b7a32c69e58c5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07203b6782",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x061b7a32c69e58c5"
+	},
+
+ "DifficultyTest976" : {
+		"parentTimestamp" : "0x03230dea1e",
+		"parentDifficulty" : "0x08343eeee48757c6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03230dea30",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x08343eeee48757c6"
+	},
+
+ "DifficultyTest977" : {
+		"parentTimestamp" : "0x0665afa76e",
+		"parentDifficulty" : "0x4573dc1c0c2c9206",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0665afa780",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x4573dc1c0c2c9206"
+	},
+
+ "DifficultyTest978" : {
+		"parentTimestamp" : "0x030d3898d3",
+		"parentDifficulty" : "0x7a5ae2915252c86b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x030d3898e5",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x7a5ae2915252c86b"
+	},
+
+ "DifficultyTest979" : {
+		"parentTimestamp" : "0x01b2cf3710",
+		"parentDifficulty" : "0x7d1cb121798043bb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01b2cf3722",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x7d1cb121798043bb"
+	},
+
+ "DifficultyTest980" : {
+		"parentTimestamp" : "0x03da78bd16",
+		"parentDifficulty" : "0x35abb1ae4fff3ff8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03da78bd28",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x35abb1ae4fff3ff8"
+	},
+
+ "DifficultyTest981" : {
+		"parentTimestamp" : "0x0670660408",
+		"parentDifficulty" : "0x51a7115862c79d33",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x067066041c",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x519cdc7637bb4440"
+	},
+
+ "DifficultyTest982" : {
+		"parentTimestamp" : "0x036fa8acb5",
+		"parentDifficulty" : "0x5f6f89fd0548d434",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x036fa8acc9",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x5f639c0bc5a82b1b"
+	},
+
+ "DifficultyTest983" : {
+		"parentTimestamp" : "0x046580a612",
+		"parentDifficulty" : "0x607e63e2e1b01f40",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046580a626",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x607254166553e93f"
+	},
+
+ "DifficultyTest984" : {
+		"parentTimestamp" : "0x02e730f407",
+		"parentDifficulty" : "0x0da1044088b7b20b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e730f41b",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x0d9f502000a69b19"
+	},
+
+ "DifficultyTest985" : {
+		"parentTimestamp" : "0x02f759183c",
+		"parentDifficulty" : "0x63aee0ffc4f8dcc1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02f7591850",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x63a26b23a5003dae"
+	},
+
+ "DifficultyTest986" : {
+		"parentTimestamp" : "0x04c546cb47",
+		"parentDifficulty" : "0x42a4795e3a8d9173",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c546cb5b",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x429c24cf0ec63fd1"
+	},
+
+ "DifficultyTest987" : {
+		"parentTimestamp" : "0x07974ecb0b",
+		"parentDifficulty" : "0x440146b757aafde2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07974ecb1f",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x43f8c68e80c008a3"
+	},
+
+ "DifficultyTest988" : {
+		"parentTimestamp" : "0x08dcb2bb",
+		"parentDifficulty" : "0x48343297454abf3d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x08dcb2cf",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x482b2c10f2621626"
+	},
+
+ "DifficultyTest989" : {
+		"parentTimestamp" : "0xa0fe8b48",
+		"parentDifficulty" : "0x55867325a3f318ad",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa0fe8b5c",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x557bc2573f3e9aca"
+	},
+
+ "DifficultyTest990" : {
+		"parentTimestamp" : "0x05dc1a7ff4",
+		"parentDifficulty" : "0x49cced104e1d79f2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05dc1a8008",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x49c3b372ac13b743"
+	},
+
+ "DifficultyTest991" : {
+		"parentTimestamp" : "0xa805fa39",
+		"parentDifficulty" : "0x725bb6fc68095e4d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa805fa4d",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x724d6b85887c5f22"
+	},
+
+ "DifficultyTest992" : {
+		"parentTimestamp" : "0x0323ee8ff6",
+		"parentDifficulty" : "0x7165a4aab94b487d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0323ee900a",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x715777f623f42314"
+	},
+
+ "DifficultyTest993" : {
+		"parentTimestamp" : "0x0133ccc096",
+		"parentDifficulty" : "0x3608ed0242ee10a3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0133ccc0aa",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x36022be4a2a5bae1"
+	},
+
+ "DifficultyTest994" : {
+		"parentTimestamp" : "0x05f8441c5b",
+		"parentDifficulty" : "0x02250bc20ea4aa60",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f8441c6f",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x0224c7209662e5cb"
+	},
+
+ "DifficultyTest995" : {
+		"parentTimestamp" : "0x06aa93cadb",
+		"parentDifficulty" : "0x7ff571d0d5df88c8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06aa93caef",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x7fe573229bc4ecd7"
+	},
+
+ "DifficultyTest996" : {
+		"parentTimestamp" : "0x04346157e9",
+		"parentDifficulty" : "0x4ff9cb97d6af4ec3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04346157fd",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x4fefcc5e63b4b8da"
+	},
+
+ "DifficultyTest997" : {
+		"parentTimestamp" : "0x0653d3840f",
+		"parentDifficulty" : "0x6955272c6b84a1fb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0653d38423",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x6947fc8785f73167"
+	},
+
+ "DifficultyTest998" : {
+		"parentTimestamp" : "0x0731ce8e72",
+		"parentDifficulty" : "0x1b4422df42015bb1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0731ce8e86",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x1b40ba5ae6191b86"
+	},
+
+ "DifficultyTest999" : {
+		"parentTimestamp" : "0x02e7168ed3",
+		"parentDifficulty" : "0x618933f510e4d8eb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e7168ee7",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x617d02ce9242bc50"
+	},
+
+ "DifficultyTest1000" : {
+		"parentTimestamp" : "0x05178ae9fe",
+		"parentDifficulty" : "0x59f9c3c9d8a8ed58",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05178aea12",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x59ee84915f6dd83b"
+	},
+
+ "DifficultyTest1001" : {
+		"parentTimestamp" : "0x0748044656",
+		"parentDifficulty" : "0x5d2717f004aaf69c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x074804466a",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x5d1b730d06aa613e"
+	},
+
+ "DifficultyTest1002" : {
+		"parentTimestamp" : "0x07acd271bb",
+		"parentDifficulty" : "0x637eb76ac2c591a7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07acd271cf",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x63724793d56d38f5"
+	},
+
+ "DifficultyTest1003" : {
+		"parentTimestamp" : "0x0635a658fa",
+		"parentDifficulty" : "0x642d4803d719273b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0635a6590e",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x6420c25ad69e4417"
+	},
+
+ "DifficultyTest1004" : {
+		"parentTimestamp" : "0x0440324079",
+		"parentDifficulty" : "0x01c0fda34c43a98d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044032408d",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x01c0c58397da2118"
+	},
+
+ "DifficultyTest1005" : {
+		"parentTimestamp" : "0x0226821236",
+		"parentDifficulty" : "0x6e0a0e7e96e3d2d9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x022682124a",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x6dfc4d3cc710f65f"
+	},
+
+ "DifficultyTest1006" : {
+		"parentTimestamp" : "0x0734aba7a2",
+		"parentDifficulty" : "0x6674faa6a55f5a99",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0734aba7b6",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x66682c07508aaeae"
+	},
+
+ "DifficultyTest1007" : {
+		"parentTimestamp" : "0x46c25421",
+		"parentDifficulty" : "0x52c4d15e7b2d072a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x46c25435",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x52ba78c44f5da18a"
+	},
+
+ "DifficultyTest1008" : {
+		"parentTimestamp" : "0x04ac4583d3",
+		"parentDifficulty" : "0x5db9f43491ffe0c8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04ac4583e7",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x5dae3cf60b6da0cc"
+	},
+
+ "DifficultyTest1009" : {
+		"parentTimestamp" : "0x07ba418a97",
+		"parentDifficulty" : "0x652f4ef0fadabf55",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07ba418aab",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x6522a9071cbb63fe"
+	},
+
+ "DifficultyTest1010" : {
+		"parentTimestamp" : "0x04a8f932d5",
+		"parentDifficulty" : "0x059352d3300ffe0a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04a8f932e9",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x0592a068d5a9fc0b"
+	},
+
+ "DifficultyTest1011" : {
+		"parentTimestamp" : "0x043036f9ca",
+		"parentDifficulty" : "0x3c24b3ce26ddf080",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x043036f9de",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3c1d2f37ad1914c2"
+	},
+
+ "DifficultyTest1012" : {
+		"parentTimestamp" : "0x01596f0bfe",
+		"parentDifficulty" : "0x29cf1a4293f01059",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01596f0c12",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x29c9e05f4b9d9258"
+	},
+
+ "DifficultyTest1013" : {
+		"parentTimestamp" : "0x0370db1699",
+		"parentDifficulty" : "0x0447c1c00ef9b9d0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0370db16ad",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x044738c7d6f7da9b"
+	},
+
+ "DifficultyTest1014" : {
+		"parentTimestamp" : "0x02ebb6c065",
+		"parentDifficulty" : "0x0a54947517462af1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ebb6c079",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x0a5349e288a34230"
+	},
+
+ "DifficultyTest1015" : {
+		"parentTimestamp" : "0xd98370aa",
+		"parentDifficulty" : "0x76ff8389a8cdacb7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xd98370be",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x76f0a3993798930a"
+	},
+
+ "DifficultyTest1016" : {
+		"parentTimestamp" : "0x0234149d3e",
+		"parentDifficulty" : "0x13d1fa35618dfb20",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0234149d52",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x13cf7ff61ae1c971"
+	},
+
+ "DifficultyTest1017" : {
+		"parentTimestamp" : "0x0271b4d963",
+		"parentDifficulty" : "0x567bf86c2458edad",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0271b4d977",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x567128ed16d462b0"
+	},
+
+ "DifficultyTest1018" : {
+		"parentTimestamp" : "0x0655dc3661",
+		"parentDifficulty" : "0x2c0b1b40984f7d00",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0655dc3675",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2c0599dd303c7351"
+	},
+
+ "DifficultyTest1019" : {
+		"parentTimestamp" : "0x04bb79590f",
+		"parentDifficulty" : "0x77204348129ef86f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04bb795923",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x77115f3fa99ca510"
+	},
+
+ "DifficultyTest1020" : {
+		"parentTimestamp" : "0x73c1a479",
+		"parentDifficulty" : "0x56f1c638f315ddf8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x73c1a48d",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x56e6e8002bf77c3d"
+	},
+
+ "DifficultyTest1021" : {
+		"parentTimestamp" : "0x03aabae0e0",
+		"parentDifficulty" : "0x54b0334b84269866",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03aabae0f4",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x54a59d451ab61593"
+	},
+
+ "DifficultyTest1022" : {
+		"parentTimestamp" : "0x03e9e78839",
+		"parentDifficulty" : "0x390095b70ac51d8c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e9e7884d",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x38f975a453e3c8e9"
+	},
+
+ "DifficultyTest1023" : {
+		"parentTimestamp" : "0x037f9b22f8",
+		"parentDifficulty" : "0x482061c1ba2fb029",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x037f9b230c",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x48175db581f86a33"
+	},
+
+ "DifficultyTest1024" : {
+		"parentTimestamp" : "0x073f46468f",
+		"parentDifficulty" : "0x40f9a599ceebd2b3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x073f4646a3",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x40f186651bb1f539"
+	},
+
+ "DifficultyTest1025" : {
+		"parentTimestamp" : "0x0343755823",
+		"parentDifficulty" : "0x26765ed400048a4e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0343755837",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x26719008258489bd"
+	},
+
+ "DifficultyTest1026" : {
+		"parentTimestamp" : "0x032e85cccd",
+		"parentDifficulty" : "0x3114c68cdecb6dd7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x032e85cce1",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x310ea3f40d2f946a"
+	},
+
+ "DifficultyTest1027" : {
+		"parentTimestamp" : "0xfb7cb9fe",
+		"parentDifficulty" : "0x2b95cc37ad867480",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xfb7cba12",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x2b90597e2690c3b2"
+	},
+
+ "DifficultyTest1028" : {
+		"parentTimestamp" : "0x037eb005dd",
+		"parentDifficulty" : "0x19dad2aa34e1a87a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x037eb005f1",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x19d7974fdf9b0c45"
+	},
+
+ "DifficultyTest1029" : {
+		"parentTimestamp" : "0x0279241055",
+		"parentDifficulty" : "0x614d0656ad7c6fbc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0279241069",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x6140dcb5e2a6c02f"
+	},
+
+ "DifficultyTest1030" : {
+		"parentTimestamp" : "0x0147905ed5",
+		"parentDifficulty" : "0x710b588989b1bddb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0147905ee9",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x70fd371e788087a4"
+	},
+
+ "DifficultyTest1031" : {
+		"parentTimestamp" : "0x05e92b1383",
+		"parentDifficulty" : "0x3140568c6056ef78",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e92b1397",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x313a2e818ecae49c"
+	},
+
+ "DifficultyTest1032" : {
+		"parentTimestamp" : "0x0703780551",
+		"parentDifficulty" : "0x2e8bfd24a912d941",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0703780565",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x2e862ba5047db6e8"
+	},
+
+ "DifficultyTest1033" : {
+		"parentTimestamp" : "0x138b8dbc",
+		"parentDifficulty" : "0x0f477daac82f4293",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x138b8dd0",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x0f4594bb12d63caf"
+	},
+
+ "DifficultyTest1034" : {
+		"parentTimestamp" : "0x02c7aea52d",
+		"parentDifficulty" : "0x0fe4c66f22dbc3d3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02c7aea541",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x0fe2c9d654f76863"
+	},
+
+ "DifficultyTest1035" : {
+		"parentTimestamp" : "0x586f886e",
+		"parentDifficulty" : "0x41cc4f4c556f2da1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x586f8882",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x41c415c26be47fcc"
+	},
+
+ "DifficultyTest1036" : {
+		"parentTimestamp" : "0x06c5812a9d",
+		"parentDifficulty" : "0x6fbf1d1938bf3c6c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c5812ab1",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x6fb12535959824a5"
+	},
+
+ "DifficultyTest1037" : {
+		"parentTimestamp" : "0x0305cce1e1",
+		"parentDifficulty" : "0x2ebc7287fc3114d1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0305cce1f5",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x2eb69af9ab318eef"
+	},
+
+ "DifficultyTest1038" : {
+		"parentTimestamp" : "0x01ffcdd6c3",
+		"parentDifficulty" : "0x0d1512e1ffc63f70",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ffcdd6d7",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x0d13703fa3864729"
+	},
+
+ "DifficultyTest1039" : {
+		"parentTimestamp" : "0x0541153791",
+		"parentDifficulty" : "0x2e78e8a0f671bef6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05411537a5",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x2e731983e252f1bf"
+	},
+
+ "DifficultyTest1040" : {
+		"parentTimestamp" : "0x07c459c887",
+		"parentDifficulty" : "0x22a027bf50ae6951",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07c459c89b",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x229bd3ba58c45584"
+	},
+
+ "DifficultyTest1041" : {
+		"parentTimestamp" : "0x064299694a",
+		"parentDifficulty" : "0x7206b46b1c6a2247",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x064299695e",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x71f873948f069903"
+	},
+
+ "DifficultyTest1042" : {
+		"parentTimestamp" : "0x041af8548d",
+		"parentDifficulty" : "0x30660e674f1e1336",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x041af854a1",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x306001a582343774"
+	},
+
+ "DifficultyTest1043" : {
+		"parentTimestamp" : "0x07be14aba4",
+		"parentDifficulty" : "0x7f942e16f67e5c48",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07be14abb8",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x7f843b91339f9c7d"
+	},
+
+ "DifficultyTest1044" : {
+		"parentTimestamp" : "0x04d968cdfb",
+		"parentDifficulty" : "0x0ba6f51e6bd3bdec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04d968ce0f",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x0ba5803fc8066375"
+	},
+
+ "DifficultyTest1045" : {
+		"parentTimestamp" : "0x04514bad84",
+		"parentDifficulty" : "0x0c1e03f01942ec11",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04514bad98",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x0c1c802f9b4003b4"
+	},
+
+ "DifficultyTest1046" : {
+		"parentTimestamp" : "0x0735995d35",
+		"parentDifficulty" : "0x52a8c5810224970e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0735995d49",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x52a8c5810224970e"
+	},
+
+ "DifficultyTest1047" : {
+		"parentTimestamp" : "0x0658195a63",
+		"parentDifficulty" : "0x723443d342bbdcd5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0658195a77",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x723443d342bbdcd5"
+	},
+
+ "DifficultyTest1048" : {
+		"parentTimestamp" : "0x0321ebeac1",
+		"parentDifficulty" : "0x680287d6ae731bce",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0321ebead5",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x680287d6ae731bce"
+	},
+
+ "DifficultyTest1049" : {
+		"parentTimestamp" : "0x02c2d691e9",
+		"parentDifficulty" : "0x0716ab7f48fb49e6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02c2d691fd",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x0716ab7f48fb49e6"
+	},
+
+ "DifficultyTest1050" : {
+		"parentTimestamp" : "0xf19c43b3",
+		"parentDifficulty" : "0x7bf494faff2fd662",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xf19c43c7",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x7bf494faff2fd662"
+	},
+
+ "DifficultyTest1051" : {
+		"parentTimestamp" : "0x04444e4818",
+		"parentDifficulty" : "0x3a054cd726b949e3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04444e482c",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x3a054cd726b949e3"
+	},
+
+ "DifficultyTest1052" : {
+		"parentTimestamp" : "0x07ae697903",
+		"parentDifficulty" : "0x31bf2ba566a66faf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07ae697917",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x31bf2ba566a66faf"
+	},
+
+ "DifficultyTest1053" : {
+		"parentTimestamp" : "0x0143424afb",
+		"parentDifficulty" : "0x48c06d1f97a094ac",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0143424b0f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x48c06d1f97a094ac"
+	},
+
+ "DifficultyTest1054" : {
+		"parentTimestamp" : "0x04c462dacb",
+		"parentDifficulty" : "0x7ac82712d7a85305",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04c462dadf",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x7ac82712d7a85305"
+	},
+
+ "DifficultyTest1055" : {
+		"parentTimestamp" : "0x029bc6341d",
+		"parentDifficulty" : "0x63b3750d3a421ab4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029bc63431",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x63b3750d3a421ab4"
+	},
+
+ "DifficultyTest1056" : {
+		"parentTimestamp" : "0x0324c53d2b",
+		"parentDifficulty" : "0x7fdba5cd61fbd368",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0324c53d3f",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x7fdba5cd61fbd368"
+	},
+
+ "DifficultyTest1057" : {
+		"parentTimestamp" : "0xc3551747",
+		"parentDifficulty" : "0x7482fdef707589ef",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xc355175b",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x7482fdef707589ef"
+	},
+
+ "DifficultyTest1058" : {
+		"parentTimestamp" : "0x0232cfbe03",
+		"parentDifficulty" : "0x7241708510ebea75",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0232cfbe17",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x7241708510ebea75"
+	},
+
+ "DifficultyTest1059" : {
+		"parentTimestamp" : "0x4789a194",
+		"parentDifficulty" : "0x2943937d3bf2c1f9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x4789a1a8",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x2943937d3bf2c1f9"
+	},
+
+ "DifficultyTest1060" : {
+		"parentTimestamp" : "0x029db5a969",
+		"parentDifficulty" : "0x4b80e5b7e492d495",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029db5a97d",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x4b80e5b7e492d495"
+	},
+
+ "DifficultyTest1061" : {
+		"parentTimestamp" : "0x04a8b94a13",
+		"parentDifficulty" : "0x7bea305c64905683",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04a8b94a27",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x7bea305c64905684"
+	},
+
+ "DifficultyTest1062" : {
+		"parentTimestamp" : "0x74b01dd2",
+		"parentDifficulty" : "0x29cedcb184b02be3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x74b01de6",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x29cedcb184b02be5"
+	},
+
+ "DifficultyTest1063" : {
+		"parentTimestamp" : "0x0179bc77a8",
+		"parentDifficulty" : "0x24e0ad46ed05cb91",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0179bc77bc",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x24e0ad46ed05cb95"
+	},
+
+ "DifficultyTest1064" : {
+		"parentTimestamp" : "0x034f246357",
+		"parentDifficulty" : "0x7de05bdcd474767a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x034f24636b",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x7de05bdcd4747682"
+	},
+
+ "DifficultyTest1065" : {
+		"parentTimestamp" : "0x011055cf0b",
+		"parentDifficulty" : "0x19df24985e7a0f2e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x011055cf1f",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x19df24985e7a0f3e"
+	},
+
+ "DifficultyTest1066" : {
+		"parentTimestamp" : "0xdeb2c9ca",
+		"parentDifficulty" : "0x6549ac2a67d3a432",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xdeb2c9de",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x6549ac2a67d3a452"
+	},
+
+ "DifficultyTest1067" : {
+		"parentTimestamp" : "0x01b42347e9",
+		"parentDifficulty" : "0x2fc0513f214e7a36",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01b42347fd",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2fc0513f214e7a76"
+	},
+
+ "DifficultyTest1068" : {
+		"parentTimestamp" : "0x037d6c57ac",
+		"parentDifficulty" : "0x040e83de7ae5a140",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x037d6c57c0",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x040e83de7ae5a1c0"
+	},
+
+ "DifficultyTest1069" : {
+		"parentTimestamp" : "0x01e35c7176",
+		"parentDifficulty" : "0x0bed3c72e862c5e2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e35c718a",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x0bed3c72e862c6e2"
+	},
+
+ "DifficultyTest1070" : {
+		"parentTimestamp" : "0x0486a89a26",
+		"parentDifficulty" : "0x4c54373da44bbdb8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0486a89a3a",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x4c54373da44bbfb8"
+	},
+
+ "DifficultyTest1071" : {
+		"parentTimestamp" : "0x04422fad5d",
+		"parentDifficulty" : "0x457e11abe16fa1b3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04422fad71",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x457e11abe16fa5b3"
+	},
+
+ "DifficultyTest1072" : {
+		"parentTimestamp" : "0x0448ff6223",
+		"parentDifficulty" : "0x34c1d9b10dcc4b7c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0448ff6237",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x34c1d9b10dcc4b7c"
+	},
+
+ "DifficultyTest1073" : {
+		"parentTimestamp" : "0x028ed7e219",
+		"parentDifficulty" : "0x4a8b697b93da930e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x028ed7e22d",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x4a8b697b93da930e"
+	},
+
+ "DifficultyTest1074" : {
+		"parentTimestamp" : "0x067b0a38fe",
+		"parentDifficulty" : "0x5c7f86c16ae2ef52",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x067b0a3912",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x5c7f86c16ae2ef52"
+	},
+
+ "DifficultyTest1075" : {
+		"parentTimestamp" : "0x039548baf7",
+		"parentDifficulty" : "0x3874139f9a57529a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039548bb0b",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x3874139f9a57529a"
+	},
+
+ "DifficultyTest1076" : {
+		"parentTimestamp" : "0x072122c4d5",
+		"parentDifficulty" : "0x0cabbbe300137d42",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x072122c4e9",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x0cabbbe300137d42"
+	},
+
+ "DifficultyTest1077" : {
+		"parentTimestamp" : "0x0140dbcf1b",
+		"parentDifficulty" : "0x013985ae2a116939",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0140dbcf2f",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x013985ae2a116939"
+	},
+
+ "DifficultyTest1078" : {
+		"parentTimestamp" : "0x03aaeb71af",
+		"parentDifficulty" : "0x507fcbe29e5ac363",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03aaeb71c3",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x507fcbe29e5ac363"
+	},
+
+ "DifficultyTest1079" : {
+		"parentTimestamp" : "0x03840f17cf",
+		"parentDifficulty" : "0x1b701819c775e749",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03840f17e5",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x1b6caa16c43cf88d"
+	},
+
+ "DifficultyTest1080" : {
+		"parentTimestamp" : "0x04ff1faa9f",
+		"parentDifficulty" : "0x74f80b4d4e99301b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04ff1faab5",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x74e96c4be4ef5cf6"
+	},
+
+ "DifficultyTest1081" : {
+		"parentTimestamp" : "0x0464f3b0b5",
+		"parentDifficulty" : "0x0eaa431dfb9fd654",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0464f3b0cb",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x0ea86dd597e0625c"
+	},
+
+ "DifficultyTest1082" : {
+		"parentTimestamp" : "0x04d115f9ac",
+		"parentDifficulty" : "0x2c6bf656ba35ab3f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04d115f9c2",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x2c6668d7ef5e648e"
+	},
+
+ "DifficultyTest1083" : {
+		"parentTimestamp" : "0x079e2263b7",
+		"parentDifficulty" : "0x3ee704de86b8393b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x079e2263cd",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x3edf27fdeae7623c"
+	},
+
+ "DifficultyTest1084" : {
+		"parentTimestamp" : "0x05702826ea",
+		"parentDifficulty" : "0x47953e1cd39a2ebb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0570282700",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x478c4b750fffbb86"
+	},
+
+ "DifficultyTest1085" : {
+		"parentTimestamp" : "0x0706813809",
+		"parentDifficulty" : "0x4815f1e5b5cb4ed6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x070681381f",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x480cef277914958d"
+	},
+
+ "DifficultyTest1086" : {
+		"parentTimestamp" : "0x05c853439d",
+		"parentDifficulty" : "0x7c78d851671b0231",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05c85343b3",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x7c6949365cee1f11"
+	},
+
+ "DifficultyTest1087" : {
+		"parentTimestamp" : "0x0246a7afca",
+		"parentDifficulty" : "0x0ba0b3469a11b86e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0246a7afe0",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x0b9f3f30313e76b7"
+	},
+
+ "DifficultyTest1088" : {
+		"parentTimestamp" : "0x02d6c1ee23",
+		"parentDifficulty" : "0x1afd9cd1f8047f54",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d6c1ee39",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x1afa3d1e5dc57fc5"
+	},
+
+ "DifficultyTest1089" : {
+		"parentTimestamp" : "0x06ca7a0e40",
+		"parentDifficulty" : "0x31bf308e4aef88b6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ca7a0e56",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x31b8f8a839262cc5"
+	},
+
+ "DifficultyTest1090" : {
+		"parentTimestamp" : "0x030add130e",
+		"parentDifficulty" : "0x0c5f715272ed99ca",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x030add1324",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x0c5de564489f4017"
+	},
+
+ "DifficultyTest1091" : {
+		"parentTimestamp" : "0x05f1fbb8c1",
+		"parentDifficulty" : "0x34a4a8deb4bbd395",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f1fbb8d7",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x349e144998e5441b"
+	},
+
+ "DifficultyTest1092" : {
+		"parentTimestamp" : "0x06a6f5da68",
+		"parentDifficulty" : "0x3766bad9033f4161",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06a6f5da7e",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x375fce01a81ee979"
+	},
+
+ "DifficultyTest1093" : {
+		"parentTimestamp" : "0x023db7fa66",
+		"parentDifficulty" : "0x7a7a801f6af04169",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x023db7fa7c",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x7a6b30cf67030361"
+	},
+
+ "DifficultyTest1094" : {
+		"parentTimestamp" : "0x020ae7751b",
+		"parentDifficulty" : "0x672377195e585db7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x020ae77531",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x671692aa7b2cd2ac"
+	},
+
+ "DifficultyTest1095" : {
+		"parentTimestamp" : "0x035e510d3c",
+		"parentDifficulty" : "0x4e3d64d5934770c0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x035e510d52",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x4e339d28f89507d2"
+	},
+
+ "DifficultyTest1096" : {
+		"parentTimestamp" : "0x011255c7f0",
+		"parentDifficulty" : "0x7341dbe235f68f58",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x011255c806",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x733373a6b9afd087"
+	},
+
+ "DifficultyTest1097" : {
+		"parentTimestamp" : "0x05989ac2c7",
+		"parentDifficulty" : "0x3290caa220072cf2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05989ac2dd",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x328a7888cbc32c0d"
+	},
+
+ "DifficultyTest1098" : {
+		"parentTimestamp" : "0x064ceaf81f",
+		"parentDifficulty" : "0x4d12281874c9ed7a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x064ceaf835",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x4d0885d371bb543d"
+	},
+
+ "DifficultyTest1099" : {
+		"parentTimestamp" : "0x01bc36871d",
+		"parentDifficulty" : "0x0f018cda9670362a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01bc368733",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x0effaca8fb1d6824"
+	},
+
+ "DifficultyTest1100" : {
+		"parentTimestamp" : "0x26f0873f",
+		"parentDifficulty" : "0x2f9ca7f205b5ef29",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x26f08755",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x2f96b45d0775386c"
+	},
+
+ "DifficultyTest1101" : {
+		"parentTimestamp" : "0x24dfd8d8",
+		"parentDifficulty" : "0x78cda3b8905dbfea",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x24dfd8ee",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x78be8a04194bb433"
+	},
+
+ "DifficultyTest1102" : {
+		"parentTimestamp" : "0x79a99f1b",
+		"parentDifficulty" : "0x79a5fd97ccf3b1cf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x79a99f31",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x7996c8d819fa1359"
+	},
+
+ "DifficultyTest1103" : {
+		"parentTimestamp" : "0x0663d76c7c",
+		"parentDifficulty" : "0x0146039e222bfca9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0663d76c92",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x0145daddae67b72a"
+	},
+
+ "DifficultyTest1104" : {
+		"parentTimestamp" : "0x04b8df7948",
+		"parentDifficulty" : "0x2cb6b0e5ab9d40a2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b8df795e",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x2cb11a0f8ee7ccfa"
+	},
+
+ "DifficultyTest1105" : {
+		"parentTimestamp" : "0x070b13110f",
+		"parentDifficulty" : "0x3d9b836bf6b730a7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x070b131125",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x3d93cffb893859c1"
+	},
+
+ "DifficultyTest1106" : {
+		"parentTimestamp" : "0x010c4096ee",
+		"parentDifficulty" : "0x0c1547a4cd4e63bd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x010c409704",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x0c13c4fbd8b4b9f1"
+	},
+
+ "DifficultyTest1107" : {
+		"parentTimestamp" : "0x05f1c49b80",
+		"parentDifficulty" : "0x7a3a1fa23dfe6d7a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f1c49b96",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x7a2ad85e49b6adad"
+	},
+
+ "DifficultyTest1108" : {
+		"parentTimestamp" : "0x0248deae72",
+		"parentDifficulty" : "0x374243c978b44eed",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0248deae88",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x373b5b80ff853864"
+	},
+
+ "DifficultyTest1109" : {
+		"parentTimestamp" : "0x05faa89906",
+		"parentDifficulty" : "0x3076f9bd2d42de64",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05faa8991c",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3070eaddf59d3609"
+	},
+
+ "DifficultyTest1110" : {
+		"parentTimestamp" : "0x637a60c4",
+		"parentDifficulty" : "0x0d2e4cfcc15ba0bf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x637a60da",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x0d2ca73321c3754c"
+	},
+
+ "DifficultyTest1111" : {
+		"parentTimestamp" : "0x0115ad8cc5",
+		"parentDifficulty" : "0x7dcaa844f1a9b1ad",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0115ad8cdb",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x7dbaeeefe90b7c79"
+	},
+
+ "DifficultyTest1112" : {
+		"parentTimestamp" : "0x0337990694",
+		"parentDifficulty" : "0x41d677271ed4a651",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03379906aa",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x41ce3c5839f0cbc1"
+	},
+
+ "DifficultyTest1113" : {
+		"parentTimestamp" : "0x043cb3889b",
+		"parentDifficulty" : "0x66f2874688c0f5b5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x043cb388b1",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x66e5a8f59fefdd9f"
+	},
+
+ "DifficultyTest1114" : {
+		"parentTimestamp" : "0x2a9961b7",
+		"parentDifficulty" : "0x67a53adb5ec46d93",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2a9961cd",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6798463403589516"
+	},
+
+ "DifficultyTest1115" : {
+		"parentTimestamp" : "0x01b05d00a9",
+		"parentDifficulty" : "0x6e7dac510b36c0bd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01b05d00bf",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x6e6fdc9b81155a05"
+	},
+
+ "DifficultyTest1116" : {
+		"parentTimestamp" : "0x0479de6964",
+		"parentDifficulty" : "0x0ce8cd6c59abed2d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0479de697a",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x0ce73052ac20b7f0"
+	},
+
+ "DifficultyTest1117" : {
+		"parentTimestamp" : "0x03b2fa5aa3",
+		"parentDifficulty" : "0x1c5740f5c2c069c2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b2fa5ab9",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x1c53b60da4081235"
+	},
+
+ "DifficultyTest1118" : {
+		"parentTimestamp" : "0xe0e94fbd",
+		"parentDifficulty" : "0x2556043fa32a3db9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xe0e94fd3",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x2551597f1b35d972"
+	},
+
+ "DifficultyTest1119" : {
+		"parentTimestamp" : "0x044d04d0fa",
+		"parentDifficulty" : "0x2400d3bdca4cc761",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044d04d110",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x23fc53a352937fc9"
+	},
+
+ "DifficultyTest1120" : {
+		"parentTimestamp" : "0x020314e350",
+		"parentDifficulty" : "0x7029199ae18c8313",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x020314e366",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x701b1477ae305583"
+	},
+
+ "DifficultyTest1121" : {
+		"parentTimestamp" : "0x01de4b19b7",
+		"parentDifficulty" : "0x75f42f71a4e38416",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01de4b19cd",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x75e570ebb6aee7a6"
+	},
+
+ "DifficultyTest1122" : {
+		"parentTimestamp" : "0x02df22819b",
+		"parentDifficulty" : "0x76a3bc656f2d42f8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02df2281b1",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x7694e7ede27f5d50"
+	},
+
+ "DifficultyTest1123" : {
+		"parentTimestamp" : "0x04c5a0ab15",
+		"parentDifficulty" : "0x3cde7fecff823742",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c5a0ab2b",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x3cd6e41d01e246fc"
+	},
+
+ "DifficultyTest1124" : {
+		"parentTimestamp" : "0x0647ac5cff",
+		"parentDifficulty" : "0x4e1bfe9fce5cf03e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0647ac5d15",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x4e123b1ffa6324a0"
+	},
+
+ "DifficultyTest1125" : {
+		"parentTimestamp" : "0x02cb800f04",
+		"parentDifficulty" : "0x62b76b44ade97b31",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02cb800f1a",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x62ab14574553be02"
+	},
+
+ "DifficultyTest1126" : {
+		"parentTimestamp" : "0x075eba4152",
+		"parentDifficulty" : "0x452d8380ab1b28d2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x075eba4168",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x4524ddd03b05c56d"
+	},
+
+ "DifficultyTest1127" : {
+		"parentTimestamp" : "0x0616ab8ca8",
+		"parentDifficulty" : "0x3b11e0e51633a456",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0616ab8cbe",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x3b0a7ea8f990dde2"
+	},
+
+ "DifficultyTest1128" : {
+		"parentTimestamp" : "0x0332c98174",
+		"parentDifficulty" : "0x3caf1b805aca4324",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0332c9818a",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x3ca7859ceabee9dc"
+	},
+
+ "DifficultyTest1129" : {
+		"parentTimestamp" : "0x020e3281c8",
+		"parentDifficulty" : "0x53140ef745659854",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x020e3281de",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x5309ac75667ceba2"
+	},
+
+ "DifficultyTest1130" : {
+		"parentTimestamp" : "0x07b75c6f64",
+		"parentDifficulty" : "0x57340229e193d0b7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07b75c6f7a",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x57291ba99c579e3f"
+	},
+
+ "DifficultyTest1131" : {
+		"parentTimestamp" : "0x073f33e1a7",
+		"parentDifficulty" : "0x4b72b9f222b20e73",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x073f33e1bd",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x4b694b9ae46db836"
+	},
+
+ "DifficultyTest1132" : {
+		"parentTimestamp" : "0x051a4eaa74",
+		"parentDifficulty" : "0x3057b439b7d666d2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x051a4eaa8a",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x3051a943309f6c0e"
+	},
+
+ "DifficultyTest1133" : {
+		"parentTimestamp" : "0x0219c84c00",
+		"parentDifficulty" : "0x3b2d266f63c3d889",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0219c84c16",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x3b25c0ca95d7601e"
+	},
+
+ "DifficultyTest1134" : {
+		"parentTimestamp" : "0x06d752e4d9",
+		"parentDifficulty" : "0x03ef58af9a926920",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06d752e4ef",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x03eedac4849f16f3"
+	},
+
+ "DifficultyTest1135" : {
+		"parentTimestamp" : "0x02f3f742fd",
+		"parentDifficulty" : "0x38498b75db217a4c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f3f74313",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x384282446c66165d"
+	},
+
+ "DifficultyTest1136" : {
+		"parentTimestamp" : "0x02b51e85e3",
+		"parentDifficulty" : "0x25b3d03f617c63f6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02b51e85f9",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x25af19c5599034ea"
+	},
+
+ "DifficultyTest1137" : {
+		"parentTimestamp" : "0x04c413991d",
+		"parentDifficulty" : "0x077df90ec2e7c792",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04c4139933",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x077d094fa10f6b9a"
+	},
+
+ "DifficultyTest1138" : {
+		"parentTimestamp" : "0x038ee07d37",
+		"parentDifficulty" : "0x124179efbdc34ab3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x038ee07d4d",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x123f31c07fcb944a"
+	},
+
+ "DifficultyTest1139" : {
+		"parentTimestamp" : "0x013ef78cbe",
+		"parentDifficulty" : "0x1d3093c83589cb44",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013ef78cd4",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x1d2cedb5bc831e0b"
+	},
+
+ "DifficultyTest1140" : {
+		"parentTimestamp" : "0x015bb0849e",
+		"parentDifficulty" : "0x153b5aff50593c78",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x015bb084b4",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x1538b393f06f3951"
+	},
+
+ "DifficultyTest1141" : {
+		"parentTimestamp" : "0x0775f9f13d",
+		"parentDifficulty" : "0x2facf06419c77db2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0775f9f153",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x2fa6fac60d4454c3"
+	},
+
+ "DifficultyTest1142" : {
+		"parentTimestamp" : "0x07a6a0c62a",
+		"parentDifficulty" : "0x3858f37fe3350e2a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a6a0c640",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x3851e8617338c789"
+	},
+
+ "DifficultyTest1143" : {
+		"parentTimestamp" : "0x02694ef4eb",
+		"parentDifficulty" : "0x09479681ef00c99d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02694ef501",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x09466d8f1ec32984"
+	},
+
+ "DifficultyTest1144" : {
+		"parentTimestamp" : "0xc3e149ae",
+		"parentDifficulty" : "0x057425bbb62232d2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xc3e149c4",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x057425bbb62232d2"
+	},
+
+ "DifficultyTest1145" : {
+		"parentTimestamp" : "0x05cd0779fe",
+		"parentDifficulty" : "0x765056ea564e362e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05cd077a14",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x765056ea564e362e"
+	},
+
+ "DifficultyTest1146" : {
+		"parentTimestamp" : "0x06047e4cc7",
+		"parentDifficulty" : "0x36bbee8ff31bff9d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06047e4cdd",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x36bbee8ff31bff9d"
+	},
+
+ "DifficultyTest1147" : {
+		"parentTimestamp" : "0x05e235ccf2",
+		"parentDifficulty" : "0x103bff9949755fed",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e235cd08",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x103bff9949755fed"
+	},
+
+ "DifficultyTest1148" : {
+		"parentTimestamp" : "0xc45c4125",
+		"parentDifficulty" : "0x4ab64308107fe796",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xc45c413b",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x4ab64308107fe796"
+	},
+
+ "DifficultyTest1149" : {
+		"parentTimestamp" : "0x0619970222",
+		"parentDifficulty" : "0x527bd2841b057f3d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0619970238",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x527bd2841b057f3d"
+	},
+
+ "DifficultyTest1150" : {
+		"parentTimestamp" : "0x04b54561c2",
+		"parentDifficulty" : "0x37a3643c0894e946",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04b54561d8",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x37a3643c0894e946"
+	},
+
+ "DifficultyTest1151" : {
+		"parentTimestamp" : "0x053c742971",
+		"parentDifficulty" : "0x67abf96e0ff84ff2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x053c742987",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x67abf96e0ff84ff2"
+	},
+
+ "DifficultyTest1152" : {
+		"parentTimestamp" : "0xf0a9d202",
+		"parentDifficulty" : "0x3d7bf9c679caf1fc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xf0a9d218",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x3d7bf9c679caf1fc"
+	},
+
+ "DifficultyTest1153" : {
+		"parentTimestamp" : "0x069cd2a934",
+		"parentDifficulty" : "0x47d2f61a21ccca1f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x069cd2a94a",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x47d2f61a21ccca1f"
+	},
+
+ "DifficultyTest1154" : {
+		"parentTimestamp" : "0x0245d9d9ac",
+		"parentDifficulty" : "0x19c637040f8f0e87",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0245d9d9c2",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x19c637040f8f0e87"
+	},
+
+ "DifficultyTest1155" : {
+		"parentTimestamp" : "0x01c2204069",
+		"parentDifficulty" : "0x7c04dd7d7a4557b7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c220407f",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x7c04dd7d7a4557b7"
+	},
+
+ "DifficultyTest1156" : {
+		"parentTimestamp" : "0x05d8990006",
+		"parentDifficulty" : "0x02eaeb0479e235f0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05d899001c",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x02eaeb0479e235f0"
+	},
+
+ "DifficultyTest1157" : {
+		"parentTimestamp" : "0x02f3b134be",
+		"parentDifficulty" : "0x0fa627c731988ac3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f3b134d4",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x0fa627c731988ac3"
+	},
+
+ "DifficultyTest1158" : {
+		"parentTimestamp" : "0xee1d59a8",
+		"parentDifficulty" : "0x0de03ffa4683efc7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xee1d59be",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x0de03ffa4683efc7"
+	},
+
+ "DifficultyTest1159" : {
+		"parentTimestamp" : "0x0463af5013",
+		"parentDifficulty" : "0x3133b8231b031d7d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0463af5029",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x3133b8231b031d7e"
+	},
+
+ "DifficultyTest1160" : {
+		"parentTimestamp" : "0x07e47d2d38",
+		"parentDifficulty" : "0x20fe45be3f53bdb0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e47d2d4e",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x20fe45be3f53bdb2"
+	},
+
+ "DifficultyTest1161" : {
+		"parentTimestamp" : "0x05c83ee05b",
+		"parentDifficulty" : "0x58d3469ce227fcf5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05c83ee071",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x58d3469ce227fcf9"
+	},
+
+ "DifficultyTest1162" : {
+		"parentTimestamp" : "0x0101141f62",
+		"parentDifficulty" : "0x242ae6159bb39649",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0101141f78",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x242ae6159bb39651"
+	},
+
+ "DifficultyTest1163" : {
+		"parentTimestamp" : "0x0193f43324",
+		"parentDifficulty" : "0x6161d37a9805dd7d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0193f4333a",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6161d37a9805dd8d"
+	},
+
+ "DifficultyTest1164" : {
+		"parentTimestamp" : "0x4a55a8d3",
+		"parentDifficulty" : "0x5009645863e94cb1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x4a55a8e9",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x5009645863e94cd1"
+	},
+
+ "DifficultyTest1165" : {
+		"parentTimestamp" : "0x991d61d5",
+		"parentDifficulty" : "0x54ab6397340507fd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x991d61eb",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x54ab63973405083d"
+	},
+
+ "DifficultyTest1166" : {
+		"parentTimestamp" : "0x06b5984eea",
+		"parentDifficulty" : "0x597fb7fbc1750cc2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06b5984f00",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x597fb7fbc1750d42"
+	},
+
+ "DifficultyTest1167" : {
+		"parentTimestamp" : "0x01cdb96f78",
+		"parentDifficulty" : "0x39c0bdc69b3110e5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01cdb96f8e",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x39c0bdc69b3111e5"
+	},
+
+ "DifficultyTest1168" : {
+		"parentTimestamp" : "0x0795ff37d8",
+		"parentDifficulty" : "0x319bca6863241c10",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0795ff37ee",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x319bca6863241e10"
+	},
+
+ "DifficultyTest1169" : {
+		"parentTimestamp" : "0x029c89784a",
+		"parentDifficulty" : "0x694fff519857f147",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029c897860",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x694fff519857f547"
+	},
+
+ "DifficultyTest1170" : {
+		"parentTimestamp" : "0x012906b3d9",
+		"parentDifficulty" : "0x28aa7f3ed174760c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x012906b3ef",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x28aa7f3ed174760c"
+	},
+
+ "DifficultyTest1171" : {
+		"parentTimestamp" : "0x07b7ca6a56",
+		"parentDifficulty" : "0x1503d9c5e301e8fc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07b7ca6a6c",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1503d9c5e301e8fc"
+	},
+
+ "DifficultyTest1172" : {
+		"parentTimestamp" : "0x02fc5a700d",
+		"parentDifficulty" : "0x0a3440ca1dfde2a9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02fc5a7023",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x0a3440ca1dfde2a9"
+	},
+
+ "DifficultyTest1173" : {
+		"parentTimestamp" : "0x0785aa26b6",
+		"parentDifficulty" : "0x3ff2b16697a7a8fa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0785aa26cc",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x3ff2b16697a7a8fa"
+	},
+
+ "DifficultyTest1174" : {
+		"parentTimestamp" : "0x07df4bfb27",
+		"parentDifficulty" : "0x2095348735f6b972",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07df4bfb3d",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x2095348735f6b972"
+	},
+
+ "DifficultyTest1175" : {
+		"parentTimestamp" : "0x07e8191bb1",
+		"parentDifficulty" : "0x2ac52d215e0236e6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e8191bc7",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x2ac52d215e0236e6"
+	},
+
+ "DifficultyTest1176" : {
+		"parentTimestamp" : "0x0308e9effd",
+		"parentDifficulty" : "0x2f7fcba7022608c3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0308e9f013",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x2f7fcba7022608c3"
+	},
+
+ "DifficultyTest1177" : {
+		"parentTimestamp" : "0x01594914c7",
+		"parentDifficulty" : "0x273a2f14591c6234",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01594914df",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x273547ce76913ea8"
+	},
+
+ "DifficultyTest1178" : {
+		"parentTimestamp" : "0x042d965ec1",
+		"parentDifficulty" : "0x4f9fe49223252272",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x042d965ed9",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x4f95f09590e0bdcf"
+	},
+
+ "DifficultyTest1179" : {
+		"parentTimestamp" : "0x0243533402",
+		"parentDifficulty" : "0x718f5029722c59cb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x024353341a",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x71811e3f6cfe1442"
+	},
+
+ "DifficultyTest1180" : {
+		"parentTimestamp" : "0x067e41428e",
+		"parentDifficulty" : "0x6a776e902d607c1c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x067e4142a6",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x6a6a1fa25b5ad011"
+	},
+
+ "DifficultyTest1181" : {
+		"parentTimestamp" : "0x02ddf37a1c",
+		"parentDifficulty" : "0x2ac8d9e6f1aaa1b0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ddf37a34",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x2ac380cbb4cc6c64"
+	},
+
+ "DifficultyTest1182" : {
+		"parentTimestamp" : "0x05d8f6def4",
+		"parentDifficulty" : "0x741076c92b84a7cb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d8f6df0c",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x7401f4ba525f3747"
+	},
+
+ "DifficultyTest1183" : {
+		"parentTimestamp" : "0x03ad4e44f6",
+		"parentDifficulty" : "0x33c1d62836e37435",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03ad4e450e",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x33bb5ded71dc97e7"
+	},
+
+ "DifficultyTest1184" : {
+		"parentTimestamp" : "0x039e092260",
+		"parentDifficulty" : "0x0971286f1a5e6451",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x039e092278",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x096ffa4a0c7b18c5"
+	},
+
+ "DifficultyTest1185" : {
+		"parentTimestamp" : "0x03273e1566",
+		"parentDifficulty" : "0x1f3c3b1952cab989",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03273e157e",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x1f385391efa060b2"
+	},
+
+ "DifficultyTest1186" : {
+		"parentTimestamp" : "0x0683703245",
+		"parentDifficulty" : "0x64f88f66245d1fd3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x068370325d",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x64ebf05437989530"
+	},
+
+ "DifficultyTest1187" : {
+		"parentTimestamp" : "0x0549feb524",
+		"parentDifficulty" : "0x15abf3d9c5b0557b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0549feb53c",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x15a93e5b4a77a171"
+	},
+
+ "DifficultyTest1188" : {
+		"parentTimestamp" : "0x0659ab3875",
+		"parentDifficulty" : "0x73de7a9a67fee626",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0659ab388d",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x73cffecb14b1ea4a"
+	},
+
+ "DifficultyTest1189" : {
+		"parentTimestamp" : "0x06fec2a016",
+		"parentDifficulty" : "0x3d51797c99c6cef8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06fec2a02e",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x3d49cf4d6a339e1f"
+	},
+
+ "DifficultyTest1190" : {
+		"parentTimestamp" : "0x04627cb2e3",
+		"parentDifficulty" : "0x3d406af7c46ce347",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04627cb2fb",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x3d38c2ea657465ab"
+	},
+
+ "DifficultyTest1191" : {
+		"parentTimestamp" : "0x452003dd",
+		"parentDifficulty" : "0x34f2465ca9e62969",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x452003f5",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x34eba813de510ca4"
+	},
+
+ "DifficultyTest1192" : {
+		"parentTimestamp" : "0x05b5c77e3f",
+		"parentDifficulty" : "0x4faad3c4546e398d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b5c77e57",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x4fa0de69dbe3ebc6"
+	},
+
+ "DifficultyTest1193" : {
+		"parentTimestamp" : "0x049f496ca9",
+		"parentDifficulty" : "0x703da69ee1278b3e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x049f496cc1",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x702f9eea0d4b664d"
+	},
+
+ "DifficultyTest1194" : {
+		"parentTimestamp" : "0xa950a2d7",
+		"parentDifficulty" : "0x09b50c70a44f21d8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa950a2ef",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x09b3d5cf163a97f4"
+	},
+
+ "DifficultyTest1195" : {
+		"parentTimestamp" : "0x03e0abce7e",
+		"parentDifficulty" : "0x56c201898b5f6817",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e0abce96",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x56b729495a2dfc2a"
+	},
+
+ "DifficultyTest1196" : {
+		"parentTimestamp" : "0x02d8664fd4",
+		"parentDifficulty" : "0x543a24de530c7680",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d8664fec",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x542f9d99b74214f2"
+	},
+
+ "DifficultyTest1197" : {
+		"parentTimestamp" : "0x02da3a499b",
+		"parentDifficulty" : "0x38517090615f93be",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02da3a49b3",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x384a66624f5367cc"
+	},
+
+ "DifficultyTest1198" : {
+		"parentTimestamp" : "0x3eaf9d7d",
+		"parentDifficulty" : "0x29997304a13aa92f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x3eaf9d95",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x29943fd640a681da"
+	},
+
+ "DifficultyTest1199" : {
+		"parentTimestamp" : "0x02b73019fa",
+		"parentDifficulty" : "0x2f621ac4c7ceea68",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02b7301a12",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x2f5c2e816f35f08b"
+	},
+
+ "DifficultyTest1200" : {
+		"parentTimestamp" : "0xa96a1352",
+		"parentDifficulty" : "0x68f44fc2d72e933c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa96a136a",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x68e73138ded3ad6a"
+	},
+
+ "DifficultyTest1201" : {
+		"parentTimestamp" : "0x02962ca2b9",
+		"parentDifficulty" : "0x7af46cfd5932cda1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02962ca2d1",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x7ae50e6fb987a748"
+	},
+
+ "DifficultyTest1202" : {
+		"parentTimestamp" : "0x05b2ac6cda",
+		"parentDifficulty" : "0x29bc68916f707a1c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b2ac6cf2",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x29b731045d428c0d"
+	},
+
+ "DifficultyTest1203" : {
+		"parentTimestamp" : "0x013aba4da3",
+		"parentDifficulty" : "0x4dde522f1d31c07f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x013aba4dbb",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x4dd49664d74e1a47"
+	},
+
+ "DifficultyTest1204" : {
+		"parentTimestamp" : "0x025a64c764",
+		"parentDifficulty" : "0x28625c3a6ef2c845",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x025a64c77c",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x285d4feee7a4e9ec"
+	},
+
+ "DifficultyTest1205" : {
+		"parentTimestamp" : "0x9c70bd46",
+		"parentDifficulty" : "0x76286973c317c252",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x9c70bd5e",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x7619a466949f5f5a"
+	},
+
+ "DifficultyTest1206" : {
+		"parentTimestamp" : "0x8ed07bd7",
+		"parentDifficulty" : "0x641755d99872ebb9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x8ed07bef",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x640ad2eedd3fdd5c"
+	},
+
+ "DifficultyTest1207" : {
+		"parentTimestamp" : "0x014b30bc90",
+		"parentDifficulty" : "0x09355c265449ed51",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x014b30bca8",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x0934357acf7f6414"
+	},
+
+ "DifficultyTest1208" : {
+		"parentTimestamp" : "0x0437b329bc",
+		"parentDifficulty" : "0x1cf41cd45327b2e6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0437b329d4",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x1cf07e50b89d4df1"
+	},
+
+ "DifficultyTest1209" : {
+		"parentTimestamp" : "0x062b0cb7e3",
+		"parentDifficulty" : "0x16ff9d676d87d2a2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x062b0cb7fb",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x16fcbd73c09a21aa"
+	},
+
+ "DifficultyTest1210" : {
+		"parentTimestamp" : "0x6754b3",
+		"parentDifficulty" : "0x27bc67e19c6e6368",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6754cb",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x27b77054a03ad5a0"
+	},
+
+ "DifficultyTest1211" : {
+		"parentTimestamp" : "0x04b5094dbc",
+		"parentDifficulty" : "0x5579c952fb6947e5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b5094dd4",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x556f1a19d109dac5"
+	},
+
+ "DifficultyTest1212" : {
+		"parentTimestamp" : "0x079ae8f860",
+		"parentDifficulty" : "0x600ea75953b1e8bc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x079ae8f878",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6002a5846887728f"
+	},
+
+ "DifficultyTest1213" : {
+		"parentTimestamp" : "0x048ec43768",
+		"parentDifficulty" : "0x2440616d1541188e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x048ec43780",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x243bd960e79e708b"
+	},
+
+ "DifficultyTest1214" : {
+		"parentTimestamp" : "0x06493d355e",
+		"parentDifficulty" : "0x73feb6160a7e0788",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06493d3576",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x73f0363f47bcb808"
+	},
+
+ "DifficultyTest1215" : {
+		"parentTimestamp" : "0x0166f8fa1c",
+		"parentDifficulty" : "0x51ff42304622886b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0166f8fa34",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x51f502480019c49a"
+	},
+
+ "DifficultyTest1216" : {
+		"parentTimestamp" : "0x041163bc92",
+		"parentDifficulty" : "0x2f9f450d7824330f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x041163bcaa",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x2f995124d6752f89"
+	},
+
+ "DifficultyTest1217" : {
+		"parentTimestamp" : "0x06e8392cca",
+		"parentDifficulty" : "0x4d83841145d28be0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06e8392ce2",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x4d79d3a0c3a9d38f"
+	},
+
+ "DifficultyTest1218" : {
+		"parentTimestamp" : "0x0207238a3e",
+		"parentDifficulty" : "0x6804fac718369e0f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0207238a56",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x67f7fa27bf539b3c"
+	},
+
+ "DifficultyTest1219" : {
+		"parentTimestamp" : "0x07dd04b364",
+		"parentDifficulty" : "0x168f27820f7eae09",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07dd04b37c",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x168c559d1f3cbe34"
+	},
+
+ "DifficultyTest1220" : {
+		"parentTimestamp" : "0x43681d57",
+		"parentDifficulty" : "0x19486eb331f3a5b2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x43681d6f",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x194545a55b8d673e"
+	},
+
+ "DifficultyTest1221" : {
+		"parentTimestamp" : "0x02ee4cbce1",
+		"parentDifficulty" : "0x796234244bc537ad",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ee4cbcf9",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x795307ddc73bbf07"
+	},
+
+ "DifficultyTest1222" : {
+		"parentTimestamp" : "0x23957500",
+		"parentDifficulty" : "0x025549096460dd28",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x23957518",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x0254fe604334510d"
+	},
+
+ "DifficultyTest1223" : {
+		"parentTimestamp" : "0x045bee6702",
+		"parentDifficulty" : "0x1d5caf3d6150b26a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x045bee671a",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x1d5903a779a48854"
+	},
+
+ "DifficultyTest1224" : {
+		"parentTimestamp" : "0x010b933dfe",
+		"parentDifficulty" : "0x47143af9ce965ddb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x010b933e16",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x470b58726f5c8b10"
+	},
+
+ "DifficultyTest1225" : {
+		"parentTimestamp" : "0xdd1a8b0c",
+		"parentDifficulty" : "0x1ed3cd3769157376",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xdd1a8b24",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x1ecff2bdc22850c8"
+	},
+
+ "DifficultyTest1226" : {
+		"parentTimestamp" : "0x05b5fd3095",
+		"parentDifficulty" : "0x62f7213c8639541a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05b5fd30ad",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x62eac2585ea88cf0"
+	},
+
+ "DifficultyTest1227" : {
+		"parentTimestamp" : "0x044ec09e42",
+		"parentDifficulty" : "0x7ea71d7eaee4c4ef",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x044ec09e5a",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x7e97489aff0ee858"
+	},
+
+ "DifficultyTest1228" : {
+		"parentTimestamp" : "0x0718093bd4",
+		"parentDifficulty" : "0x0e534bf089622b27",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0718093bec",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x0e5181870b50fee4"
+	},
+
+ "DifficultyTest1229" : {
+		"parentTimestamp" : "0x061a5e6692",
+		"parentDifficulty" : "0x5ad39051628e0d5d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061a5e66aa",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x5ac835df5861bba0"
+	},
+
+ "DifficultyTest1230" : {
+		"parentTimestamp" : "0x07845c6b6f",
+		"parentDifficulty" : "0x21873f0b1d3b6d07",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07845c6b87",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x21830e233bd7c5a2"
+	},
+
+ "DifficultyTest1231" : {
+		"parentTimestamp" : "0x02412fa4ee",
+		"parentDifficulty" : "0x3ed5eaf30ee7448c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02412fa506",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x3ece1035b08567b4"
+	},
+
+ "DifficultyTest1232" : {
+		"parentTimestamp" : "0x0183a6c82c",
+		"parentDifficulty" : "0x711ddc5078a661ac",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0183a6c844",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x710fb894ee974d00"
+	},
+
+ "DifficultyTest1233" : {
+		"parentTimestamp" : "0x07a58e1cdc",
+		"parentDifficulty" : "0x7a87e36854184f91",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a58e1cf4",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x7a78926be70dccc8"
+	},
+
+ "DifficultyTest1234" : {
+		"parentTimestamp" : "0x02d8c0bc12",
+		"parentDifficulty" : "0x42efe1c6ba01d1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02d8c0bc2a",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x42e783ca812b11"
+	},
+
+ "DifficultyTest1235" : {
+		"parentTimestamp" : "0x069b8c0545",
+		"parentDifficulty" : "0x23e874137e44d4be",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x069b8c055d",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x23e3f704fbd50d24"
+	},
+
+ "DifficultyTest1236" : {
+		"parentTimestamp" : "0x0143c7784a",
+		"parentDifficulty" : "0x0c28cd6cd5683462",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0143c77862",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x0c27485327cd895c"
+	},
+
+ "DifficultyTest1237" : {
+		"parentTimestamp" : "0x071d5a9719",
+		"parentDifficulty" : "0x4458877be226f8e4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x071d5a9731",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x444ffc6af2aab805"
+	},
+
+ "DifficultyTest1238" : {
+		"parentTimestamp" : "0x039d2d1354",
+		"parentDifficulty" : "0x41aaf5bf82d0bf60",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039d2d136c",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x41a2c060cae06d49"
+	},
+
+ "DifficultyTest1239" : {
+		"parentTimestamp" : "0x044810d34a",
+		"parentDifficulty" : "0x1b25f261c0a89286",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x044810d362",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x1b228da374708d74"
+	},
+
+ "DifficultyTest1240" : {
+		"parentTimestamp" : "0x07b722d8bd",
+		"parentDifficulty" : "0x55579055178c20c3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07b722d8d5",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x554ce5630ce94f3f"
+	},
+
+ "DifficultyTest1241" : {
+		"parentTimestamp" : "0x077ba563ab",
+		"parentDifficulty" : "0x267711b630c902d3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x077ba563c3",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x267242d3fa0329b3"
+	},
+
+ "DifficultyTest1242" : {
+		"parentTimestamp" : "0x01be1b3855",
+		"parentDifficulty" : "0x33ed91c1d690428c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01be1b386d",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x33ed91c1d690428c"
+	},
+
+ "DifficultyTest1243" : {
+		"parentTimestamp" : "0x0156be1b2c",
+		"parentDifficulty" : "0x53205590e662f1df",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0156be1b44",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x53205590e662f1df"
+	},
+
+ "DifficultyTest1244" : {
+		"parentTimestamp" : "0x01ff411f71",
+		"parentDifficulty" : "0x1655caf60d7445a3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ff411f89",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x1655caf60d7445a3"
+	},
+
+ "DifficultyTest1245" : {
+		"parentTimestamp" : "0x041627698a",
+		"parentDifficulty" : "0x72fb2e355bef92a5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04162769a2",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x72fb2e355bef92a5"
+	},
+
+ "DifficultyTest1246" : {
+		"parentTimestamp" : "0x1f027b2b",
+		"parentDifficulty" : "0x086dcd3dfbebb5dc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1f027b43",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x086dcd3dfbebb5dc"
+	},
+
+ "DifficultyTest1247" : {
+		"parentTimestamp" : "0x04e97c1e70",
+		"parentDifficulty" : "0x0eecf702b097fe3e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e97c1e88",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x0eecf702b097fe3e"
+	},
+
+ "DifficultyTest1248" : {
+		"parentTimestamp" : "0x01bbb43b6c",
+		"parentDifficulty" : "0x2b9220694265ccf6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01bbb43b84",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x2b9220694265ccf6"
+	},
+
+ "DifficultyTest1249" : {
+		"parentTimestamp" : "0x06bb480767",
+		"parentDifficulty" : "0x2a7db0be9f07526c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06bb48077f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x2a7db0be9f07526c"
+	},
+
+ "DifficultyTest1250" : {
+		"parentTimestamp" : "0x04c3931b9f",
+		"parentDifficulty" : "0x7ef83d79add7b8e0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04c3931bb7",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x7ef83d79add7b8e0"
+	},
+
+ "DifficultyTest1251" : {
+		"parentTimestamp" : "0x02c2f125e3",
+		"parentDifficulty" : "0x3bc3d72d207db85a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02c2f125fb",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x3bc3d72d207db85a"
+	},
+
+ "DifficultyTest1252" : {
+		"parentTimestamp" : "0x01b4eddec3",
+		"parentDifficulty" : "0x1e0af619f409b8a7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01b4eddedb",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x1e0af619f409b8a7"
+	},
+
+ "DifficultyTest1253" : {
+		"parentTimestamp" : "0x0489291a14",
+		"parentDifficulty" : "0x04c83850cad1c3b4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0489291a2c",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x04c83850cad1c3b4"
+	},
+
+ "DifficultyTest1254" : {
+		"parentTimestamp" : "0x032286364a",
+		"parentDifficulty" : "0x5414931ecefff398",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0322863662",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x5414931ecefff398"
+	},
+
+ "DifficultyTest1255" : {
+		"parentTimestamp" : "0x04f610e4",
+		"parentDifficulty" : "0x2446ec4f7653adac",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04f610fc",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x2446ec4f7653adac"
+	},
+
+ "DifficultyTest1256" : {
+		"parentTimestamp" : "0xff0fd792",
+		"parentDifficulty" : "0x1bb28be1568581a5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xff0fd7aa",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x1bb28be1568581a5"
+	},
+
+ "DifficultyTest1257" : {
+		"parentTimestamp" : "0x01ad61b6bc",
+		"parentDifficulty" : "0x2a9efa3416118808",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ad61b6d4",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x2a9efa3416118809"
+	},
+
+ "DifficultyTest1258" : {
+		"parentTimestamp" : "0x05537868ef",
+		"parentDifficulty" : "0x6c875a5649a2476c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0553786907",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x6c875a5649a2476e"
+	},
+
+ "DifficultyTest1259" : {
+		"parentTimestamp" : "0x046a7fe465",
+		"parentDifficulty" : "0x6a5a84df2ee7c8c7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x046a7fe47d",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x6a5a84df2ee7c8cb"
+	},
+
+ "DifficultyTest1260" : {
+		"parentTimestamp" : "0x019d849b89",
+		"parentDifficulty" : "0x2d2e81b470304786",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x019d849ba1",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x2d2e81b47030478e"
+	},
+
+ "DifficultyTest1261" : {
+		"parentTimestamp" : "0x05eb42ca56",
+		"parentDifficulty" : "0x2da64d3c19e4f84a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05eb42ca6e",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x2da64d3c19e4f85a"
+	},
+
+ "DifficultyTest1262" : {
+		"parentTimestamp" : "0x0417e522bb",
+		"parentDifficulty" : "0x54193e75915535c4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0417e522d3",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x54193e75915535e4"
+	},
+
+ "DifficultyTest1263" : {
+		"parentTimestamp" : "0x02ad571c5d",
+		"parentDifficulty" : "0x73827826c1cf0232",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ad571c75",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x73827826c1cf0272"
+	},
+
+ "DifficultyTest1264" : {
+		"parentTimestamp" : "0x040e39bf8e",
+		"parentDifficulty" : "0x30ca5f044c3244b6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x040e39bfa6",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x30ca5f044c324536"
+	},
+
+ "DifficultyTest1265" : {
+		"parentTimestamp" : "0x04b62a7889",
+		"parentDifficulty" : "0x7788367cf3e2cef4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04b62a78a1",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x7788367cf3e2cff4"
+	},
+
+ "DifficultyTest1266" : {
+		"parentTimestamp" : "0x0583f46dc6",
+		"parentDifficulty" : "0x64dbf066e6e9227e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0583f46dde",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x64dbf066e6e9247e"
+	},
+
+ "DifficultyTest1267" : {
+		"parentTimestamp" : "0x03fac800b1",
+		"parentDifficulty" : "0x667ad889fb0c6818",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03fac800c9",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x667ad889fb0c6c18"
+	},
+
+ "DifficultyTest1268" : {
+		"parentTimestamp" : "0x04150325aa",
+		"parentDifficulty" : "0xb6eae4a490fe54",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04150325c2",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0xb6eae4a490fe54"
+	},
+
+ "DifficultyTest1269" : {
+		"parentTimestamp" : "0x1d198799",
+		"parentDifficulty" : "0x034490aa49a13415",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1d1987b1",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x034490aa49a13415"
+	},
+
+ "DifficultyTest1270" : {
+		"parentTimestamp" : "0x077336b406",
+		"parentDifficulty" : "0x41c902814cee01fb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x077336b41e",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x41c902814cee01fb"
+	},
+
+ "DifficultyTest1271" : {
+		"parentTimestamp" : "0x057d1a1bb4",
+		"parentDifficulty" : "0x2a432c02cef6c8be",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x057d1a1bcc",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x2a432c02cef6c8be"
+	},
+
+ "DifficultyTest1272" : {
+		"parentTimestamp" : "0x38ab2c38",
+		"parentDifficulty" : "0x0dc8edb6b5ffc922",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x38ab2c50",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x0dc8edb6b5ffc922"
+	},
+
+ "DifficultyTest1273" : {
+		"parentTimestamp" : "0x052196ce68",
+		"parentDifficulty" : "0x559ee6db921ca9c1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x052196ce80",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x559ee6db921ca9c1"
+	},
+
+ "DifficultyTest1274" : {
+		"parentTimestamp" : "0x060f2fdcbf",
+		"parentDifficulty" : "0x1c78ace9e24d5a28",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x060f2fdcd7",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x1c78ace9e24d5a28"
+	},
+
+ "DifficultyTest1275" : {
+		"parentTimestamp" : "0x0636bfe4b4",
+		"parentDifficulty" : "0x14c167b7b2b66b59",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0636bfe4ce",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x14becf8abbc0148c"
+	},
+
+ "DifficultyTest1276" : {
+		"parentTimestamp" : "0x0189bf5475",
+		"parentDifficulty" : "0x586927dbf3ba487c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0189bf548f",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x585e1ab6f83bd134"
+	},
+
+ "DifficultyTest1277" : {
+		"parentTimestamp" : "0x0777837285",
+		"parentDifficulty" : "0x1907241beeaeeb76",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x077783729f",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x190403376b31159b"
+	},
+
+ "DifficultyTest1278" : {
+		"parentTimestamp" : "0x02609efd4c",
+		"parentDifficulty" : "0x04a8ff8f757e4bdd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02609efd66",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x04a86a6f838f9c18"
+	},
+
+ "DifficultyTest1279" : {
+		"parentTimestamp" : "0x04b19bc6ea",
+		"parentDifficulty" : "0x0ff945deb4817024",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b19bc704",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x0ff746b5f8aadffe"
+	},
+
+ "DifficultyTest1280" : {
+		"parentTimestamp" : "0x057d4fe524",
+		"parentDifficulty" : "0x7b5a63ec296401",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x057d4fe53e",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x7b4af89fabdee5"
+	},
+
+ "DifficultyTest1281" : {
+		"parentTimestamp" : "0x04eb4e8645",
+		"parentDifficulty" : "0x61ba36d93d6f756e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04eb4e865f",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x61adff926247c7a0"
+	},
+
+ "DifficultyTest1282" : {
+		"parentTimestamp" : "0x026f981a52",
+		"parentDifficulty" : "0x0a973853112d379e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x026f981a6c",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x0a95e56c06cb1238"
+	},
+
+ "DifficultyTest1283" : {
+		"parentTimestamp" : "0x03dff8065b",
+		"parentDifficulty" : "0x42b041378f13c671",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03dff80675",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x42a7eb2f6821e479"
+	},
+
+ "DifficultyTest1284" : {
+		"parentTimestamp" : "0x076de47f5f",
+		"parentDifficulty" : "0x431dd82753af632f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x076de47f79",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x4315746c4ec4ee43"
+	},
+
+ "DifficultyTest1285" : {
+		"parentTimestamp" : "0x02225e50bb",
+		"parentDifficulty" : "0x686c9d9554bc96ec",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02225e50d5",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x685f9001a212015a"
+	},
+
+ "DifficultyTest1286" : {
+		"parentTimestamp" : "0x05ab496076",
+		"parentDifficulty" : "0x066a62e6ad0d0134",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ab496090",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x0669959a50376394"
+	},
+
+ "DifficultyTest1287" : {
+		"parentTimestamp" : "0x02cd3bdeb3",
+		"parentDifficulty" : "0x2195bbd6f60a068b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02cd3bdecd",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x2191891f7b2b4d4b"
+	},
+
+ "DifficultyTest1288" : {
+		"parentTimestamp" : "0x05886db8d4",
+		"parentDifficulty" : "0x0b78898313408c70",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05886db8ee",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x0b771a71e2de345f"
+	},
+
+ "DifficultyTest1289" : {
+		"parentTimestamp" : "0x039cb7a13a",
+		"parentDifficulty" : "0x35c56c72025aadfc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x039cb7a154",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x35beb3c4741a82a7"
+	},
+
+ "DifficultyTest1290" : {
+		"parentTimestamp" : "0x01c917cbc6",
+		"parentDifficulty" : "0x4e37b8fe5d9a3b51",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01c917cbe0",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x4e2df2073dcec80a"
+	},
+
+ "DifficultyTest1291" : {
+		"parentTimestamp" : "0x02ec07fd05",
+		"parentDifficulty" : "0x78f08d5014958f87",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ec07fd1f",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x78e16f3e6a92fcd6"
+	},
+
+ "DifficultyTest1292" : {
+		"parentTimestamp" : "0x0740e994d9",
+		"parentDifficulty" : "0x03662862fcf28721",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0740e994f3",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x0365bb9df092e8d1"
+	},
+
+ "DifficultyTest1293" : {
+		"parentTimestamp" : "0x060d1829c1",
+		"parentDifficulty" : "0x0b48fde1bee782f4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060d1829db",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x0b4794c202afa604"
+	},
+
+ "DifficultyTest1294" : {
+		"parentTimestamp" : "0x0591bb9a99",
+		"parentDifficulty" : "0x65d3e02279ab312a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0591bb9ab3",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x65c725a6755bfbc4"
+	},
+
+ "DifficultyTest1295" : {
+		"parentTimestamp" : "0x07bed733f8",
+		"parentDifficulty" : "0x027cf25e20317bf3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07bed73412",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x027ca2bfd46d75c4"
+	},
+
+ "DifficultyTest1296" : {
+		"parentTimestamp" : "0x0620ea2068",
+		"parentDifficulty" : "0x78977d0a21f4b3be",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0620ea2082",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x78886a1a80b07528"
+	},
+
+ "DifficultyTest1297" : {
+		"parentTimestamp" : "0x029e1f17d4",
+		"parentDifficulty" : "0x4944606dd4e110dc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x029e1f17ee",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x493b37e1c72674ba"
+	},
+
+ "DifficultyTest1298" : {
+		"parentTimestamp" : "0x05134cbd6a",
+		"parentDifficulty" : "0x2c3e34a9292e4061",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05134cbd84",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x2c38ace294091a99"
+	},
+
+ "DifficultyTest1299" : {
+		"parentTimestamp" : "0x03c9def3bd",
+		"parentDifficulty" : "0x1b9420e9f65eb47d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03c9def3d7",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x1b90ae65d91fe8a7"
+	},
+
+ "DifficultyTest1300" : {
+		"parentTimestamp" : "0x060968035a",
+		"parentDifficulty" : "0x2fd3936bda1c548e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0609680374",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x2fcd98f96ca11104"
+	},
+
+ "DifficultyTest1301" : {
+		"parentTimestamp" : "0x7a822aa5",
+		"parentDifficulty" : "0x379defcfe0b38661",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x7a822abf",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x3796fc11e6b76ff1"
+	},
+
+ "DifficultyTest1302" : {
+		"parentTimestamp" : "0x02a44ce52a",
+		"parentDifficulty" : "0x6789de8ec7ffc074",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02a44ce544",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x677ced52f626c07c"
+	},
+
+ "DifficultyTest1303" : {
+		"parentTimestamp" : "0x042bf99b05",
+		"parentDifficulty" : "0x2807adad40179041",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x042bf99b1f",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x2802acb78a6f8d4f"
+	},
+
+ "DifficultyTest1304" : {
+		"parentTimestamp" : "0x069ab52aa9",
+		"parentDifficulty" : "0x7912b78445bdbec5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x069ab52ac3",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x7903952d5535070e"
+	},
+
+ "DifficultyTest1305" : {
+		"parentTimestamp" : "0x06c1358f39",
+		"parentDifficulty" : "0x4dccf5d1b7fe7321",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06c1358f53",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x4dc33c32fdc77353"
+	},
+
+ "DifficultyTest1306" : {
+		"parentTimestamp" : "0x67b1dc7f",
+		"parentDifficulty" : "0x2e0c44bbdee3d9c8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x67b1dc99",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x2e0683334767fd4e"
+	},
+
+ "DifficultyTest1307" : {
+		"parentTimestamp" : "0x06789a4be9",
+		"parentDifficulty" : "0x6667ae79727d13ed",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06789a4c03",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x665ae183a34ec44d"
+	},
+
+ "DifficultyTest1308" : {
+		"parentTimestamp" : "0x02652e7c5d",
+		"parentDifficulty" : "0x7e707f572ee92be1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02652e7c77",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x7e60b14744034ec0"
+	},
+
+ "DifficultyTest1309" : {
+		"parentTimestamp" : "0x015a0c0092",
+		"parentDifficulty" : "0x180dff18fc69ed2b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x015a0c00ac",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x180afd59194a5ff6"
+	},
+
+ "DifficultyTest1310" : {
+		"parentTimestamp" : "0x052b6226f4",
+		"parentDifficulty" : "0x028033761ad41d61",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x052b62270e",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x027fe36fac10c2ee"
+	},
+
+ "DifficultyTest1311" : {
+		"parentTimestamp" : "0x065f159e83",
+		"parentDifficulty" : "0x45d096fdad39451c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x065f159e9d",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x45c7dceacd839e14"
+	},
+
+ "DifficultyTest1312" : {
+		"parentTimestamp" : "0x05f2c2e25f",
+		"parentDifficulty" : "0x4e196e37d15e2a42",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f2c2e279",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x4e0fab0a0a63febd"
+	},
+
+ "DifficultyTest1313" : {
+		"parentTimestamp" : "0x996be556",
+		"parentDifficulty" : "0x5be02b08ca1db88c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x996be570",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x5bd4af0369047555"
+	},
+
+ "DifficultyTest1314" : {
+		"parentTimestamp" : "0x5ea0140f",
+		"parentDifficulty" : "0x4233dfb3ee6634b3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x5ea01429",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x422b9937f7e868ed"
+	},
+
+ "DifficultyTest1315" : {
+		"parentTimestamp" : "0x6e484650",
+		"parentDifficulty" : "0x6993f37b5526a0b5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6e48466a",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x6986c0fce5bbfde1"
+	},
+
+ "DifficultyTest1316" : {
+		"parentTimestamp" : "0x0763d2e7b0",
+		"parentDifficulty" : "0x6923065e1fdd82b6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0763d2e7ca",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x6915e1fd54198b06"
+	},
+
+ "DifficultyTest1317" : {
+		"parentTimestamp" : "0x06a383c730",
+		"parentDifficulty" : "0x04b4522e354f58f8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06a383c74a",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x04b3bba3ef88af0d"
+	},
+
+ "DifficultyTest1318" : {
+		"parentTimestamp" : "0x04c71adf7a",
+		"parentDifficulty" : "0x1b39fb2dfbd1f6d8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c71adf94",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1b3693ee96127c9a"
+	},
+
+ "DifficultyTest1319" : {
+		"parentTimestamp" : "0xa880c725",
+		"parentDifficulty" : "0x11f88d6d1b8e0ab8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa880c73f",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x11f64e5b6dea98f7"
+	},
+
+ "DifficultyTest1320" : {
+		"parentTimestamp" : "0x02e8badf7c",
+		"parentDifficulty" : "0x36f77dcd6c0815dd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e8badf96",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x36f09eddb25a94db"
+	},
+
+ "DifficultyTest1321" : {
+		"parentTimestamp" : "0x32b3fc61",
+		"parentDifficulty" : "0x5dd684e29f40ae11",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x32b3fc7b",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x5dcaca1202ecc5fc"
+	},
+
+ "DifficultyTest1322" : {
+		"parentTimestamp" : "0x0416b34684",
+		"parentDifficulty" : "0x1505be3e9bd8dbf7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0416b3469e",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x15031d86d40560dc"
+	},
+
+ "DifficultyTest1323" : {
+		"parentTimestamp" : "0x047486a6cd",
+		"parentDifficulty" : "0x2289d75e3737ee48",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x047486a6e7",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x228586234b71074b"
+	},
+
+ "DifficultyTest1324" : {
+		"parentTimestamp" : "0x82280023",
+		"parentDifficulty" : "0x2c16bdd25cf77906",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x8228003d",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x2c113afaa2abda17"
+	},
+
+ "DifficultyTest1325" : {
+		"parentTimestamp" : "0x050938bd0d",
+		"parentDifficulty" : "0x78817c81a8e35c22",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x050938bd27",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x78726c5218ae3fb8"
+	},
+
+ "DifficultyTest1326" : {
+		"parentTimestamp" : "0x0253e184ac",
+		"parentDifficulty" : "0x5130b8cf8ec8c538",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0253e184c6",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x512692b874d6ec22"
+	},
+
+ "DifficultyTest1327" : {
+		"parentTimestamp" : "0x05be3537a3",
+		"parentDifficulty" : "0x0444d11e7bfface8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05be3537bd",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x0444488458302cf7"
+	},
+
+ "DifficultyTest1328" : {
+		"parentTimestamp" : "0x062d9316d0",
+		"parentDifficulty" : "0x29e9a9c015f38c19",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x062d9316ea",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x29e46c8addf0cdb0"
+	},
+
+ "DifficultyTest1329" : {
+		"parentTimestamp" : "0x06e8f09246",
+		"parentDifficulty" : "0x11cd2cc0d2061dfd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06e8f09260",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x11caf31b39ebdd4a"
+	},
+
+ "DifficultyTest1330" : {
+		"parentTimestamp" : "0x062b849a5a",
+		"parentDifficulty" : "0x28c1d34d4eb7a851",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x062b849a74",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x28bcbb12e50dd17c"
+	},
+
+ "DifficultyTest1331" : {
+		"parentTimestamp" : "0x07a9c52474",
+		"parentDifficulty" : "0x0beb22517301c79b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a9c5248e",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x0be9a4ed28d367a3"
+	},
+
+ "DifficultyTest1332" : {
+		"parentTimestamp" : "0x0321c40169",
+		"parentDifficulty" : "0x01eb6a3719ef9c8e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0321c40183",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x01eb2cc9d30c5f1b"
+	},
+
+ "DifficultyTest1333" : {
+		"parentTimestamp" : "0x05e6c13cdf",
+		"parentDifficulty" : "0x6a657cadbc3bc7ba",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e6c13cf9",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x6a582ffe26844142"
+	},
+
+ "DifficultyTest1334" : {
+		"parentTimestamp" : "0xa507c058",
+		"parentDifficulty" : "0x0fbce7603e870e45",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xa507c072",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x0fbaefc3527f3f64"
+	},
+
+ "DifficultyTest1335" : {
+		"parentTimestamp" : "0x01ed9ba833",
+		"parentDifficulty" : "0x1197aa7db23d3055",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ed9ba84d",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x119577886286ecaf"
+	},
+
+ "DifficultyTest1336" : {
+		"parentTimestamp" : "0x0757c24b11",
+		"parentDifficulty" : "0x6c438fcfbab27ead",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0757c24b2b",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x6c36075dc0bb305e"
+	},
+
+ "DifficultyTest1337" : {
+		"parentTimestamp" : "0xd17fee5d",
+		"parentDifficulty" : "0x2aa2b20d71f8b387",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xd17fee77",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x2a9d5db7304a8471"
+	},
+
+ "DifficultyTest1338" : {
+		"parentTimestamp" : "0x05d7e09f93",
+		"parentDifficulty" : "0x796f594136dc59b5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05d7e09fad",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x79602b560eb59e2a"
+	},
+
+ "DifficultyTest1339" : {
+		"parentTimestamp" : "0x03dc1a2aad",
+		"parentDifficulty" : "0x1e39c9e33f9bf74f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03dc1a2ac7",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x1e3602aa033443d1"
+	},
+
+ "DifficultyTest1340" : {
+		"parentTimestamp" : "0x07c857747d",
+		"parentDifficulty" : "0x0d35969feaddad48",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07c8577497",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x0d35969feaddad48"
+	},
+
+ "DifficultyTest1341" : {
+		"parentTimestamp" : "0x0620e98c37",
+		"parentDifficulty" : "0x07dfe5b30f6b03d6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0620e98c51",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x07dfe5b30f6b03d6"
+	},
+
+ "DifficultyTest1342" : {
+		"parentTimestamp" : "0x03786f7c6f",
+		"parentDifficulty" : "0x487166106603f382",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03786f7c89",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x487166106603f382"
+	},
+
+ "DifficultyTest1343" : {
+		"parentTimestamp" : "0x02cc9fa8f0",
+		"parentDifficulty" : "0x6cbbdb5e1fe778ca",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cc9fa90a",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6cbbdb5e1fe778ca"
+	},
+
+ "DifficultyTest1344" : {
+		"parentTimestamp" : "0x059d43f158",
+		"parentDifficulty" : "0x08a77d8785f0f6d2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x059d43f172",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x08a77d8785f0f6d2"
+	},
+
+ "DifficultyTest1345" : {
+		"parentTimestamp" : "0x05e7ae394e",
+		"parentDifficulty" : "0x767619f86aafb832",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e7ae3968",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x767619f86aafb832"
+	},
+
+ "DifficultyTest1346" : {
+		"parentTimestamp" : "0x044306bafc",
+		"parentDifficulty" : "0x352fee749ff36ab5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x044306bb16",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x352fee749ff36ab5"
+	},
+
+ "DifficultyTest1347" : {
+		"parentTimestamp" : "0x02146f1cd5",
+		"parentDifficulty" : "0x53daaed8fa717eca",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02146f1cef",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x53daaed8fa717eca"
+	},
+
+ "DifficultyTest1348" : {
+		"parentTimestamp" : "0x01b315913a",
+		"parentDifficulty" : "0x0656439d9fd66e28",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01b3159154",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x0656439d9fd66e28"
+	},
+
+ "DifficultyTest1349" : {
+		"parentTimestamp" : "0x0123d74d37",
+		"parentDifficulty" : "0x03874d5834e98b09",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0123d74d51",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x03874d5834e98b09"
+	},
+
+ "DifficultyTest1350" : {
+		"parentTimestamp" : "0x06db5d0cb1",
+		"parentDifficulty" : "0x748c4cf8891fcb90",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06db5d0ccb",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x748c4cf8891fcb90"
+	},
+
+ "DifficultyTest1351" : {
+		"parentTimestamp" : "0x04a64d0b77",
+		"parentDifficulty" : "0xd87381b1316501",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04a64d0b91",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0xd87381b1316501"
+	},
+
+ "DifficultyTest1352" : {
+		"parentTimestamp" : "0x036656f227",
+		"parentDifficulty" : "0x7892849909bdbfa0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x036656f241",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x7892849909bdbfa0"
+	},
+
+ "DifficultyTest1353" : {
+		"parentTimestamp" : "0x0767caf7db",
+		"parentDifficulty" : "0x33c40a0b11c6e3e5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0767caf7f5",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x33c40a0b11c6e3e5"
+	},
+
+ "DifficultyTest1354" : {
+		"parentTimestamp" : "0x0320c077cb",
+		"parentDifficulty" : "0x3de73edf36f39950",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0320c077e5",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3de73edf36f39950"
+	},
+
+ "DifficultyTest1355" : {
+		"parentTimestamp" : "0x2e9704aa",
+		"parentDifficulty" : "0x3b9d76e7e18352dd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x2e9704c4",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x3b9d76e7e18352de"
+	},
+
+ "DifficultyTest1356" : {
+		"parentTimestamp" : "0x0696732ad4",
+		"parentDifficulty" : "0x3a88d7839b9f124b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0696732aee",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x3a88d7839b9f124d"
+	},
+
+ "DifficultyTest1357" : {
+		"parentTimestamp" : "0x05b78c574c",
+		"parentDifficulty" : "0x6a59e90980c5b9c9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05b78c5766",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x6a59e90980c5b9cd"
+	},
+
+ "DifficultyTest1358" : {
+		"parentTimestamp" : "0x0123cd020c",
+		"parentDifficulty" : "0x57b43b1693994986",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0123cd0226",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x57b43b169399498e"
+	},
+
+ "DifficultyTest1359" : {
+		"parentTimestamp" : "0x0739c64cc7",
+		"parentDifficulty" : "0x78b8a9ccb3227f0b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0739c64ce1",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x78b8a9ccb3227f1b"
+	},
+
+ "DifficultyTest1360" : {
+		"parentTimestamp" : "0x06c5ea3137",
+		"parentDifficulty" : "0x3664c42cb507a660",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c5ea3151",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x3664c42cb507a680"
+	},
+
+ "DifficultyTest1361" : {
+		"parentTimestamp" : "0x1f1854aa",
+		"parentDifficulty" : "0x0e700c71284df76d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1f1854c4",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x0e700c71284df7ad"
+	},
+
+ "DifficultyTest1362" : {
+		"parentTimestamp" : "0x04d64881a9",
+		"parentDifficulty" : "0x291d983e4431d058",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04d64881c3",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x291d983e4431d0d8"
+	},
+
+ "DifficultyTest1363" : {
+		"parentTimestamp" : "0x01cc6f5ad2",
+		"parentDifficulty" : "0x42f28c7d98c8ce10",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01cc6f5aec",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x42f28c7d98c8cf10"
+	},
+
+ "DifficultyTest1364" : {
+		"parentTimestamp" : "0xf4db29a8",
+		"parentDifficulty" : "0x179bbaf55878b4d8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xf4db29c2",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x179bbaf55878b6d8"
+	},
+
+ "DifficultyTest1365" : {
+		"parentTimestamp" : "0x0643872d2b",
+		"parentDifficulty" : "0x2ca4a8e6f58f8a5e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0643872d45",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x2ca4a8e6f58f8e5e"
+	},
+
+ "DifficultyTest1366" : {
+		"parentTimestamp" : "0x06f63d1df6",
+		"parentDifficulty" : "0x047712a184b789cc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06f63d1e10",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x047712a184b789cc"
+	},
+
+ "DifficultyTest1367" : {
+		"parentTimestamp" : "0x02c0d4602e",
+		"parentDifficulty" : "0x43335b0b330f090f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02c0d46048",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x43335b0b330f090f"
+	},
+
+ "DifficultyTest1368" : {
+		"parentTimestamp" : "0x0795690842",
+		"parentDifficulty" : "0x56be11879676388f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x079569085c",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x56be11879676388f"
+	},
+
+ "DifficultyTest1369" : {
+		"parentTimestamp" : "0x0236037a05",
+		"parentDifficulty" : "0x6d3d25180c4b9254",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0236037a1f",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x6d3d25180c4b9254"
+	},
+
+ "DifficultyTest1370" : {
+		"parentTimestamp" : "0x030526b654",
+		"parentDifficulty" : "0x742e737978815c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x030526b66e",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x742e737978815c"
+	},
+
+ "DifficultyTest1371" : {
+		"parentTimestamp" : "0x0204b27f0c",
+		"parentDifficulty" : "0x66a51627a0f24f56",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0204b27f26",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x66a51627a0f24f56"
+	},
+
+ "DifficultyTest1372" : {
+		"parentTimestamp" : "0x0216567d98",
+		"parentDifficulty" : "0x54f41f5378cb84da",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0216567db2",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x54f41f5378cb84da"
+	},
+
+ "DifficultyTest1373" : {
+		"parentTimestamp" : "0x05987de7ff",
+		"parentDifficulty" : "0x34c499d16c48b7aa",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05987de81b",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x34be013e321b2e94"
+	},
+
+ "DifficultyTest1374" : {
+		"parentTimestamp" : "0x07ac110ddb",
+		"parentDifficulty" : "0x3f8d9dac614c2b97",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07ac110df7",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x3f85abf8abc00213"
+	},
+
+ "DifficultyTest1375" : {
+		"parentTimestamp" : "0x018b7116d2",
+		"parentDifficulty" : "0x537cbfc7738763fb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x018b7116ee",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x5372502f7a98f311"
+	},
+
+ "DifficultyTest1376" : {
+		"parentTimestamp" : "0x07c99ed920",
+		"parentDifficulty" : "0x0cbe9ebff8fa921e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07c99ed93c",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x0cbd06ec20fb72d0"
+	},
+
+ "DifficultyTest1377" : {
+		"parentTimestamp" : "0x05e6d0cbb4",
+		"parentDifficulty" : "0x0abbc74d50cdca8e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e6d0cbd0",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x0aba6fd46723b0dd"
+	},
+
+ "DifficultyTest1378" : {
+		"parentTimestamp" : "0x025879ff54",
+		"parentDifficulty" : "0x4aeeb4ab9c65f766",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x025879ff70",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x4ae556d506f26ab8"
+	},
+
+ "DifficultyTest1379" : {
+		"parentTimestamp" : "0x027f93bb61",
+		"parentDifficulty" : "0x1636f896725b1ff7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x027f93bb7d",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x163431b75f8cd4b4"
+	},
+
+ "DifficultyTest1380" : {
+		"parentTimestamp" : "0x06356a970f",
+		"parentDifficulty" : "0x141c092d182613d6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06356a972b",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x141985abf2830f54"
+	},
+
+ "DifficultyTest1381" : {
+		"parentTimestamp" : "0x0352404c3d",
+		"parentDifficulty" : "0x37009e3ea77940c8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0352404c59",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x36f9be2adfa45220"
+	},
+
+ "DifficultyTest1382" : {
+		"parentTimestamp" : "0x0576d2bbf1",
+		"parentDifficulty" : "0x0275b3df5d84c3cd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0576d2bc0d",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x02756528e1991435"
+	},
+
+ "DifficultyTest1383" : {
+		"parentTimestamp" : "0x04394526a3",
+		"parentDifficulty" : "0x1860a64f34eb3126",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04394526bf",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x185d9a3a6b0495c0"
+	},
+
+ "DifficultyTest1384" : {
+		"parentTimestamp" : "0x010bdbe57e",
+		"parentDifficulty" : "0x4e3275cce17f0b3d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x010bdbe59a",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x4e28af7e27e2df5c"
+	},
+
+ "DifficultyTest1385" : {
+		"parentTimestamp" : "0x074b75df18",
+		"parentDifficulty" : "0x345ce16ae5aa11df",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x074b75df34",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x345655ceb84d649d"
+	},
+
+ "DifficultyTest1386" : {
+		"parentTimestamp" : "0x078ea9c74d",
+		"parentDifficulty" : "0x098447e169107f77",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x078ea9c769",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x098317586ce36d68"
+	},
+
+ "DifficultyTest1387" : {
+		"parentTimestamp" : "0x0277bdfa5f",
+		"parentDifficulty" : "0x2b0bde648318855e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0277bdfa7b",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x2b067ce8b688424e"
+	},
+
+ "DifficultyTest1388" : {
+		"parentTimestamp" : "0x05d0e18aeb",
+		"parentDifficulty" : "0x0291405be55d82aa",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d0e18b07",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x0290ee33d9e116fa"
+	},
+
+ "DifficultyTest1389" : {
+		"parentTimestamp" : "0x0103771a83",
+		"parentDifficulty" : "0x2921e8c6b8df01cf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0103771a9f",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x2917a04c8730ca0f"
+	},
+
+ "DifficultyTest1390" : {
+		"parentTimestamp" : "0x079cbe6c0b",
+		"parentDifficulty" : "0x372e874a42f0c6fe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x079cbe6c27",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x3720bba870600ace"
+	},
+
+ "DifficultyTest1391" : {
+		"parentTimestamp" : "0x075c75214e",
+		"parentDifficulty" : "0x58711ef887f615af",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x075c75216a",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x585b02b0c9d4182b"
+	},
+
+ "DifficultyTest1392" : {
+		"parentTimestamp" : "0x075746fb79",
+		"parentDifficulty" : "0x60ae8fdec68ebc96",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x075746fb95",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6096643acedd18e8"
+	},
+
+ "DifficultyTest1393" : {
+		"parentTimestamp" : "0x011f100590",
+		"parentDifficulty" : "0x35e6c050b3d186e7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x011f1005ac",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x35d946a09fa49287"
+	},
+
+ "DifficultyTest1394" : {
+		"parentTimestamp" : "0x07b0c4382a",
+		"parentDifficulty" : "0x3905da7578588f6e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07b0c43846",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x38f798fedafa794c"
+	},
+
+ "DifficultyTest1395" : {
+		"parentTimestamp" : "0x0146461661",
+		"parentDifficulty" : "0x0f5654dd72456af7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x014646167d",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x0f527f483ae8d99d"
+	},
+
+ "DifficultyTest1396" : {
+		"parentTimestamp" : "0x0707245909",
+		"parentDifficulty" : "0x370052d4482234dd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0707245925",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x36f292bf93102c51"
+	},
+
+ "DifficultyTest1397" : {
+		"parentTimestamp" : "0x0712ff83cf",
+		"parentDifficulty" : "0x7474ff549f753841",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0712ff83eb",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x7457e214ca4d5af3"
+	},
+
+ "DifficultyTest1398" : {
+		"parentTimestamp" : "0x036a4010bb",
+		"parentDifficulty" : "0x06d33a7d1a1a8244",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x036a4010d7",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x06d185ae7ad3fba4"
+	},
+
+ "DifficultyTest1399" : {
+		"parentTimestamp" : "0x016b4df678",
+		"parentDifficulty" : "0x6ba8ef4531a0a00d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x016b4df694",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x6b8e0509605437e5"
+	},
+
+ "DifficultyTest1400" : {
+		"parentTimestamp" : "0x02e8c5b2e2",
+		"parentDifficulty" : "0x0e4337e999a32db5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e8c5b2fe",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x0e3fa71b9f3cc4eb"
+	},
+
+ "DifficultyTest1401" : {
+		"parentTimestamp" : "0x06c768fc98",
+		"parentDifficulty" : "0x1ce877e123dd5504",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06c768fcb4",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x1ce13dc32b945db0"
+	},
+
+ "DifficultyTest1402" : {
+		"parentTimestamp" : "0x0106d3b4a9",
+		"parentDifficulty" : "0x536997c855eb45c4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0106d3b4c5",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x5354bd6263d5caf4"
+	},
+
+ "DifficultyTest1403" : {
+		"parentTimestamp" : "0x0665775356",
+		"parentDifficulty" : "0x4348c82ce30bf965",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0665775372",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x4337f5fad7d33667"
+	},
+
+ "DifficultyTest1404" : {
+		"parentTimestamp" : "0x057c7408ae",
+		"parentDifficulty" : "0x7261a7b862197105",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x057c7408ca",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x72450f4e7400eaaa"
+	},
+
+ "DifficultyTest1405" : {
+		"parentTimestamp" : "0x02d39431fc",
+		"parentDifficulty" : "0x21194a9404dc108d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d3943218",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x211104415fdad98b"
+	},
+
+ "DifficultyTest1406" : {
+		"parentTimestamp" : "0x04293e5049",
+		"parentDifficulty" : "0x79968665d348310e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04293e5065",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x797820c439d35f06"
+	},
+
+ "DifficultyTest1407" : {
+		"parentTimestamp" : "0x02acf03574",
+		"parentDifficulty" : "0x7ddb74b2c28d43da",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02acf03590",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x7dbbfdd595dca092"
+	},
+
+ "DifficultyTest1408" : {
+		"parentTimestamp" : "0x0580017702",
+		"parentDifficulty" : "0x76ae72728317f689",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x058001771e",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x7690c6d5e677309d"
+	},
+
+ "DifficultyTest1409" : {
+		"parentTimestamp" : "0x020e1bc5cc",
+		"parentDifficulty" : "0x2f33edbf4c7c36bd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x020e1bc5e8",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x2f2820c3dca917d1"
+	},
+
+ "DifficultyTest1410" : {
+		"parentTimestamp" : "0xd739f074",
+		"parentDifficulty" : "0x297192a321f1e34d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xd739f090",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2967363e79296715"
+	},
+
+ "DifficultyTest1411" : {
+		"parentTimestamp" : "0x020a6cb9d1",
+		"parentDifficulty" : "0x67d8f84b29bd5d02",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x020a6cb9ed",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x67bf020d16f2ee2c"
+	},
+
+ "DifficultyTest1412" : {
+		"parentTimestamp" : "0x032c1986b3",
+		"parentDifficulty" : "0x20d4189419f9c5be",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x032c1986cf",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x20cbe38df4f3484e"
+	},
+
+ "DifficultyTest1413" : {
+		"parentTimestamp" : "0x032e87d34e",
+		"parentDifficulty" : "0x748bc5f506a8aeb0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x032e87d36a",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x746ea30389670686"
+	},
+
+ "DifficultyTest1414" : {
+		"parentTimestamp" : "0x06ba4db0d1",
+		"parentDifficulty" : "0x4f88c27a0bf8028a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ba4db0ed",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x4f74e0496d75088a"
+	},
+
+ "DifficultyTest1415" : {
+		"parentTimestamp" : "0x016f103934",
+		"parentDifficulty" : "0x3980aebfa2825faa",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x016f103950",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x39724e93f299bf14"
+	},
+
+ "DifficultyTest1416" : {
+		"parentTimestamp" : "0x05aed8c684",
+		"parentDifficulty" : "0x4f0411b2a8ebbec9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05aed8c6a0",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x4ef050ae3c4183db"
+	},
+
+ "DifficultyTest1417" : {
+		"parentTimestamp" : "0x05b9f84b6a",
+		"parentDifficulty" : "0x17508868ebcf1e85",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b9f84b86",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x174ab446d1942abf"
+	},
+
+ "DifficultyTest1418" : {
+		"parentTimestamp" : "0x0170d88cd4",
+		"parentDifficulty" : "0x2be04805d2591471",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0170d88cf0",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x2bd54ff3d0e47e2d"
+	},
+
+ "DifficultyTest1419" : {
+		"parentTimestamp" : "0x045980c37c",
+		"parentDifficulty" : "0x7793b1dab991b8b2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x045980c398",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x7775ccee42e35444"
+	},
+
+ "DifficultyTest1420" : {
+		"parentTimestamp" : "0x01a1abd08b",
+		"parentDifficulty" : "0x332bec741b5f19bf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01a1abd0a7",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x331f2178fe5841f9"
+	},
+
+ "DifficultyTest1421" : {
+		"parentTimestamp" : "0x054f760afc",
+		"parentDifficulty" : "0x2d670f40ecf44ab3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x054f760b18",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x2d5bb57d1cb90da1"
+	},
+
+ "DifficultyTest1422" : {
+		"parentTimestamp" : "0x067ecdcf31",
+		"parentDifficulty" : "0x6bf5b30d6b6a5093",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x067ecdcf4d",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x6be8345709bce349"
+	},
+
+ "DifficultyTest1423" : {
+		"parentTimestamp" : "0x0463015adb",
+		"parentDifficulty" : "0x580a7a308b814d8c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0463015af7",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x57ff78e1456fdd64"
+	},
+
+ "DifficultyTest1424" : {
+		"parentTimestamp" : "0x0772bab5b4",
+		"parentDifficulty" : "0x32b4dbe1a394f5bd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0772bab5d0",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x32ae854627608321"
+	},
+
+ "DifficultyTest1425" : {
+		"parentTimestamp" : "0x03d97579eb",
+		"parentDifficulty" : "0x6e8a07f4ab41ef83",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03d9757a07",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x6e7c36b3acac874a"
+	},
+
+ "DifficultyTest1426" : {
+		"parentTimestamp" : "0x05c4ab6d7b",
+		"parentDifficulty" : "0x79f511bee55180ea",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05c4ab6d97",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x79e5d31cad74d6c2"
+	},
+
+ "DifficultyTest1427" : {
+		"parentTimestamp" : "0x0796861ba1",
+		"parentDifficulty" : "0x62173d6ab8699e65",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0796861bbd",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x620afa830b129142"
+	},
+
+ "DifficultyTest1428" : {
+		"parentTimestamp" : "0x0445c4c0e8",
+		"parentDifficulty" : "0x2f12ec9655193753",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0445c4c104",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x2f0d0a38c24e944d"
+	},
+
+ "DifficultyTest1429" : {
+		"parentTimestamp" : "0x071bdb356e",
+		"parentDifficulty" : "0x790535ee4cfd4a7c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x071bdb358a",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x78f615478f33ab13"
+	},
+
+ "DifficultyTest1430" : {
+		"parentTimestamp" : "0x07e4c2d2a7",
+		"parentDifficulty" : "0x65a95d537e59fd36",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e4c2d2c3",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x659ca827d3ea3277"
+	},
+
+ "DifficultyTest1431" : {
+		"parentTimestamp" : "0x01b115798f",
+		"parentDifficulty" : "0x0250b6bc107809f2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01b11579ab",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x02506ca538f5fbf1"
+	},
+
+ "DifficultyTest1432" : {
+		"parentTimestamp" : "0x70573872",
+		"parentDifficulty" : "0x2c578a081294d50c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7057388e",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x2c51ff16d1928472"
+	},
+
+ "DifficultyTest1433" : {
+		"parentTimestamp" : "0x06b83f81e4",
+		"parentDifficulty" : "0x38d7c71fd787249a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06b83f8200",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x38d0ac26f38c37b6"
+	},
+
+ "DifficultyTest1434" : {
+		"parentTimestamp" : "0x0752cd7472",
+		"parentDifficulty" : "0x3f2a666ca02a1d09",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0752cd748e",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x3f22811fd2961fc6"
+	},
+
+ "DifficultyTest1435" : {
+		"parentTimestamp" : "0x04252356d2",
+		"parentDifficulty" : "0x3e318edcc6031c5c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04252356ee",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x3e29c8aaea6a6bf9"
+	},
+
+ "DifficultyTest1436" : {
+		"parentTimestamp" : "0x04d9651973",
+		"parentDifficulty" : "0x7c051c5f2cc534bc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04d965198f",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x7bf59bbba0dfbc16"
+	},
+
+ "DifficultyTest1437" : {
+		"parentTimestamp" : "0x061ff49c1f",
+		"parentDifficulty" : "0x0aaa48a4f8b7b98d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061ff49c3b",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x0aa8f35be418e296"
+	},
+
+ "DifficultyTest1438" : {
+		"parentTimestamp" : "0x030e0a60d4",
+		"parentDifficulty" : "0x090119241362f1ce",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x030e0a60f0",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x08fff900eee08570"
+	},
+
+ "DifficultyTest1439" : {
+		"parentTimestamp" : "0x07774effdb",
+		"parentDifficulty" : "0x3653a36bc71da656",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07774efff7",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x364cd8f759a4c2a2"
+	},
+
+ "DifficultyTest1440" : {
+		"parentTimestamp" : "0x017d443507",
+		"parentDifficulty" : "0x210d3611dfd21a92",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x017d443523",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x2109146b1d96204f"
+	},
+
+ "DifficultyTest1441" : {
+		"parentTimestamp" : "0x02f14aba6d",
+		"parentDifficulty" : "0x69800babee77bb1c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f14aba89",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6972dbaa78f9ec25"
+	},
+
+ "DifficultyTest1442" : {
+		"parentTimestamp" : "0x06899bb074",
+		"parentDifficulty" : "0x3199af8760e63208",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06899bb090",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x31937c516ffa1542"
+	},
+
+ "DifficultyTest1443" : {
+		"parentTimestamp" : "0x04a8f938ee",
+		"parentDifficulty" : "0x7da52ce254849aca",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04a8f9390a",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x7d95783cb83a0a37"
+	},
+
+ "DifficultyTest1444" : {
+		"parentTimestamp" : "0x2cdcbe11",
+		"parentDifficulty" : "0x3adede942c8153f3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x2cdcbe2d",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x3ad782b859fbc3c9"
+	},
+
+ "DifficultyTest1445" : {
+		"parentTimestamp" : "0x073b7b93bb",
+		"parentDifficulty" : "0x027f774b0fd1cfdb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x073b7b93d7",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x027f275c266fd5a2"
+	},
+
+ "DifficultyTest1446" : {
+		"parentTimestamp" : "0x06c21c0942",
+		"parentDifficulty" : "0x644d8e233f2ab06a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c21c095e",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x644104717ac2cb14"
+	},
+
+ "DifficultyTest1447" : {
+		"parentTimestamp" : "0x01bae072ff",
+		"parentDifficulty" : "0x7f37e38a877e161e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01bae0731b",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x7f27fc8e162d265c"
+	},
+
+ "DifficultyTest1448" : {
+		"parentTimestamp" : "0x0441ae87de",
+		"parentDifficulty" : "0x485a9ff4c9446605",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0441ae87fa",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x485194a0caab3d79"
+	},
+
+ "DifficultyTest1449" : {
+		"parentTimestamp" : "0x0123a3272f",
+		"parentDifficulty" : "0x7aeb7a89b555e32b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0123a3274b",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x7adc1d1a641f386f"
+	},
+
+ "DifficultyTest1450" : {
+		"parentTimestamp" : "0x06475f7ea6",
+		"parentDifficulty" : "0x2a6816ff266d55e6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06475f7ec2",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x2a62c9fc4688883c"
+	},
+
+ "DifficultyTest1451" : {
+		"parentTimestamp" : "0x07d62c0fc7",
+		"parentDifficulty" : "0x45a37c0be8b0be7b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07d62c0fe3",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x459ac79c6733a864"
+	},
+
+ "DifficultyTest1452" : {
+		"parentTimestamp" : "0x014c57f2c2",
+		"parentDifficulty" : "0x1aa230b7465a465d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x014c57f2de",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x1a9edc712f717b15"
+	},
+
+ "DifficultyTest1453" : {
+		"parentTimestamp" : "0x048ee7a478",
+		"parentDifficulty" : "0x3f4e8fc6969f0196",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x048ee7a494",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x3f46a5f49dcc2db7"
+	},
+
+ "DifficultyTest1454" : {
+		"parentTimestamp" : "0x06399233af",
+		"parentDifficulty" : "0x27fb524f86eccc6b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06399233cb",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x27f652e53cfbeed4"
+	},
+
+ "DifficultyTest1455" : {
+		"parentTimestamp" : "0x05137f990e",
+		"parentDifficulty" : "0x71db3aefb1244268",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05137f992a",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x71ccff88532e1de4"
+	},
+
+ "DifficultyTest1456" : {
+		"parentTimestamp" : "0x98ce8464",
+		"parentDifficulty" : "0x63f99164a0837679",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x98ce8480",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x63ed123273ef6613"
+	},
+
+ "DifficultyTest1457" : {
+		"parentTimestamp" : "0x04e788057c",
+		"parentDifficulty" : "0x6ffcb3813c3b1077",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e7880598",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6feeb3eacc138925"
+	},
+
+ "DifficultyTest1458" : {
+		"parentTimestamp" : "0x055a33a762",
+		"parentDifficulty" : "0x5c4edd0a884a2211",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x055a33a77e",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x5c43532ee6f918ed"
+	},
+
+ "DifficultyTest1459" : {
+		"parentTimestamp" : "0x0470e9ddbd",
+		"parentDifficulty" : "0x7fd7965244eb0606",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0470e9ddd9",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x7fc79b5f7aa268e6"
+	},
+
+ "DifficultyTest1460" : {
+		"parentTimestamp" : "0x0232b6bfd9",
+		"parentDifficulty" : "0x715e91733b7ef2e8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0232b6bff5",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x715065a10d17838a"
+	},
+
+ "DifficultyTest1461" : {
+		"parentTimestamp" : "0x040bc89c2d",
+		"parentDifficulty" : "0x2f4a2e8cb2b474e6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x040bc89c49",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x2f444546e11e1f58"
+	},
+
+ "DifficultyTest1462" : {
+		"parentTimestamp" : "0x03ee9a4095",
+		"parentDifficulty" : "0x501aa224df6050",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ee9a40b1",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x50109ed09ac664"
+	},
+
+ "DifficultyTest1463" : {
+		"parentTimestamp" : "0x01798d9a3c",
+		"parentDifficulty" : "0x017a2e89a790e3b9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01798d9a58",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x0179ff43d65bf59d"
+	},
+
+ "DifficultyTest1464" : {
+		"parentTimestamp" : "0x27a5f1b1",
+		"parentDifficulty" : "0x3912f0118f744bbd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x27a5f1cd",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x390bcdb38d425d34"
+	},
+
+ "DifficultyTest1465" : {
+		"parentTimestamp" : "0x04ba4770cb",
+		"parentDifficulty" : "0x1e2ecdec58ea6081",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04ba4770e7",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1e2b08129b5f4335"
+	},
+
+ "DifficultyTest1466" : {
+		"parentTimestamp" : "0x03eb753076",
+		"parentDifficulty" : "0x76a6f476f3cb7c72",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03eb753092",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x76981f9864ed0303"
+	},
+
+ "DifficultyTest1467" : {
+		"parentTimestamp" : "0x014a4a0f6e",
+		"parentDifficulty" : "0x0ed5ae088b57a264",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x014a4a0f8a",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x0ed3d352ca463770"
+	},
+
+ "DifficultyTest1468" : {
+		"parentTimestamp" : "0x037e2300ce",
+		"parentDifficulty" : "0x1fb589d55a231de0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x037e2300ea",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x1fb193241f77d97d"
+	},
+
+ "DifficultyTest1469" : {
+		"parentTimestamp" : "0x01bd1bf252",
+		"parentDifficulty" : "0x2713be2a8626360d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01bd1bf26e",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x270edbb2c0d57147"
+	},
+
+ "DifficultyTest1470" : {
+		"parentTimestamp" : "0x06b44fb3f3",
+		"parentDifficulty" : "0x3bfac1c95d5d0ab3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06b44fb40f",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x3bf3427124315f12"
+	},
+
+ "DifficultyTest1471" : {
+		"parentTimestamp" : "0x018b1ef8a9",
+		"parentDifficulty" : "0x34f581b7cf8e294e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x018b1ef8c7",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x34e84457619a45c4"
+	},
+
+ "DifficultyTest1472" : {
+		"parentTimestamp" : "0x012b01fd86",
+		"parentDifficulty" : "0x1325f523a8352fdd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x012b01fda4",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x13212ba65f4b2294"
+	},
+
+ "DifficultyTest1473" : {
+		"parentTimestamp" : "0x073b3d1721",
+		"parentDifficulty" : "0x72b0b0356b514df4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x073b3d173f",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x729404095df679a4"
+	},
+
+ "DifficultyTest1474" : {
+		"parentTimestamp" : "0x06067c76d7",
+		"parentDifficulty" : "0x70f91fba78ad6e73",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06067c76f5",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x70dce1728a0f431d"
+	},
+
+ "DifficultyTest1475" : {
+		"parentTimestamp" : "0x0710230f93",
+		"parentDifficulty" : "0x525afd1df991ecce",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0710230fb1",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x5246665eb213885c"
+	},
+
+ "DifficultyTest1476" : {
+		"parentTimestamp" : "0x04b0818b65",
+		"parentDifficulty" : "0x751ad50f311e8dc9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b0818b83",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x74fd8e59ed524637"
+	},
+
+ "DifficultyTest1477" : {
+		"parentTimestamp" : "0x0400bae4da",
+		"parentDifficulty" : "0x69e229f886443cf9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0400bae4f8",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x69c7b16e0822ac0b"
+	},
+
+ "DifficultyTest1478" : {
+		"parentTimestamp" : "0x0269d3b3a3",
+		"parentDifficulty" : "0x6ffd2f0b68674275",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0269d3b3c1",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x6fe12fbfa58d28e5"
+	},
+
+ "DifficultyTest1479" : {
+		"parentTimestamp" : "0x025866e34b",
+		"parentDifficulty" : "0x07cab15e09618407",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x025866e369",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x07c8beb1b1df2c27"
+	},
+
+ "DifficultyTest1480" : {
+		"parentTimestamp" : "0x05b2da2adb",
+		"parentDifficulty" : "0x64b40ec2a7a60e7d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b2da2af9",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x649ae1bef6fc25fb"
+	},
+
+ "DifficultyTest1481" : {
+		"parentTimestamp" : "0x0541f28b10",
+		"parentDifficulty" : "0x1c74737e9c3452a8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0541f28b2e",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x1c6d5661bc8d4794"
+	},
+
+ "DifficultyTest1482" : {
+		"parentTimestamp" : "0x02dcd86494",
+		"parentDifficulty" : "0x2695865583e47e57",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02dcd864b2",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x268be0f3ee838939"
+	},
+
+ "DifficultyTest1483" : {
+		"parentTimestamp" : "0x0744557a23",
+		"parentDifficulty" : "0x4e7a7cab6329866b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0744557a41",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x4e66de0c3850c40b"
+	},
+
+ "DifficultyTest1484" : {
+		"parentTimestamp" : "0x02e03bdae0",
+		"parentDifficulty" : "0x69f49fe97f848a1d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e03bdafe",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x69da22c18524b8fb"
+	},
+
+ "DifficultyTest1485" : {
+		"parentTimestamp" : "0x021791718d",
+		"parentDifficulty" : "0x5620c9da8e8ad718",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02179171ab",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x560b41a817e75464"
+	},
+
+ "DifficultyTest1486" : {
+		"parentTimestamp" : "0x046db75928",
+		"parentDifficulty" : "0x27a30755e353537f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046db75946",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x27991e940ddabeab"
+	},
+
+ "DifficultyTest1487" : {
+		"parentTimestamp" : "0x0213251745",
+		"parentDifficulty" : "0x60a0ec91c9bf5fc5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0213251763",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x6088c456a54cefef"
+	},
+
+ "DifficultyTest1488" : {
+		"parentTimestamp" : "0x0347ffc48a",
+		"parentDifficulty" : "0x5be99a4d648b3d94",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0347ffc4a8",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x5bd29fe6d1321ac6"
+	},
+
+ "DifficultyTest1489" : {
+		"parentTimestamp" : "0x04af29f579",
+		"parentDifficulty" : "0x6aed879d1912639a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04af29f597",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x6ad2cc3b31cc1f02"
+	},
+
+ "DifficultyTest1490" : {
+		"parentTimestamp" : "0x057ef2aacd",
+		"parentDifficulty" : "0x39bb9837565c51ef",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x057ef2aaeb",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x39ad29514886badb"
+	},
+
+ "DifficultyTest1491" : {
+		"parentTimestamp" : "0x05903df2ce",
+		"parentDifficulty" : "0x02d305516169c431",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05903df2ec",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x02d250900d1169c1"
+	},
+
+ "DifficultyTest1492" : {
+		"parentTimestamp" : "0x02c648b858",
+		"parentDifficulty" : "0x6cf0e274df6c0b4c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02c648b876",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x6cd5a63c4234304a"
+	},
+
+ "DifficultyTest1493" : {
+		"parentTimestamp" : "0x07b40331c9",
+		"parentDifficulty" : "0x707fa73ba9a4b145",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07b40331e7",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x70638751daba4819"
+	},
+
+ "DifficultyTest1494" : {
+		"parentTimestamp" : "0x06481c9f51",
+		"parentDifficulty" : "0x155ff9d560ff155b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06481c9f6f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x155aa1d6eba6d597"
+	},
+
+ "DifficultyTest1495" : {
+		"parentTimestamp" : "0x2c860e5c",
+		"parentDifficulty" : "0x12941a09bd313536",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2c860e7a",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x128f75033ac1e8ea"
+	},
+
+ "DifficultyTest1496" : {
+		"parentTimestamp" : "0x02bf9efdd8",
+		"parentDifficulty" : "0x66b27030216196c6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02bf9efdf6",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x6698c39415593e62"
+	},
+
+ "DifficultyTest1497" : {
+		"parentTimestamp" : "0x033c64bdf1",
+		"parentDifficulty" : "0x5b3eb5a72312e62d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x033c64be0f",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x5b27e5f9b94a2175"
+	},
+
+ "DifficultyTest1498" : {
+		"parentTimestamp" : "0x01c74864f7",
+		"parentDifficulty" : "0x7f126b9ce26f23aa",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01c7486515",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x7ef2a701fb3687e2"
+	},
+
+ "DifficultyTest1499" : {
+		"parentTimestamp" : "0x0350bf3a54",
+		"parentDifficulty" : "0x2a04bad6c8d10913",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0350bf3a72",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x29fa39a8131ed4d1"
+	},
+
+ "DifficultyTest1500" : {
+		"parentTimestamp" : "0x0340f09552",
+		"parentDifficulty" : "0x452746edfda78307",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0340f09570",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x4515fd1c42281927"
+	},
+
+ "DifficultyTest1501" : {
+		"parentTimestamp" : "0x0732229ea1",
+		"parentDifficulty" : "0x7d1ce12f6b505b17",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0732229ebf",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x7cfd99f71f758701"
+	},
+
+ "DifficultyTest1502" : {
+		"parentTimestamp" : "0xfe27152f",
+		"parentDifficulty" : "0x07602c743b1a5b85",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xfe27154d",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x075e54691e0b94f0"
+	},
+
+ "DifficultyTest1503" : {
+		"parentTimestamp" : "0x01f5d39183",
+		"parentDifficulty" : "0x78d5fcb451c361b4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f5d391a1",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x78b7c73524aef0de"
+	},
+
+ "DifficultyTest1504" : {
+		"parentTimestamp" : "0x03323b5ed9",
+		"parentDifficulty" : "0x6486ac0cb8525ba8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03323b5ef7",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x646d8a61b5244716"
+	},
+
+ "DifficultyTest1505" : {
+		"parentTimestamp" : "0x037d9da171",
+		"parentDifficulty" : "0x0f52c01a4a40513f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x037d9da18f",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x0f4eeb6a43adc133"
+	},
+
+ "DifficultyTest1506" : {
+		"parentTimestamp" : "0x01e652af41",
+		"parentDifficulty" : "0x22e24b57d718e2a3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01e652af5f",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x22d992c501231c7b"
+	},
+
+ "DifficultyTest1507" : {
+		"parentTimestamp" : "0x0484da5676",
+		"parentDifficulty" : "0x6cc7314cd5b6d65b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0484da5694",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x6cabff80828168c7"
+	},
+
+ "DifficultyTest1508" : {
+		"parentTimestamp" : "0x068e9ca3e4",
+		"parentDifficulty" : "0x584e593a1cc3c734",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x068e9ca402",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x583845a3ce3c9684"
+	},
+
+ "DifficultyTest1509" : {
+		"parentTimestamp" : "0x06f69290c0",
+		"parentDifficulty" : "0x09423e24017a01f7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06f69290de",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x093fed947879a3f7"
+	},
+
+ "DifficultyTest1510" : {
+		"parentTimestamp" : "0x01aa1dce2f",
+		"parentDifficulty" : "0x743db043edc9af3e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01aa1dce4d",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x7420a0d7dcce3dd4"
+	},
+
+ "DifficultyTest1511" : {
+		"parentTimestamp" : "0x05d29d2f13",
+		"parentDifficulty" : "0x687da6d08f6c0db7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d29d2f31",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x68638766db4834b5"
+	},
+
+ "DifficultyTest1512" : {
+		"parentTimestamp" : "0x02ff2b5b79",
+		"parentDifficulty" : "0x5ea857ffac1ce6dd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ff2b5b97",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x5e90ade9ac31e3a5"
+	},
+
+ "DifficultyTest1513" : {
+		"parentTimestamp" : "0x0595d73c66",
+		"parentDifficulty" : "0x76488fec31d42575",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0595d73c84",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x762afdc836c7b06d"
+	},
+
+ "DifficultyTest1514" : {
+		"parentTimestamp" : "0x0401ace82b",
+		"parentDifficulty" : "0x6361c80d5caa4986",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0401ace849",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x6348ef9b59531ef4"
+	},
+
+ "DifficultyTest1515" : {
+		"parentTimestamp" : "0x02f37dcf02",
+		"parentDifficulty" : "0x03adc7e68ac2311d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02f37dcf20",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x03acdc74911f8091"
+	},
+
+ "DifficultyTest1516" : {
+		"parentTimestamp" : "0x0649788b8a",
+		"parentDifficulty" : "0x1cc28d7662eaa211",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0649788ba8",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x1cbb5cd30551e769"
+	},
+
+ "DifficultyTest1517" : {
+		"parentTimestamp" : "0xf89f6b48",
+		"parentDifficulty" : "0x0a0115f642fe7fff",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xf89f6b66",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x09fe95b0c56dc061"
+	},
+
+ "DifficultyTest1518" : {
+		"parentTimestamp" : "0x03284d8274",
+		"parentDifficulty" : "0x5109831c7ce3a992",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03284d8292",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x50f540bbb5c470a8"
+	},
+
+ "DifficultyTest1519" : {
+		"parentTimestamp" : "0x0313a258a6",
+		"parentDifficulty" : "0x554cec13cbd1a7ca",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0313a258c4",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x553798d8c6deb362"
+	},
+
+ "DifficultyTest1520" : {
+		"parentTimestamp" : "0x02f940a19d",
+		"parentDifficulty" : "0x6f152b8af94f7212",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f940a1bb",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x6ef9664016911e36"
+	},
+
+ "DifficultyTest1521" : {
+		"parentTimestamp" : "0x07e6254090",
+		"parentDifficulty" : "0x5ef1c70e70c9e977",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e62540ae",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x5eda0a9cad2db6fe"
+	},
+
+ "DifficultyTest1522" : {
+		"parentTimestamp" : "0x06a85071f1",
+		"parentDifficulty" : "0x0bdade18df455756",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06a850720f",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x0bd7e761590d8604"
+	},
+
+ "DifficultyTest1523" : {
+		"parentTimestamp" : "0x03ebcbfb36",
+		"parentDifficulty" : "0x31f51d61aba83fd8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ebcbfb54",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x31e8a01a533d55ce"
+	},
+
+ "DifficultyTest1524" : {
+		"parentTimestamp" : "0x01ca971e13",
+		"parentDifficulty" : "0x3cb4d1697efec9b7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ca971e31",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x3ca5a435249f0a0d"
+	},
+
+ "DifficultyTest1525" : {
+		"parentTimestamp" : "0x40679d66",
+		"parentDifficulty" : "0x1c829d2603e0f657",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x40679d84",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x1c7b7c7eba5ffe2b"
+	},
+
+ "DifficultyTest1526" : {
+		"parentTimestamp" : "0xfe0bb546",
+		"parentDifficulty" : "0x3b1e9f538e34c81c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xfe0bb564",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x3b0fd7abb9513b0a"
+	},
+
+ "DifficultyTest1527" : {
+		"parentTimestamp" : "0x059345625d",
+		"parentDifficulty" : "0x12cfb7ca12d07b94",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x059345627b",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x12cb03dc204bc7b6"
+	},
+
+ "DifficultyTest1528" : {
+		"parentTimestamp" : "0x50d07452",
+		"parentDifficulty" : "0x2ca8dece48059d07",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x50d07470",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x2c9db49694739c21"
+	},
+
+ "DifficultyTest1529" : {
+		"parentTimestamp" : "0x038f991aeb",
+		"parentDifficulty" : "0x45384f0df525aa80",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x038f991b09",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x452700fa31a86216"
+	},
+
+ "DifficultyTest1530" : {
+		"parentTimestamp" : "0x04a54196e2",
+		"parentDifficulty" : "0x3b926b8b68213288",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04a5419700",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x3b8386f085472c3c"
+	},
+
+ "DifficultyTest1531" : {
+		"parentTimestamp" : "0x079225bc2d",
+		"parentDifficulty" : "0x115c1feaad69c93d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x079225bc4b",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x1157c8e2b2be72cb"
+	},
+
+ "DifficultyTest1532" : {
+		"parentTimestamp" : "0x07d7eac0c2",
+		"parentDifficulty" : "0x37f8ae6b530c6092",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07d7eac0e0",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x37eab03fb837a57a"
+	},
+
+ "DifficultyTest1533" : {
+		"parentTimestamp" : "0x01c7b650d0",
+		"parentDifficulty" : "0x04f15ab7a697b734",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c7b650ee",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x04f01e60f8ae2148"
+	},
+
+ "DifficultyTest1534" : {
+		"parentTimestamp" : "0x04f3f0d7c7",
+		"parentDifficulty" : "0x10af24ab9803b588",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04f3f0d7e5",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x10aaf8e26d1dd49c"
+	},
+
+ "DifficultyTest1535" : {
+		"parentTimestamp" : "0x062c7f32a6",
+		"parentDifficulty" : "0x6f2e9eeaea2c062a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x062c7f32c4",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x6f12d3432f71bb2a"
+	},
+
+ "DifficultyTest1536" : {
+		"parentTimestamp" : "0x0213a4eeba",
+		"parentDifficulty" : "0x7ede6b54e22c7d23",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0213a4eed8",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x7ece8f8777903794"
+	},
+
+ "DifficultyTest1537" : {
+		"parentTimestamp" : "0x04d72e14ae",
+		"parentDifficulty" : "0x1d067057aedb1a08",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04d72e14cc",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x1d02cf89a3e53ea5"
+	},
+
+ "DifficultyTest1538" : {
+		"parentTimestamp" : "0x9c46bde2",
+		"parentDifficulty" : "0x43e039face37717c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9c46be00",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x43d7bdf38eddaa8e"
+	},
+
+ "DifficultyTest1539" : {
+		"parentTimestamp" : "0x06182dd27f",
+		"parentDifficulty" : "0x6a66f09663fc510c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06182dd29d",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x6a59a3b8512fd182"
+	},
+
+ "DifficultyTest1540" : {
+		"parentTimestamp" : "0x02009d59d4",
+		"parentDifficulty" : "0x0c6b291db364893a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02009d59f2",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x0c699bb88fae1ca9"
+	},
+
+ "DifficultyTest1541" : {
+		"parentTimestamp" : "0x012a5bea2d",
+		"parentDifficulty" : "0x657406a2b4fbb6b6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x012a5bea4b",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x65675821e0a51740"
+	},
+
+ "DifficultyTest1542" : {
+		"parentTimestamp" : "0x038ece488d",
+		"parentDifficulty" : "0x4b4bc2bf457b854f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x038ece48ab",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x4b425946ed92d5df"
+	},
+
+ "DifficultyTest1543" : {
+		"parentTimestamp" : "0x03e7a059fb",
+		"parentDifficulty" : "0x210d34e2255b1cae",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03e7a05a19",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x2109133b8916714b"
+	},
+
+ "DifficultyTest1544" : {
+		"parentTimestamp" : "0x0704923797",
+		"parentDifficulty" : "0x24168f9867a9059f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07049237b5",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x24120cc6749c107f"
+	},
+
+ "DifficultyTest1545" : {
+		"parentTimestamp" : "0x04222a2f02",
+		"parentDifficulty" : "0x491e19909db9011f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04222a2f20",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x4914f5cd6ba549ff"
+	},
+
+ "DifficultyTest1546" : {
+		"parentTimestamp" : "0x0580769eda",
+		"parentDifficulty" : "0x437d08c9ec04eb0b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0580769ef8",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x43749928d2c76a6e"
+	},
+
+ "DifficultyTest1547" : {
+		"parentTimestamp" : "0x07e1db5176",
+		"parentDifficulty" : "0x3fedfe6b7b1903c0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e1db5194",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x3fe600abada9a0a0"
+	},
+
+ "DifficultyTest1548" : {
+		"parentTimestamp" : "0x040ddf4178",
+		"parentDifficulty" : "0x39f9d0df82e3c667",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x040ddf4196",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x39f291a566f369ef"
+	},
+
+ "DifficultyTest1549" : {
+		"parentTimestamp" : "0x0437566444",
+		"parentDifficulty" : "0x3782a6c03ee139e2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0437566462",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x377bb66b66d95dbb"
+	},
+
+ "DifficultyTest1550" : {
+		"parentTimestamp" : "0x028453949a",
+		"parentDifficulty" : "0x69a964e52f74bbca",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02845394b8",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x699c2fb892cecd33"
+	},
+
+ "DifficultyTest1551" : {
+		"parentTimestamp" : "0x05986eb158",
+		"parentDifficulty" : "0x3ee41bc59a2cfb77",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05986eb176",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x3edc3f422179b5d9"
+	},
+
+ "DifficultyTest1552" : {
+		"parentTimestamp" : "0x07559f82c8",
+		"parentDifficulty" : "0x6c538c9b8ac46ca2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07559f82e6",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x6c460229f7531417"
+	},
+
+ "DifficultyTest1553" : {
+		"parentTimestamp" : "0x04261233b3",
+		"parentDifficulty" : "0x68c64b954c3f783c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04261233d1",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x68b932cbd995f051"
+	},
+
+ "DifficultyTest1554" : {
+		"parentTimestamp" : "0x0103bb624c",
+		"parentDifficulty" : "0x3adb8574a90aa668",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0103bb626a",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x3ad42a03fa75851c"
+	},
+
+ "DifficultyTest1555" : {
+		"parentTimestamp" : "0x0130eeea9b",
+		"parentDifficulty" : "0x6a54f1b12d6175f1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0130eeeab9",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6a47a712f73bc9d3"
+	},
+
+ "DifficultyTest1556" : {
+		"parentTimestamp" : "0x075c8dfdef",
+		"parentDifficulty" : "0x5d836c81bd42f2c7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x075c8dfe0d",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x5d77bc142d0b4a89"
+	},
+
+ "DifficultyTest1557" : {
+		"parentTimestamp" : "0x039e7ee767",
+		"parentDifficulty" : "0x7d8adc7cc9288bf6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039e7ee785",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x7d7b2b21398f6725"
+	},
+
+ "DifficultyTest1558" : {
+		"parentTimestamp" : "0x04009b84cb",
+		"parentDifficulty" : "0x69b195337c7ad372",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04009b84e9",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x69a45f00d60b4498"
+	},
+
+ "DifficultyTest1559" : {
+		"parentTimestamp" : "0x04e6628d9e",
+		"parentDifficulty" : "0x7e45eae30dac7a8d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e6628dbc",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x7e362225b14ac5fe"
+	},
+
+ "DifficultyTest1560" : {
+		"parentTimestamp" : "0x07c84b4a37",
+		"parentDifficulty" : "0x0ef379cf674d7cd9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07c84b4a55",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x0ef19b602d60952a"
+	},
+
+ "DifficultyTest1561" : {
+		"parentTimestamp" : "0x8f0513e4",
+		"parentDifficulty" : "0x6800ef6b34a7b3b9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x8f051402",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x67f3ef4d474122c3"
+	},
+
+ "DifficultyTest1562" : {
+		"parentTimestamp" : "0x041482ab32",
+		"parentDifficulty" : "0x5b58d1c9db778d95",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x041482ab50",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x5b4d66afa23c1ea4"
+	},
+
+ "DifficultyTest1563" : {
+		"parentTimestamp" : "0x02bf3e42cf",
+		"parentDifficulty" : "0x54795d08771378ab",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02bf3e42ed",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x546ecddcd604963c"
+	},
+
+ "DifficultyTest1564" : {
+		"parentTimestamp" : "0x0345b56ad6",
+		"parentDifficulty" : "0x1b8b3b6f48e2dd34",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0345b56af4",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x1b87ca07daf9c0d9"
+	},
+
+ "DifficultyTest1565" : {
+		"parentTimestamp" : "0x029b26c94b",
+		"parentDifficulty" : "0x62caefb65f7c55c9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029b26c969",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x62be965868b0663f"
+	},
+
+ "DifficultyTest1566" : {
+		"parentTimestamp" : "0x06ee5799ef",
+		"parentDifficulty" : "0x305c468dafcd164e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06ee579a0d",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x30563b04de171cac"
+	},
+
+ "DifficultyTest1567" : {
+		"parentTimestamp" : "0x04054f311c",
+		"parentDifficulty" : "0x0cb50ca38e4f5d02",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04054f313a",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x0cb37601f9dd9317"
+	},
+
+ "DifficultyTest1568" : {
+		"parentTimestamp" : "0x05368a241a",
+		"parentDifficulty" : "0x5eee8a9ed42b2412",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05368a2438",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x5ee2accd80509eae"
+	},
+
+ "DifficultyTest1569" : {
+		"parentTimestamp" : "0x0662827cbc",
+		"parentDifficulty" : "0x73d9d7cfba2779bf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0662827cdc",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x73bce159c638efe1"
+	},
+
+ "DifficultyTest1570" : {
+		"parentTimestamp" : "0x0458e09d7f",
+		"parentDifficulty" : "0x7d13d585184becc0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0458e09d9f",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x7cf4908fb705d9c7"
+	},
+
+ "DifficultyTest1571" : {
+		"parentTimestamp" : "0x06d4c03576",
+		"parentDifficulty" : "0x6594ca7ed399b947",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06d4c03596",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x657b654c33e4d2db"
+	},
+
+ "DifficultyTest1572" : {
+		"parentTimestamp" : "0x015129a53a",
+		"parentDifficulty" : "0x2e3020d8ec7ecb3e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x015129a55a",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x2e2494d0b643ab90"
+	},
+
+ "DifficultyTest1573" : {
+		"parentTimestamp" : "0x0532fcfa78",
+		"parentDifficulty" : "0x442218a22c741083",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0532fcfa98",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x4411101c03e8f387"
+	},
+
+ "DifficultyTest1574" : {
+		"parentTimestamp" : "0x07036d5cf4",
+		"parentDifficulty" : "0x4a3a3ffa63883a00",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07036d5d14",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x4a27b16a64ef5802"
+	},
+
+ "DifficultyTest1575" : {
+		"parentTimestamp" : "0x06963feda0",
+		"parentDifficulty" : "0x7beaf8709100a5e7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06963fedc0",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x7bcbfdb274dc65df"
+	},
+
+ "DifficultyTest1576" : {
+		"parentTimestamp" : "0x07a65171ae",
+		"parentDifficulty" : "0x6a0f904b21a56f31",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07a65171ce",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x69f50c670edd0617"
+	},
+
+ "DifficultyTest1577" : {
+		"parentTimestamp" : "0x01363060c5",
+		"parentDifficulty" : "0x4da12dfba124f593",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01363060e5",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x4d8dc5b0223cacd7"
+	},
+
+ "DifficultyTest1578" : {
+		"parentTimestamp" : "0x015e08eb45",
+		"parentDifficulty" : "0x434ef6a753d93b31",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x015e08eb65",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x433e22e9aa0445e3"
+	},
+
+ "DifficultyTest1579" : {
+		"parentTimestamp" : "0x0245e0d73e",
+		"parentDifficulty" : "0x78b5be9442e438a3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0245e0d75e",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x789791249dd38195"
+	},
+
+ "DifficultyTest1580" : {
+		"parentTimestamp" : "0x065bffa02d",
+		"parentDifficulty" : "0x657dc81ccb05171b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x065bffa04d",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x656468aac3d259d7"
+	},
+
+ "DifficultyTest1581" : {
+		"parentTimestamp" : "0x034dede879",
+		"parentDifficulty" : "0x5027b24d9db179ff",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x034dede899",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x5013a8610a4a15a1"
+	},
+
+ "DifficultyTest1582" : {
+		"parentTimestamp" : "0x03b254847a",
+		"parentDifficulty" : "0x25d1490af3583df4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b254849a",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x25c7d4b8b09b77e6"
+	},
+
+ "DifficultyTest1583" : {
+		"parentTimestamp" : "0x0280f32989",
+		"parentDifficulty" : "0x472ad37564ddf592",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0280f329a9",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x471908c08784de16"
+	},
+
+ "DifficultyTest1584" : {
+		"parentTimestamp" : "0x06fb736873",
+		"parentDifficulty" : "0x4672e546d12f0c86",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06fb736893",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x4661488d7f7b00c4"
+	},
+
+ "DifficultyTest1585" : {
+		"parentTimestamp" : "0x06037a1e10",
+		"parentDifficulty" : "0x38109344f6cf902e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06037a1e30",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x38028f202591dc4a"
+	},
+
+ "DifficultyTest1586" : {
+		"parentTimestamp" : "0x0777c205ae",
+		"parentDifficulty" : "0x4304fb46aeae401b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0777c205ce",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x42f43a07dd02948b"
+	},
+
+ "DifficultyTest1587" : {
+		"parentTimestamp" : "0x046e55b8c4",
+		"parentDifficulty" : "0x3c9266ac02ef4818",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046e55b8e4",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x3c83421257ee8c46"
+	},
+
+ "DifficultyTest1588" : {
+		"parentTimestamp" : "0x01ccccf523",
+		"parentDifficulty" : "0x3c138f2800207b30",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01ccccf543",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x3c048a4436207312"
+	},
+
+ "DifficultyTest1589" : {
+		"parentTimestamp" : "0xcf99c54f",
+		"parentDifficulty" : "0x7f6e19e380a5f9f3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xcf99c56f",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x7f4e3e5d07c5d075"
+	},
+
+ "DifficultyTest1590" : {
+		"parentTimestamp" : "0x01f271295e",
+		"parentDifficulty" : "0x363658996ecb4904",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f271297e",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x3628cb03486f9632"
+	},
+
+ "DifficultyTest1591" : {
+		"parentTimestamp" : "0x01f8affb1f",
+		"parentDifficulty" : "0x570e94cf3815ec9c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f8affb3f",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x56f8d12a0447e722"
+	},
+
+ "DifficultyTest1592" : {
+		"parentTimestamp" : "0x03476b8e2e",
+		"parentDifficulty" : "0x6af645264a5f3b57",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03476b8e4e",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x6adb879500cca389"
+	},
+
+ "DifficultyTest1593" : {
+		"parentTimestamp" : "0x26267fbc",
+		"parentDifficulty" : "0x15e905fea337d8f3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x26267fdc",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x15e38bbd238f0afd"
+	},
+
+ "DifficultyTest1594" : {
+		"parentTimestamp" : "0x3587e722",
+		"parentDifficulty" : "0x34733a46990b6ec4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x3587e742",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x34661d7807652bea"
+	},
+
+ "DifficultyTest1595" : {
+		"parentTimestamp" : "0x066bf88e43",
+		"parentDifficulty" : "0x61d716edcf9506be",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x066bf88e63",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x61bea1281421217e"
+	},
+
+ "DifficultyTest1596" : {
+		"parentTimestamp" : "0x030c4f3afa",
+		"parentDifficulty" : "0x0902978fee72f002",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x030c4f3b1a",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x090056ea0a775346"
+	},
+
+ "DifficultyTest1597" : {
+		"parentTimestamp" : "0x01a2e17acf",
+		"parentDifficulty" : "0x6b846b1406ea8c84",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01a2e17aef",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x6b6989f941e8d1e2"
+	},
+
+ "DifficultyTest1598" : {
+		"parentTimestamp" : "0x04a5d81414",
+		"parentDifficulty" : "0x314d7cba9e6df599",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04a5d81434",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x3141295b6fc65a1d"
+	},
+
+ "DifficultyTest1599" : {
+		"parentTimestamp" : "0x02a62cfa56",
+		"parentDifficulty" : "0x3380be2108147e5d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02a62cfa76",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3373ddf17fd2793f"
+	},
+
+ "DifficultyTest1600" : {
+		"parentTimestamp" : "0x7dda41b2",
+		"parentDifficulty" : "0x27fffbe912996686",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x7dda41d2",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x27f5fbea1854c02f"
+	},
+
+ "DifficultyTest1601" : {
+		"parentTimestamp" : "0x0296fc9d15",
+		"parentDifficulty" : "0x30ee63fef201fb39",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0296fc9d35",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x30e22865f2457abd"
+	},
+
+ "DifficultyTest1602" : {
+		"parentTimestamp" : "0x079172eaaa",
+		"parentDifficulty" : "0x365f0b04aafacbf1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x079172eaca",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x36517341e9d00d43"
+	},
+
+ "DifficultyTest1603" : {
+		"parentTimestamp" : "0x06abbda704",
+		"parentDifficulty" : "0x23dcd65c316c31a0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06abbda724",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x23d3df269a5fd69c"
+	},
+
+ "DifficultyTest1604" : {
+		"parentTimestamp" : "0x042c4cce99",
+		"parentDifficulty" : "0x6cc792964e3a86e6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x042c4cceb9",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x6cac60b1a8a6f856"
+	},
+
+ "DifficultyTest1605" : {
+		"parentTimestamp" : "0x02c1057ded",
+		"parentDifficulty" : "0x6c089df3474258d3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02c1057e0d",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x6bed9bcbca70885d"
+	},
+
+ "DifficultyTest1606" : {
+		"parentTimestamp" : "0x0216ea4165",
+		"parentDifficulty" : "0x2d83646ff4b4f1d2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0216ea4185",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2d780396d8b7c4d6"
+	},
+
+ "DifficultyTest1607" : {
+		"parentTimestamp" : "0x079bae77a8",
+		"parentDifficulty" : "0x5e01e8c7a580e33e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x079bae77c8",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x5dea684d73978386"
+	},
+
+ "DifficultyTest1608" : {
+		"parentTimestamp" : "0x05e6901bac",
+		"parentDifficulty" : "0x5dafa9601a537058",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e6901bcc",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x5d983d75c24cdc7c"
+	},
+
+ "DifficultyTest1609" : {
+		"parentTimestamp" : "0x046e3b74c4",
+		"parentDifficulty" : "0x6cdebd48364f4ac2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046e3b74e4",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x6cc38598e441b8f0"
+	},
+
+ "DifficultyTest1610" : {
+		"parentTimestamp" : "0x071ab01cf7",
+		"parentDifficulty" : "0x6e2ac4ade43bd7b0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x071ab01d17",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x6e0f39fcb8c2ccbc"
+	},
+
+ "DifficultyTest1611" : {
+		"parentTimestamp" : "0x03d25bc03b",
+		"parentDifficulty" : "0x2954a95748f5f4db",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03d25bc05b",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x294a542cf323b75f"
+	},
+
+ "DifficultyTest1612" : {
+		"parentTimestamp" : "0x05a2aeb0b8",
+		"parentDifficulty" : "0x1fc1e5b3bfe9ed42",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05a2aeb0d8",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1fb9f53a52f9f2c8"
+	},
+
+ "DifficultyTest1613" : {
+		"parentTimestamp" : "0x0409c289c1",
+		"parentDifficulty" : "0x35175b36511a08e6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0409c289e1",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x350a155f8385c264"
+	},
+
+ "DifficultyTest1614" : {
+		"parentTimestamp" : "0x017782b2bf",
+		"parentDifficulty" : "0x7c77116de920c55c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x017782b2df",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x7c57f3a98da67d2c"
+	},
+
+ "DifficultyTest1615" : {
+		"parentTimestamp" : "0x034f629502",
+		"parentDifficulty" : "0x3162b25e0704aa79",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x034f629522",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x315659b16f82e94f"
+	},
+
+ "DifficultyTest1616" : {
+		"parentTimestamp" : "0x04f1bc3c18",
+		"parentDifficulty" : "0x117decf323f09982",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f1bc3c38",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x11798d77e7279d5c"
+	},
+
+ "DifficultyTest1617" : {
+		"parentTimestamp" : "0x692b4e21",
+		"parentDifficulty" : "0x637145e1801060d0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x692b4e41",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x6358699007b05cb8"
+	},
+
+ "DifficultyTest1618" : {
+		"parentTimestamp" : "0x017f97da84",
+		"parentDifficulty" : "0x0d0225893a3c79c8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x017f97daa4",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x0cfee4ffd7edeaaa"
+	},
+
+ "DifficultyTest1619" : {
+		"parentTimestamp" : "0x24810085",
+		"parentDifficulty" : "0x442dcb7adf457dd3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x248100a5",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x441cc008008dac76"
+	},
+
+ "DifficultyTest1620" : {
+		"parentTimestamp" : "0x7fee24b4",
+		"parentDifficulty" : "0x3f886033678667d8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7fee24d4",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x3f787e1b5aac8642"
+	},
+
+ "DifficultyTest1621" : {
+		"parentTimestamp" : "0x564864b0",
+		"parentDifficulty" : "0xebe66ab56977de",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x564864d0",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0xebab711abc1d86"
+	},
+
+ "DifficultyTest1622" : {
+		"parentTimestamp" : "0x0373ed121a",
+		"parentDifficulty" : "0x6397e9fb9a80f86f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0373ed123a",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x637f04011b9a5839"
+	},
+
+ "DifficultyTest1623" : {
+		"parentTimestamp" : "0x2bfddd52",
+		"parentDifficulty" : "0x19898e99d6a7a6a8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x2bfddd72",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x19832c363031fcd0"
+	},
+
+ "DifficultyTest1624" : {
+		"parentTimestamp" : "0x06c7aac1b4",
+		"parentDifficulty" : "0x63cfc741123a7b78",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c7aac1d4",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x63b6d34f41f5ecfa"
+	},
+
+ "DifficultyTest1625" : {
+		"parentTimestamp" : "0x0476e66a6b",
+		"parentDifficulty" : "0x0eccfc4e6c7ec012",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0476e66a8b",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x0ec9490f58e3a0a2"
+	},
+
+ "DifficultyTest1626" : {
+		"parentTimestamp" : "0x07327b6817",
+		"parentDifficulty" : "0x6402452c61791cf1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07327b6837",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x63e9449b1660bf2b"
+	},
+
+ "DifficultyTest1627" : {
+		"parentTimestamp" : "0x07a364de55",
+		"parentDifficulty" : "0x0fdf514f0f46f1fe",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a364de75",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x0fdb597abb832142"
+	},
+
+ "DifficultyTest1628" : {
+		"parentTimestamp" : "0x07a9bc6a28",
+		"parentDifficulty" : "0x1f7eeeb4a28ac674",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a9bc6a48",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x1f770ef8f56225c4"
+	},
+
+ "DifficultyTest1629" : {
+		"parentTimestamp" : "0x043c315fff",
+		"parentDifficulty" : "0x7415e80944072c33",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x043c31601f",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x73f8e28f41b62e69"
+	},
+
+ "DifficultyTest1630" : {
+		"parentTimestamp" : "0x0672a60078",
+		"parentDifficulty" : "0x320165f2fdb6fc07",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0672a60098",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x31f4e59980f79649"
+	},
+
+ "DifficultyTest1631" : {
+		"parentTimestamp" : "0x017c7a8bcf",
+		"parentDifficulty" : "0x3bd2df52f72166e1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x017c7a8bef",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x3bc3ea9b2263ae89"
+	},
+
+ "DifficultyTest1632" : {
+		"parentTimestamp" : "0x07817dbc8f",
+		"parentDifficulty" : "0x6bb1129539ab4891",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07817dbcaf",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x6b962650945cfdbf"
+	},
+
+ "DifficultyTest1633" : {
+		"parentTimestamp" : "0x0149147497",
+		"parentDifficulty" : "0x40fbc5738997c008",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01491474b7",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x40eb86822cb59a18"
+	},
+
+ "DifficultyTest1634" : {
+		"parentTimestamp" : "0x05401a0786",
+		"parentDifficulty" : "0x24aca17b822a53d7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05401a07a6",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x24a80be752ba0e8d"
+	},
+
+ "DifficultyTest1635" : {
+		"parentTimestamp" : "0x047468efd8",
+		"parentDifficulty" : "0x7e12d081a7ca4d0f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x047468eff8",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x7e030e27979553c6"
+	},
+
+ "DifficultyTest1636" : {
+		"parentTimestamp" : "0x01fe6c2631",
+		"parentDifficulty" : "0x34660abd5690833c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01fe6c2651",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x345f7dfbfee5b12c"
+	},
+
+ "DifficultyTest1637" : {
+		"parentTimestamp" : "0x038b5be679",
+		"parentDifficulty" : "0x219076ed23639a0c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x038b5be699",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x218c44de45bf2d99"
+	},
+
+ "DifficultyTest1638" : {
+		"parentTimestamp" : "0x01009fddd5",
+		"parentDifficulty" : "0x753f1a57329b165f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01009fddf5",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x75307273e7b4c2fd"
+	},
+
+ "DifficultyTest1639" : {
+		"parentTimestamp" : "0x07c4f6337b",
+		"parentDifficulty" : "0x03224323023fc43e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07c4f6339b",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x0321deda9ddf7c46"
+	},
+
+ "DifficultyTest1640" : {
+		"parentTimestamp" : "0x0691712a72",
+		"parentDifficulty" : "0x64d8c970bdca66c2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0691712a92",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x64cc2e578fb2ad76"
+	},
+
+ "DifficultyTest1641" : {
+		"parentTimestamp" : "0x02cc3106f2",
+		"parentDifficulty" : "0x5ae6dd85e013ee26",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cc310712",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x5adb80aa2f57eba9"
+	},
+
+ "DifficultyTest1642" : {
+		"parentTimestamp" : "0x01f7c13bbc",
+		"parentDifficulty" : "0x7fa3d8f5a6a2e13f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01f7c13bdc",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x7f93e47a87ee0ce3"
+	},
+
+ "DifficultyTest1643" : {
+		"parentTimestamp" : "0x031cbdbf54",
+		"parentDifficulty" : "0x3359fbb48ee8003a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x031cbdbf74",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x335390751856233a"
+	},
+
+ "DifficultyTest1644" : {
+		"parentTimestamp" : "0x0309c4a620",
+		"parentDifficulty" : "0x311b962316e1dcb5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0309c4a640",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x311572b0527f007a"
+	},
+
+ "DifficultyTest1645" : {
+		"parentTimestamp" : "0x0291a0938d",
+		"parentDifficulty" : "0x848ad15a6695cf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0291a093ad",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x847a40003b48fd"
+	},
+
+ "DifficultyTest1646" : {
+		"parentTimestamp" : "0x052901c614",
+		"parentDifficulty" : "0x580319c222bb6244",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x052901c634",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x57f8195eea770ad8"
+	},
+
+ "DifficultyTest1647" : {
+		"parentTimestamp" : "0x01f76e0603",
+		"parentDifficulty" : "0x5069bf32fd902fd5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01f76e0623",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x505fb1fb17307dd0"
+	},
+
+ "DifficultyTest1648" : {
+		"parentTimestamp" : "0x03934d3664",
+		"parentDifficulty" : "0x6ffd0b5e00dc5650",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03934d3684",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x6fef0bbc951c3ac6"
+	},
+
+ "DifficultyTest1649" : {
+		"parentTimestamp" : "0x02e782a62e",
+		"parentDifficulty" : "0x1de852a7ba35524a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02e782a64e",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x1de4959d653e0ba1"
+	},
+
+ "DifficultyTest1650" : {
+		"parentTimestamp" : "0x06b343adf7",
+		"parentDifficulty" : "0x72a85ca8af8faa4f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06b343ae17",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x729a079d1a79b85c"
+	},
+
+ "DifficultyTest1651" : {
+		"parentTimestamp" : "0x0777464ee6",
+		"parentDifficulty" : "0x1128ed425e4d4da2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0777464f06",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x1126c824b60183fd"
+	},
+
+ "DifficultyTest1652" : {
+		"parentTimestamp" : "0x010dee1b69",
+		"parentDifficulty" : "0x6908e9021bb8836f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x010dee1b89",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x68fbc7e4fb750c67"
+	},
+
+ "DifficultyTest1653" : {
+		"parentTimestamp" : "0x024c751116",
+		"parentDifficulty" : "0x39d48a9ac88c08fc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x024c751136",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x39cd50097532f78b"
+	},
+
+ "DifficultyTest1654" : {
+		"parentTimestamp" : "0x04dab77fa7",
+		"parentDifficulty" : "0x456a975cd32a8bf1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04dab77fc7",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x4561ea09e79026c0"
+	},
+
+ "DifficultyTest1655" : {
+		"parentTimestamp" : "0x039124aaa9",
+		"parentDifficulty" : "0x5dacc7c574098d7c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039124aac9",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x5da1122c7b5b0c8b"
+	},
+
+ "DifficultyTest1656" : {
+		"parentTimestamp" : "0x06b61a7bd2",
+		"parentDifficulty" : "0x1e372c0dd98e2cbb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06b61a7bf2",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x1e33652857d2fb76"
+	},
+
+ "DifficultyTest1657" : {
+		"parentTimestamp" : "0x01c4591ff3",
+		"parentDifficulty" : "0x525a97f1b7fc4003",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c4592013",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x52504c9eb9c5417b"
+	},
+
+ "DifficultyTest1658" : {
+		"parentTimestamp" : "0x93d53cab",
+		"parentDifficulty" : "0x7c91a8856775397f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x93d53ccb",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x7c82165056c84cd8"
+	},
+
+ "DifficultyTest1659" : {
+		"parentTimestamp" : "0x0696edda3e",
+		"parentDifficulty" : "0x762d433da4b406df",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0696edda5e",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x761e7d953cff745f"
+	},
+
+ "DifficultyTest1660" : {
+		"parentTimestamp" : "0x0232a1f58c",
+		"parentDifficulty" : "0x19419076e556dcec",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0232a1f5ac",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x193e6844d67a3211"
+	},
+
+ "DifficultyTest1661" : {
+		"parentTimestamp" : "0xcb277abc",
+		"parentDifficulty" : "0x7e8d8433192f24b2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xcb277adc",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x7e7db28292cbfece"
+	},
+
+ "DifficultyTest1662" : {
+		"parentTimestamp" : "0x06f8918032",
+		"parentDifficulty" : "0x274d369df1264064",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06f8918052",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x27484cf71d681b9c"
+	},
+
+ "DifficultyTest1663" : {
+		"parentTimestamp" : "0x0bb7f26b",
+		"parentDifficulty" : "0x03ec673fd06141a2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0bb7f28b",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x03ebe9b2e867357a"
+	},
+
+ "DifficultyTest1664" : {
+		"parentTimestamp" : "0x0766c44e28",
+		"parentDifficulty" : "0x65eb081ffc909512",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0766c44e48",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x65de4abef8910300"
+	},
+
+ "DifficultyTest1665" : {
+		"parentTimestamp" : "0x02233acea1",
+		"parentDifficulty" : "0x2dc3c87a379b115a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02233acec1",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x2dbe100128541df8"
+	},
+
+ "DifficultyTest1666" : {
+		"parentTimestamp" : "0x0580ad3275",
+		"parentDifficulty" : "0x3c665cd18d48f0fa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0580ad3295",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x3c5ed005f31747dc"
+	},
+
+ "DifficultyTest1667" : {
+		"parentTimestamp" : "0x0287953108",
+		"parentDifficulty" : "0x2a786f774c0f4ddc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x028795312a",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x2a6dd15b6e3c4a0a"
+	},
+
+ "DifficultyTest1668" : {
+		"parentTimestamp" : "0x02a7d25b19",
+		"parentDifficulty" : "0x067ecb96a15b15a6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02a7d25b3b",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x067d2be3bbb2bee3"
+	},
+
+ "DifficultyTest1669" : {
+		"parentTimestamp" : "0x6f851e02",
+		"parentDifficulty" : "0x64bee15be386046a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6f851e24",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x64a5b1a38c8d22ec"
+	},
+
+ "DifficultyTest1670" : {
+		"parentTimestamp" : "0x03c9f9e3da",
+		"parentDifficulty" : "0x36b31f0a2855f539",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03c9f9e3fc",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x36a5724265cbdfc1"
+	},
+
+ "DifficultyTest1671" : {
+		"parentTimestamp" : "0x04e9c0ae51",
+		"parentDifficulty" : "0x19efd9db0a31ab02",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04e9c0ae73",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x19e95de4936f1ea0"
+	},
+
+ "DifficultyTest1672" : {
+		"parentTimestamp" : "0x01df0a1612",
+		"parentDifficulty" : "0x280187a5e5893080",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01df0a1634",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x27f78743fc0fce44"
+	},
+
+ "DifficultyTest1673" : {
+		"parentTimestamp" : "0x03babc0e86",
+		"parentDifficulty" : "0x794ff18b4a1c6a88",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03babc0ea8",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x79319d8ee749e38e"
+	},
+
+ "DifficultyTest1674" : {
+		"parentTimestamp" : "0x04c45ff3bc",
+		"parentDifficulty" : "0x4bdcb2e0d6205370",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c45ff3de",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x4bc9bbb41deacb9c"
+	},
+
+ "DifficultyTest1675" : {
+		"parentTimestamp" : "0x6b8c3481",
+		"parentDifficulty" : "0x251748bdc2772945",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6b8c34a3",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x250e02eb93068bfb"
+	},
+
+ "DifficultyTest1676" : {
+		"parentTimestamp" : "0x05bb71d3cc",
+		"parentDifficulty" : "0x148261483f27d34e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05bb71d3ee",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x147d40afed180a5a"
+	},
+
+ "DifficultyTest1677" : {
+		"parentTimestamp" : "0x06d73dad8b",
+		"parentDifficulty" : "0x6e8c9efae6c0b30f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06d73dadad",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x6e70fbd3280704e3"
+	},
+
+ "DifficultyTest1678" : {
+		"parentTimestamp" : "0x0253fe5608",
+		"parentDifficulty" : "0x4f7bc67e3d7809f2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0253fe562a",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x4f67e78c9de8aff0"
+	},
+
+ "DifficultyTest1679" : {
+		"parentTimestamp" : "0x025f58a4e5",
+		"parentDifficulty" : "0x5610092fa50e28b4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x025f58a507",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x55fa852d5924ed2a"
+	},
+
+ "DifficultyTest1680" : {
+		"parentTimestamp" : "0x053c34e0be",
+		"parentDifficulty" : "0x01d85a39efe324a3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x053c34e0e0",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x01d7e42361673bdb"
+	},
+
+ "DifficultyTest1681" : {
+		"parentTimestamp" : "0x0507bf9aed",
+		"parentDifficulty" : "0x61ea7305cbcba9e9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0507bf9b0f",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x61d1f8690a58d6ff"
+	},
+
+ "DifficultyTest1682" : {
+		"parentTimestamp" : "0x0207fda9b6",
+		"parentDifficulty" : "0x5e72d82f4f68d63f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0207fda9d8",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x5e5b3b7943953c0b"
+	},
+
+ "DifficultyTest1683" : {
+		"parentTimestamp" : "0xa5340e65",
+		"parentDifficulty" : "0x3ef58b0010ecf3fb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa5340e87",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x3ee5cd9d50e8b8bf"
+	},
+
+ "DifficultyTest1684" : {
+		"parentTimestamp" : "0x0582ba2342",
+		"parentDifficulty" : "0x236da2c1150c7e28",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0582ba2364",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x2364c75864c73b0a"
+	},
+
+ "DifficultyTest1685" : {
+		"parentTimestamp" : "0x04ce23b5f2",
+		"parentDifficulty" : "0x21392b19d1ed5d29",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04ce23b614",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x2130dccf0b78e1d3"
+	},
+
+ "DifficultyTest1686" : {
+		"parentTimestamp" : "0x04169c0c8c",
+		"parentDifficulty" : "0x758be9d016cfe7e2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04169c0cae",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x756e86d5a2ca33ea"
+	},
+
+ "DifficultyTest1687" : {
+		"parentTimestamp" : "0x6813ed90",
+		"parentDifficulty" : "0x36c9b06951017bbc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6813edb2",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x36bbfdfd36ad3b5e"
+	},
+
+ "DifficultyTest1688" : {
+		"parentTimestamp" : "0x059f3f8145",
+		"parentDifficulty" : "0x75bbd38d49ae0374",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x059f3f8167",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x759e6498665b97f4"
+	},
+
+ "DifficultyTest1689" : {
+		"parentTimestamp" : "0x05b0b14fb0",
+		"parentDifficulty" : "0x55cf1301c45f22e0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05b0b14fd2",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x55b99f3d03ee0b18"
+	},
+
+ "DifficultyTest1690" : {
+		"parentTimestamp" : "0x059b720c14",
+		"parentDifficulty" : "0x12e12640334127",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x059b720c36",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x12dc6df6a33457"
+	},
+
+ "DifficultyTest1691" : {
+		"parentTimestamp" : "0x014683c05d",
+		"parentDifficulty" : "0x208c3f72fc749322",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x014683c07f",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x20841c631fb575fe"
+	},
+
+ "DifficultyTest1692" : {
+		"parentTimestamp" : "0x07121af7f3",
+		"parentDifficulty" : "0x3bdcce459283bded",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07121af815",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x3bcdd712011f1cff"
+	},
+
+ "DifficultyTest1693" : {
+		"parentTimestamp" : "0x0167be2730",
+		"parentDifficulty" : "0x154a3dcf2f702d68",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0167be2752",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x1544eb3fbba4515e"
+	},
+
+ "DifficultyTest1694" : {
+		"parentTimestamp" : "0x93a1abf3",
+		"parentDifficulty" : "0x4dfd8c1f6d566c88",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x93a1ac15",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x4dea0cbc657b16ee"
+	},
+
+ "DifficultyTest1695" : {
+		"parentTimestamp" : "0x0799dadfd3",
+		"parentDifficulty" : "0x34f8906a5ca6692e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0799dadff5",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x34eb5246420f3f94"
+	},
+
+ "DifficultyTest1696" : {
+		"parentTimestamp" : "0x01e1392b68",
+		"parentDifficulty" : "0x182230b20f0d2b34",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01e1392b8a",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x181c2825e28967ea"
+	},
+
+ "DifficultyTest1697" : {
+		"parentTimestamp" : "0x054c87d1e9",
+		"parentDifficulty" : "0x44e38376d8f50a44",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x054c87d20b",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x44d24a95fb3ecd02"
+	},
+
+ "DifficultyTest1698" : {
+		"parentTimestamp" : "0x05d9735078",
+		"parentDifficulty" : "0x1d315c79fa66b21e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d973509a",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x1d2a1022dbe81873"
+	},
+
+ "DifficultyTest1699" : {
+		"parentTimestamp" : "0x01178c20a2",
+		"parentDifficulty" : "0x7510c22b10b33b2c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01178c20c4",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x74f37dfa85ef0e60"
+	},
+
+ "DifficultyTest1700" : {
+		"parentTimestamp" : "0x8102e774",
+		"parentDifficulty" : "0x33eeaef0f6632e07",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x8102e796",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x33e1b3453a259541"
+	},
+
+ "DifficultyTest1701" : {
+		"parentTimestamp" : "0x05ec74df29",
+		"parentDifficulty" : "0x0f60aaac28cb1bbf",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ec74df4b",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x0f5cd2817dc0e901"
+	},
+
+ "DifficultyTest1702" : {
+		"parentTimestamp" : "0x01269f9828",
+		"parentDifficulty" : "0x43c12596d519eb36",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01269f984a",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x43b0354d6f64a4cc"
+	},
+
+ "DifficultyTest1703" : {
+		"parentTimestamp" : "0x04135fd2bb",
+		"parentDifficulty" : "0x2a5ca687834b0bab",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04135fd2dd",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x2a520f5de16a3909"
+	},
+
+ "DifficultyTest1704" : {
+		"parentTimestamp" : "0x0159fd989c",
+		"parentDifficulty" : "0x5837a9f0c277acc3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0159fd98be",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x58219c0646470f19"
+	},
+
+ "DifficultyTest1705" : {
+		"parentTimestamp" : "0x036fde94f4",
+		"parentDifficulty" : "0x61f7fd85d6e35409",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x036fde9516",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x61df7f86756d9bb5"
+	},
+
+ "DifficultyTest1706" : {
+		"parentTimestamp" : "0x0618f08dfb",
+		"parentDifficulty" : "0x1e86951847f36a75",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0618f08e1d",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x1e7ef37301e16e9b"
+	},
+
+ "DifficultyTest1707" : {
+		"parentTimestamp" : "0x03fe6a9d85",
+		"parentDifficulty" : "0x2c92c7ec776edd6c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03fe6a9da7",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x2c87a33a7c5103b6"
+	},
+
+ "DifficultyTest1708" : {
+		"parentTimestamp" : "0x01af6280b4",
+		"parentDifficulty" : "0x39833a9d3f7f23e3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01af6280d6",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x3974d9ce982f481b"
+	},
+
+ "DifficultyTest1709" : {
+		"parentTimestamp" : "0x06c5d1a89e",
+		"parentDifficulty" : "0x7bc3bec5a3ffdec6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06c5d1a8c0",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x7ba4cdd5f296ded0"
+	},
+
+ "DifficultyTest1710" : {
+		"parentTimestamp" : "0x06dffaf807",
+		"parentDifficulty" : "0x6bc80ea7aaf0a558",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06dffaf829",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x6bad1ca40105e930"
+	},
+
+ "DifficultyTest1711" : {
+		"parentTimestamp" : "0x06bbeb06ab",
+		"parentDifficulty" : "0x40976fe0cde71d16",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06bbeb06cd",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x40874a04d5b3a350"
+	},
+
+ "DifficultyTest1712" : {
+		"parentTimestamp" : "0x10a47470",
+		"parentDifficulty" : "0x2f82bacdc4cc90ee",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x10a47492",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x2f76da1f115b5dca"
+	},
+
+ "DifficultyTest1713" : {
+		"parentTimestamp" : "0x0471ea582d",
+		"parentDifficulty" : "0x2990afdb55250b2c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0471ea584f",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x29864baf5e4fc1ea"
+	},
+
+ "DifficultyTest1714" : {
+		"parentTimestamp" : "0x0266b2c58f",
+		"parentDifficulty" : "0x3f7732c2b55cafec",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0266b2c5b1",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x3f6754f604af58c2"
+	},
+
+ "DifficultyTest1715" : {
+		"parentTimestamp" : "0x02be11f289",
+		"parentDifficulty" : "0x79fb778062c24202",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02be11f2ab",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x79dcf8a282a99172"
+	},
+
+ "DifficultyTest1716" : {
+		"parentTimestamp" : "0x07a7d4ccc5",
+		"parentDifficulty" : "0x3d539f585e28c169",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a7d4cce7",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x3d444a7088113739"
+	},
+
+ "DifficultyTest1717" : {
+		"parentTimestamp" : "0x0780ffc768",
+		"parentDifficulty" : "0x04c008a939b4f3eb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0780ffc78a",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x04bed8a70f6686b0"
+	},
+
+ "DifficultyTest1718" : {
+		"parentTimestamp" : "0x03bc4d48ad",
+		"parentDifficulty" : "0x6867b2dfff3dc8ba",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03bc4d48cf",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x684d98f3473df94a"
+	},
+
+ "DifficultyTest1719" : {
+		"parentTimestamp" : "0x02864beee7",
+		"parentDifficulty" : "0x3bbe15be8389d56b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02864bef09",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x3baf263913e8f2fb"
+	},
+
+ "DifficultyTest1720" : {
+		"parentTimestamp" : "0xde12002e",
+		"parentDifficulty" : "0x02d91224227c9349",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xde120050",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x02d85bdf9973f42d"
+	},
+
+ "DifficultyTest1721" : {
+		"parentTimestamp" : "0x338c72a1",
+		"parentDifficulty" : "0x476f31810d7cdf8d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x338c72c3",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x475d55b4ad398067"
+	},
+
+ "DifficultyTest1722" : {
+		"parentTimestamp" : "0x0726b678d0",
+		"parentDifficulty" : "0x2a52c5bcdf1caa4d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0726b678f2",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x2a48310b6fe4e343"
+	},
+
+ "DifficultyTest1723" : {
+		"parentTimestamp" : "0x05bd44b4d5",
+		"parentDifficulty" : "0x015a923ffe19ce9e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05bd44b4f7",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x015a3b9b6e1a486c"
+	},
+
+ "DifficultyTest1724" : {
+		"parentTimestamp" : "0x014f3c35ec",
+		"parentDifficulty" : "0x04a2d74e937fe636",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x014f3c360e",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x04a1ae98bfdb06be"
+	},
+
+ "DifficultyTest1725" : {
+		"parentTimestamp" : "0x05259f34a4",
+		"parentDifficulty" : "0x28fd324a24c9e588",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05259f34c6",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x28f2f2fd9240b410"
+	},
+
+ "DifficultyTest1726" : {
+		"parentTimestamp" : "0x036db1aba9",
+		"parentDifficulty" : "0x36ebd5576eed41ae",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x036db1abcb",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x36de1a621911885e"
+	},
+
+ "DifficultyTest1727" : {
+		"parentTimestamp" : "0x058c009502",
+		"parentDifficulty" : "0x3d8ba37f932e75c2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x058c009524",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x3d7c4096b349ae26"
+	},
+
+ "DifficultyTest1728" : {
+		"parentTimestamp" : "0x0690cafda4",
+		"parentDifficulty" : "0x14e3651d88653d6b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0690cafdc6",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x14de2c4441032c1d"
+	},
+
+ "DifficultyTest1729" : {
+		"parentTimestamp" : "0x036ea30dc9",
+		"parentDifficulty" : "0x6d7952597cce70e2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x036ea30deb",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x6d5df404e66f4d46"
+	},
+
+ "DifficultyTest1730" : {
+		"parentTimestamp" : "0x04b4512aa6",
+		"parentDifficulty" : "0x78964e320cfa3182",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04b4512ac8",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x7878289e807712f6"
+	},
+
+ "DifficultyTest1731" : {
+		"parentTimestamp" : "0x057707cfd3",
+		"parentDifficulty" : "0x6d1094661901ed62",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x057707cff5",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x6cf55040ff7bece8"
+	},
+
+ "DifficultyTest1732" : {
+		"parentTimestamp" : "0x06d80eea7e",
+		"parentDifficulty" : "0x4aab6d6765040e90",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06d80eeaa0",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x4aa217f9b8176e0f"
+	},
+
+ "DifficultyTest1733" : {
+		"parentTimestamp" : "0x0135cd00b8",
+		"parentDifficulty" : "0x53f3ebf75d9be01b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0135cd00da",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x53e96d79deb02c9f"
+	},
+
+ "DifficultyTest1734" : {
+		"parentTimestamp" : "0x022fd29c64",
+		"parentDifficulty" : "0x4eca529db2db8034",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x022fd29c86",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4ec079535f2524c4"
+	},
+
+ "DifficultyTest1735" : {
+		"parentTimestamp" : "0x06eb5ae173",
+		"parentDifficulty" : "0x1462c82c234a1731",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06eb5ae195",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x14603bd31dc5adef"
+	},
+
+ "DifficultyTest1736" : {
+		"parentTimestamp" : "0xc595d7d6",
+		"parentDifficulty" : "0x03371e1c47ea1915",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xc595d7f8",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x0336b73884611bd2"
+	},
+
+ "DifficultyTest1737" : {
+		"parentTimestamp" : "0x03e17d5cbe",
+		"parentDifficulty" : "0x7b2293cdce34b38c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03e17d5ce0",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x7b132f7b547aecf6"
+	},
+
+ "DifficultyTest1738" : {
+		"parentTimestamp" : "0x05ed01c313",
+		"parentDifficulty" : "0x492f325dd2be58bd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05ed01c335",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x49260c77870400f2"
+	},
+
+ "DifficultyTest1739" : {
+		"parentTimestamp" : "0x028499756d",
+		"parentDifficulty" : "0x4c55d009d2fde791",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x028499758f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x4c4c454fd1c387d5"
+	},
+
+ "DifficultyTest1740" : {
+		"parentTimestamp" : "0x04635b2cd3",
+		"parentDifficulty" : "0x560426021e0cd057",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04635b2cf5",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x55f9657d5dc90ebd"
+	},
+
+ "DifficultyTest1741" : {
+		"parentTimestamp" : "0x03f586659c",
+		"parentDifficulty" : "0x50f15557f56f4a08",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03f58665be",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x50e7372d4a709c1f"
+	},
+
+ "DifficultyTest1742" : {
+		"parentTimestamp" : "0x0343dd25a6",
+		"parentDifficulty" : "0x5026dd57c76731a7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0343dd25c8",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x501cd87c1c6e44c1"
+	},
+
+ "DifficultyTest1743" : {
+		"parentTimestamp" : "0x02a15c235f",
+		"parentDifficulty" : "0x14c5ac4914e74cf1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02a15c2381",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x14c313938bc4b008"
+	},
+
+ "DifficultyTest1744" : {
+		"parentTimestamp" : "0x0212428af4",
+		"parentDifficulty" : "0x5e5efe890ebef908",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0212428b16",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x5e5332a93d9d2129"
+	},
+
+ "DifficultyTest1745" : {
+		"parentTimestamp" : "0x05830293b6",
+		"parentDifficulty" : "0x0b787a2581c6c577",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05830293d8",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x0b770b163d168c9f"
+	},
+
+ "DifficultyTest1746" : {
+		"parentTimestamp" : "0x0769d2f466",
+		"parentDifficulty" : "0x3cb5eddb4619ebed",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0769d2f488",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3cae571d8ab128b0"
+	},
+
+ "DifficultyTest1747" : {
+		"parentTimestamp" : "0x73d89602",
+		"parentDifficulty" : "0x292282090dd5904d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x73d89624",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x291d5db8ccb3d59c"
+	},
+
+ "DifficultyTest1748" : {
+		"parentTimestamp" : "0x74cbc9a8",
+		"parentDifficulty" : "0x26b563f90f78dc07",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x74cbc9ca",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x26b08d4c9056ecee"
+	},
+
+ "DifficultyTest1749" : {
+		"parentTimestamp" : "0x042cc2efc2",
+		"parentDifficulty" : "0x5bd248bdbfb4b651",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x042cc2efe4",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x5bc6ce74a7fcbfbf"
+	},
+
+ "DifficultyTest1750" : {
+		"parentTimestamp" : "0x03d42674ba",
+		"parentDifficulty" : "0x1b4a4018760bd2ea",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03d42674dc",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x1b46d6d072fd1178"
+	},
+
+ "DifficultyTest1751" : {
+		"parentTimestamp" : "0x072cb617dc",
+		"parentDifficulty" : "0x4bec6c18bce88b56",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x072cb617fe",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x4be2ee8b39d0ee55"
+	},
+
+ "DifficultyTest1752" : {
+		"parentTimestamp" : "0x013ea7412f",
+		"parentDifficulty" : "0x5334195ecccc19b7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013ea74151",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x5329b2dba0f28054"
+	},
+
+ "DifficultyTest1753" : {
+		"parentTimestamp" : "0x049c6b1623",
+		"parentDifficulty" : "0x5a235ec22f4d792c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x049c6b1645",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x5a181a5657078fbd"
+	},
+
+ "DifficultyTest1754" : {
+		"parentTimestamp" : "0x046c252262",
+		"parentDifficulty" : "0x230835d8e45872b0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x046c252284",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x2303d4d2293be822"
+	},
+
+ "DifficultyTest1755" : {
+		"parentTimestamp" : "0x0184b45301",
+		"parentDifficulty" : "0x22b276160b035f20",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0184b45323",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x22ae1fc74841ffb5"
+	},
+
+ "DifficultyTest1756" : {
+		"parentTimestamp" : "0x010ecfb458",
+		"parentDifficulty" : "0x5ed8c0a2642fb625",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x010ecfb47a",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x5ecce58a4fe3322f"
+	},
+
+ "DifficultyTest1757" : {
+		"parentTimestamp" : "0x053bf17dd9",
+		"parentDifficulty" : "0x6b6ef37c741e415a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x053bf17dfb",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x6b61859e048fc192"
+	},
+
+ "DifficultyTest1758" : {
+		"parentTimestamp" : "0x05daeac83c",
+		"parentDifficulty" : "0x5beb109e33fbd510",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05daeac85e",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x5bdf933c20355596"
+	},
+
+ "DifficultyTest1759" : {
+		"parentTimestamp" : "0x9a866b38",
+		"parentDifficulty" : "0x1799d02fc415bf83",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9a866b5a",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x1796dcf5be1d3ccc"
+	},
+
+ "DifficultyTest1760" : {
+		"parentTimestamp" : "0x057f5be109",
+		"parentDifficulty" : "0x55db5219318d9ef3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x057f5be12b",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x55d096aeee676d40"
+	},
+
+ "DifficultyTest1761" : {
+		"parentTimestamp" : "0x01e832e799",
+		"parentDifficulty" : "0x08f68d445714d46d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e832e7bb",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x08f56e72ae89f1d3"
+	},
+
+ "DifficultyTest1762" : {
+		"parentTimestamp" : "0x07ba736a02",
+		"parentDifficulty" : "0x1cffde90aa41c8c9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07ba736a24",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x1cfc3e94d82c8090"
+	},
+
+ "DifficultyTest1763" : {
+		"parentTimestamp" : "0x02d91e808b",
+		"parentDifficulty" : "0x59d8709ed5c94439",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02d91e80ad",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x59cd3590c1ee8b11"
+	},
+
+ "DifficultyTest1764" : {
+		"parentTimestamp" : "0x07e7fe09a4",
+		"parentDifficulty" : "0x6439c8880377e43b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07e7fe09c6",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x642d414ef277753f"
+	},
+
+ "DifficultyTest1765" : {
+		"parentTimestamp" : "0x077487e484",
+		"parentDifficulty" : "0x264bbbdede3890a2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x077487e4a8",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x264228efe681027e"
+	},
+
+ "DifficultyTest1766" : {
+		"parentTimestamp" : "0xc6bae845",
+		"parentDifficulty" : "0x78c5515e2437805e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xc6bae869",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x78a72009ccae727f"
+	},
+
+ "DifficultyTest1767" : {
+		"parentTimestamp" : "0x0223e19d13",
+		"parentDifficulty" : "0x4fe7060e0d2d2852",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0223e19d37",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x4fd30c4c89a9dd0a"
+	},
+
+ "DifficultyTest1768" : {
+		"parentTimestamp" : "0x03caaae9bc",
+		"parentDifficulty" : "0x37c771f042001238",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03caaae9e0",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x37b98013c5ef9238"
+	},
+
+ "DifficultyTest1769" : {
+		"parentTimestamp" : "0x04f8bc540e",
+		"parentDifficulty" : "0x5fcb796a82f6b177",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f8bc5432",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x5fb3868c2855f3d3"
+	},
+
+ "DifficultyTest1770" : {
+		"parentTimestamp" : "0x0378782447",
+		"parentDifficulty" : "0x278bbbee434d1d4e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x037878246b",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x2781d8ff47bc4a18"
+	},
+
+ "DifficultyTest1771" : {
+		"parentTimestamp" : "0x067279d04d",
+		"parentDifficulty" : "0x73c125a5a2e7f5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x067279d071",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x73a4355c397f5d"
+	},
+
+ "DifficultyTest1772" : {
+		"parentTimestamp" : "0x058c57dd23",
+		"parentDifficulty" : "0x18589862d44c9f07",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x058c57dd47",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x1852823cbb978c21"
+	},
+
+ "DifficultyTest1773" : {
+		"parentTimestamp" : "0x07a4347613",
+		"parentDifficulty" : "0x4f18a9b555c9af91",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07a4347637",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x4f04e38ae8743da7"
+	},
+
+ "DifficultyTest1774" : {
+		"parentTimestamp" : "0x3b1a89fc",
+		"parentDifficulty" : "0x36ae790fcc633f65",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x3b1a8a20",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x36a0cd7188702797"
+	},
+
+ "DifficultyTest1775" : {
+		"parentTimestamp" : "0x017f9d1f60",
+		"parentDifficulty" : "0x4c6667fbe84f662f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x017f9d1f84",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x4c534e61e9555457"
+	},
+
+ "DifficultyTest1776" : {
+		"parentTimestamp" : "0x06ed81584b",
+		"parentDifficulty" : "0x4671d8334afc34f7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ed81586f",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x46603bbd3e2979eb"
+	},
+
+ "DifficultyTest1777" : {
+		"parentTimestamp" : "0x8ff3a66a",
+		"parentDifficulty" : "0x53ae416d8c10214e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x8ff3a68e",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x539955dd30ad2546"
+	},
+
+ "DifficultyTest1778" : {
+		"parentTimestamp" : "0x04b2d28b6b",
+		"parentDifficulty" : "0x42f245345c18131a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b2d28b8f",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x42e188a30f011d16"
+	},
+
+ "DifficultyTest1779" : {
+		"parentTimestamp" : "0x01f4287592",
+		"parentDifficulty" : "0x594e4164390d149c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f42875b6",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x5937edd3dffef158"
+	},
+
+ "DifficultyTest1780" : {
+		"parentTimestamp" : "0x062bc982eb",
+		"parentDifficulty" : "0x62706092f5f9b06d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x062bc9830f",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x6257c47ad13c7201"
+	},
+
+ "DifficultyTest1781" : {
+		"parentTimestamp" : "0x07143af74d",
+		"parentDifficulty" : "0x7e5a7f8719e5c300",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07143af771",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x7e2b1d97473c0cd8"
+	},
+
+ "DifficultyTest1782" : {
+		"parentTimestamp" : "0x061efc2ff7",
+		"parentDifficulty" : "0x7a5ae117e977b7fb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x061efc301b",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x7a2cff0380802b19"
+	},
+
+ "DifficultyTest1783" : {
+		"parentTimestamp" : "0x038594d06f",
+		"parentDifficulty" : "0x2200e9409d68103a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x038594d093",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x21f428e9252d0934"
+	},
+
+ "DifficultyTest1784" : {
+		"parentTimestamp" : "0x04f8869926",
+		"parentDifficulty" : "0x41bb2ba55c701d29",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f886994a",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x41a28574fe6d7320"
+	},
+
+ "DifficultyTest1785" : {
+		"parentTimestamp" : "0x044a00d5d1",
+		"parentDifficulty" : "0x54b11c413f34e5bc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044a00d5f5",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x549159d6a6bd31e8"
+	},
+
+ "DifficultyTest1786" : {
+		"parentTimestamp" : "0x0249b75609",
+		"parentDifficulty" : "0x20f0958ca1fe027d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0249b7562d",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x20e43b548d41433d"
+	},
+
+ "DifficultyTest1787" : {
+		"parentTimestamp" : "0xc7fc06a5",
+		"parentDifficulty" : "0x41dab72e547030bc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xc7fc06c9",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x41c20529a31086aa"
+	},
+
+ "DifficultyTest1788" : {
+		"parentTimestamp" : "0x05fcba3c0e",
+		"parentDifficulty" : "0x5d8611874d54ce4f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05fcba3c32",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x5d62ff40ba97ce84"
+	},
+
+ "DifficultyTest1789" : {
+		"parentTimestamp" : "0x06c8d968ea",
+		"parentDifficulty" : "0x0e0a608fe45e2501",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06c8d9690e",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x0e051cabae6881b5"
+	},
+
+ "DifficultyTest1790" : {
+		"parentTimestamp" : "0x049fbbabcc",
+		"parentDifficulty" : "0x5cc78f9997e180e3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x049fbbabf0",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x5ca4c4c3be488c53"
+	},
+
+ "DifficultyTest1791" : {
+		"parentTimestamp" : "0x06724561c7",
+		"parentDifficulty" : "0x37d9b524ef871641",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06724561eb",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x37c4c38101ad439b"
+	},
+
+ "DifficultyTest1792" : {
+		"parentTimestamp" : "0x01d042b76c",
+		"parentDifficulty" : "0x3d7859d94acfd3fe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01d042b790",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x3d614cb79953c610"
+	},
+
+ "DifficultyTest1793" : {
+		"parentTimestamp" : "0x03d97f05f6",
+		"parentDifficulty" : "0x2b47f5ff2d796761",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03d97f061a",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x2b37bb02edc859dd"
+	},
+
+ "DifficultyTest1794" : {
+		"parentTimestamp" : "0x022680fa94",
+		"parentDifficulty" : "0x669c99ff1716e523",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x022680fab8",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x66761f45576e3c8f"
+	},
+
+ "DifficultyTest1795" : {
+		"parentTimestamp" : "0x0234721bbd",
+		"parentDifficulty" : "0x1778f156aa78ebee",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0234721be1",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x177023fc29f8fe97"
+	},
+
+ "DifficultyTest1796" : {
+		"parentTimestamp" : "0xb8227a12",
+		"parentDifficulty" : "0x28e8edb13a116454",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb8227a36",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x28d99658179b9dd1"
+	},
+
+ "DifficultyTest1797" : {
+		"parentTimestamp" : "0x02fe43e47c",
+		"parentDifficulty" : "0x04cc73dca2661b1a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02fe43e4a0",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x04caa7312fa934d3"
+	},
+
+ "DifficultyTest1798" : {
+		"parentTimestamp" : "0x062e7aa915",
+		"parentDifficulty" : "0x28c3ea3735d85bc6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x062e7aa939",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x28b4a0bf61242aa9"
+	},
+
+ "DifficultyTest1799" : {
+		"parentTimestamp" : "0x04403428ee",
+		"parentDifficulty" : "0x022d99ca6388e326",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0440342912",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x022cc8b0b7a38fda"
+	},
+
+ "DifficultyTest1800" : {
+		"parentTimestamp" : "0x05ad23d10c",
+		"parentDifficulty" : "0x4b62fba747ee8c17",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ad23d130",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x4b46b688e93392b4"
+	},
+
+ "DifficultyTest1801" : {
+		"parentTimestamp" : "0x06e419ca1a",
+		"parentDifficulty" : "0x762756ca31b18c17",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06e419ca3e",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x75fb0809a5dee9a4"
+	},
+
+ "DifficultyTest1802" : {
+		"parentTimestamp" : "0x0213810e40",
+		"parentDifficulty" : "0x7647c5cd25fa4c02",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0213810e64",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x761b6ae2f90c0e67"
+	},
+
+ "DifficultyTest1803" : {
+		"parentTimestamp" : "0x04193a8c76",
+		"parentDifficulty" : "0x5a5380d319f2816c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04193a8c9a",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x5a31a182cac8c6fc"
+	},
+
+ "DifficultyTest1804" : {
+		"parentTimestamp" : "0x0220ef036c",
+		"parentDifficulty" : "0x505b4eddb53f196a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0220ef0390",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x503d2ca0221b22c1"
+	},
+
+ "DifficultyTest1805" : {
+		"parentTimestamp" : "0x041b27beb4",
+		"parentDifficulty" : "0x11f3230bc0187bc6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x041b27bed8",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x11ec67de9bb07499"
+	},
+
+ "DifficultyTest1806" : {
+		"parentTimestamp" : "0x0194087b84",
+		"parentDifficulty" : "0x5e92b1e22e2cb91c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0194087ba8",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x5e6f3adf795b6c57"
+	},
+
+ "DifficultyTest1807" : {
+		"parentTimestamp" : "0x0381632e14",
+		"parentDifficulty" : "0x22638a5092f161f8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0381632e38",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x2256a4fcb4ba4774"
+	},
+
+ "DifficultyTest1808" : {
+		"parentTimestamp" : "0x0718bc3a5b",
+		"parentDifficulty" : "0x724a5feae7a6d3b8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0718bc3a7f",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x721f8406ef8ff52a"
+	},
+
+ "DifficultyTest1809" : {
+		"parentTimestamp" : "0x030b2fd725",
+		"parentDifficulty" : "0x33454c72bc37a250",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x030b2fd749",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x3332127611310d74"
+	},
+
+ "DifficultyTest1810" : {
+		"parentTimestamp" : "0x05d19853bd",
+		"parentDifficulty" : "0x751ff6498c3b5722",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d19853e1",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x74f40a4d30a6c0e4"
+	},
+
+ "DifficultyTest1811" : {
+		"parentTimestamp" : "0x02af3fdfd3",
+		"parentDifficulty" : "0x196d2baf50a9c048",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02af3fdff7",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x1963a2beeeeb80a0"
+	},
+
+ "DifficultyTest1812" : {
+		"parentTimestamp" : "0x02ffdbd56d",
+		"parentDifficulty" : "0x6b77d3486f147340",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ffdbd591",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x6b4f865933eacb96"
+	},
+
+ "DifficultyTest1813" : {
+		"parentTimestamp" : "0x052d18d853",
+		"parentDifficulty" : "0x2995c5aaea519558",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x052d18d877",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x29862d80ca39b6c2"
+	},
+
+ "DifficultyTest1814" : {
+		"parentTimestamp" : "0x0482aa929c",
+		"parentDifficulty" : "0x572b6e061b168818",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0482aa92c0",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x5715a32a998fc276"
+	},
+
+ "DifficultyTest1815" : {
+		"parentTimestamp" : "0x04863939be",
+		"parentDifficulty" : "0x719dba59de984aba",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04863939e2",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x718152eb4820a4a9"
+	},
+
+ "DifficultyTest1816" : {
+		"parentTimestamp" : "0x031105fd1f",
+		"parentDifficulty" : "0x7e16b86a76ea843d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x031105fd43",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x7df732bc5c4cc99f"
+	},
+
+ "DifficultyTest1817" : {
+		"parentTimestamp" : "0x054b358365",
+		"parentDifficulty" : "0x1327ed7d277666bd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x054b358389",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x13232381c82c8929"
+	},
+
+ "DifficultyTest1818" : {
+		"parentTimestamp" : "0x033e4eb158",
+		"parentDifficulty" : "0x2ec3409876b5e353",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x033e4eb17c",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x2eb78fc8509835e3"
+	},
+
+ "DifficultyTest1819" : {
+		"parentTimestamp" : "0x0386bb7985",
+		"parentDifficulty" : "0x77f3dd909465380f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0386bb79a9",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x77d5e09930401ed1"
+	},
+
+ "DifficultyTest1820" : {
+		"parentTimestamp" : "0x014ea9327b",
+		"parentDifficulty" : "0x4888d5a71d04674d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x014ea9329f",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x4876b371b33d2655"
+	},
+
+ "DifficultyTest1821" : {
+		"parentTimestamp" : "0x03063ed58b",
+		"parentDifficulty" : "0x06bd3526811fa4b9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03063ed5af",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x06bb85d9377f5d11"
+	},
+
+ "DifficultyTest1822" : {
+		"parentTimestamp" : "0x045ee57196",
+		"parentDifficulty" : "0x4fe5fa81534a98f7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045ee571ba",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x4fd20102b2f5c6d1"
+	},
+
+ "DifficultyTest1823" : {
+		"parentTimestamp" : "0x06f96cf913",
+		"parentDifficulty" : "0x55c842ab678c2a93",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06f96cf937",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x55b2d09abcb24889"
+	},
+
+ "DifficultyTest1824" : {
+		"parentTimestamp" : "0x912d572f",
+		"parentDifficulty" : "0x61b9c12baf32d65f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x912d5753",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x61a152bb64470bab"
+	},
+
+ "DifficultyTest1825" : {
+		"parentTimestamp" : "0x07576d5d3e",
+		"parentDifficulty" : "0x765b8e080e0684bb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07576d5d62",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x763df7248c03071b"
+	},
+
+ "DifficultyTest1826" : {
+		"parentTimestamp" : "0x0631df0514",
+		"parentDifficulty" : "0x0cb9368c45a33051",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0631df0538",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x0cb6083ea291cf85"
+	},
+
+ "DifficultyTest1827" : {
+		"parentTimestamp" : "0x038799779b",
+		"parentDifficulty" : "0x2a96235d170e9ae9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03879977bf",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x2a8b7dd43fc8e743"
+	},
+
+ "DifficultyTest1828" : {
+		"parentTimestamp" : "0x02876b5494",
+		"parentDifficulty" : "0x1da8bb25fe5b9000",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02876b54b8",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x1da150f734dc191c"
+	},
+
+ "DifficultyTest1829" : {
+		"parentTimestamp" : "0x0725121ee0",
+		"parentDifficulty" : "0x77d3ee609cd7c78d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0725121f04",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x77b5f96504b0d19d"
+	},
+
+ "DifficultyTest1830" : {
+		"parentTimestamp" : "0xb2715962",
+		"parentDifficulty" : "0x1099f99f51fd24",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xb2715986",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x1095d320ea28a6"
+	},
+
+ "DifficultyTest1831" : {
+		"parentTimestamp" : "0x05b87c0db1",
+		"parentDifficulty" : "0x572a203d4c818b91",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05b87c0dd5",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x571455b53d2e6b2f"
+	},
+
+ "DifficultyTest1832" : {
+		"parentTimestamp" : "0x0518c2f1e2",
+		"parentDifficulty" : "0x1747ce4eec346fc6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0518c2f206",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x1741fc5b587962ac"
+	},
+
+ "DifficultyTest1833" : {
+		"parentTimestamp" : "0x02e6cf352b",
+		"parentDifficulty" : "0x06c55c54dab9a9de",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02e6cf354f",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x06c3aafdc582fb74"
+	},
+
+ "DifficultyTest1834" : {
+		"parentTimestamp" : "0x023a34e459",
+		"parentDifficulty" : "0x4948e11a02389364",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x023a34e47d",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x49368ee1bbb80540"
+	},
+
+ "DifficultyTest1835" : {
+		"parentTimestamp" : "0x1d46f015",
+		"parentDifficulty" : "0x1aaa1a26d01c7860",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1d46f039",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x1aa36fa046687142"
+	},
+
+ "DifficultyTest1836" : {
+		"parentTimestamp" : "0x02cd0f324b",
+		"parentDifficulty" : "0x695c2660acf3fcfa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cd0f326f",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x6941cf5714c8bffc"
+	},
+
+ "DifficultyTest1837" : {
+		"parentTimestamp" : "0x058d359148",
+		"parentDifficulty" : "0x08b7df819c8a39af",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x058d35916c",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x08b5b189bc231721"
+	},
+
+ "DifficultyTest1838" : {
+		"parentTimestamp" : "0x34c4b37c",
+		"parentDifficulty" : "0x4d0ea852dafda476",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x34c4b3a0",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x4cfb64a8c646e50e"
+	},
+
+ "DifficultyTest1839" : {
+		"parentTimestamp" : "0x05258854e7",
+		"parentDifficulty" : "0x1cb4b882ab22ac9a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x052588550b",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x1cad8b548a77e3f0"
+	},
+
+ "DifficultyTest1840" : {
+		"parentTimestamp" : "0x05f7767b42",
+		"parentDifficulty" : "0x2a879c920bf58113",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05f7767b66",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x2a7cfaaae77283b3"
+	},
+
+ "DifficultyTest1841" : {
+		"parentTimestamp" : "0x028ad2bb23",
+		"parentDifficulty" : "0x3d6d99908e900e6a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x028ad2bb47",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x3d5e3e2a2a6c6a68"
+	},
+
+ "DifficultyTest1842" : {
+		"parentTimestamp" : "0x05d9b4e470",
+		"parentDifficulty" : "0x3779c75dac3408ac",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05d9b4e494",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x376be8ebd4c8fbaa"
+	},
+
+ "DifficultyTest1843" : {
+		"parentTimestamp" : "0x02fabcef66",
+		"parentDifficulty" : "0x29e3ef3cea45b1a9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02fabcef8a",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x29d976411b0b203d"
+	},
+
+ "DifficultyTest1844" : {
+		"parentTimestamp" : "0x0682f2937b",
+		"parentDifficulty" : "0x19249580550e9623",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0682f2939f",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x191e4c5af4f9527f"
+	},
+
+ "DifficultyTest1845" : {
+		"parentTimestamp" : "0x06c33254ab",
+		"parentDifficulty" : "0x0e0ff84cd76262f6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c33254cf",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x0e0c744ec42c8a5f"
+	},
+
+ "DifficultyTest1846" : {
+		"parentTimestamp" : "0x06fd8cb04e",
+		"parentDifficulty" : "0x7de3e6053248db1e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06fd8cb072",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x7dc46d0bb0fc48ea"
+	},
+
+ "DifficultyTest1847" : {
+		"parentTimestamp" : "0x04faf5382e",
+		"parentDifficulty" : "0x132fff687b5f1342",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04faf53852",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x132b3368a1403b82"
+	},
+
+ "DifficultyTest1848" : {
+		"parentTimestamp" : "0x04f7d927f0",
+		"parentDifficulty" : "0x7f47f84c3959d460",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04f7d92814",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x7f28264e264b7df4"
+	},
+
+ "DifficultyTest1849" : {
+		"parentTimestamp" : "0x044dab21c8",
+		"parentDifficulty" : "0x21ff57529e72399e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x044dab21ec",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x21f6d77cc9ca9d20"
+	},
+
+ "DifficultyTest1850" : {
+		"parentTimestamp" : "0x0445ddc876",
+		"parentDifficulty" : "0x2cea703fff0b40af",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0445ddc89a",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x2cdf35a3ef0b7dff"
+	},
+
+ "DifficultyTest1851" : {
+		"parentTimestamp" : "0x02e6b41808",
+		"parentDifficulty" : "0x059d8a8aeb0655c6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02e6b4182c",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x059c2328484b9472"
+	},
+
+ "DifficultyTest1852" : {
+		"parentTimestamp" : "0x78fa56df",
+		"parentDifficulty" : "0x33d49ecddfee8b12",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x78fa5703",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x33c7a9a62c768ff0"
+	},
+
+ "DifficultyTest1853" : {
+		"parentTimestamp" : "0x10f31f4d",
+		"parentDifficulty" : "0x49a6de952e60141a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x10f31f71",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x499474dd89147d16"
+	},
+
+ "DifficultyTest1854" : {
+		"parentTimestamp" : "0x05485e8ca3",
+		"parentDifficulty" : "0x4437faa7e8dc499f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05485e8cc7",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x4426eca93ee2148d"
+	},
+
+ "DifficultyTest1855" : {
+		"parentTimestamp" : "0x02cc959d0e",
+		"parentDifficulty" : "0x324bc7da5a812c28",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cc959d32",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x323f34e863ea8fde"
+	},
+
+ "DifficultyTest1856" : {
+		"parentTimestamp" : "0x8dc810e4",
+		"parentDifficulty" : "0x5ef497fc043b94e4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x8dc81108",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x5edcdad6053a8600"
+	},
+
+ "DifficultyTest1857" : {
+		"parentTimestamp" : "0x02cd93a2cc",
+		"parentDifficulty" : "0x0cd27c67e1fa142b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cd93a2f0",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x0ccf47c8c80195a7"
+	},
+
+ "DifficultyTest1858" : {
+		"parentTimestamp" : "0x01cfc0b6e2",
+		"parentDifficulty" : "0x120f8defa8dee48e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01cfc0b706",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x120b0a0c2cf4acd6"
+	},
+
+ "DifficultyTest1859" : {
+		"parentTimestamp" : "0x013b4eb011",
+		"parentDifficulty" : "0x19d54f17dbda9191",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013b4eb035",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x19ced9c415e39aed"
+	},
+
+ "DifficultyTest1860" : {
+		"parentTimestamp" : "0x02ec9da00d",
+		"parentDifficulty" : "0x590b276cbd1360cc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ec9da031",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x58f4e4a2e1e41bf4"
+	},
+
+ "DifficultyTest1861" : {
+		"parentTimestamp" : "0x01d38215ac",
+		"parentDifficulty" : "0x040da81edab419bc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01d38215d0",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x040ca4b4d2fd6cb6"
+	},
+
+ "DifficultyTest1862" : {
+		"parentTimestamp" : "0x0593d9d3f5",
+		"parentDifficulty" : "0x37852260c36116f7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0593d9d419",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x377741182b303eb3"
+	},
+
+ "DifficultyTest1863" : {
+		"parentTimestamp" : "0x05ac72cb9f",
+		"parentDifficulty" : "0x5ae77baa4259e2e0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ac72cbc5",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x5ad0c1cb57c94c68"
+	},
+
+ "DifficultyTest1864" : {
+		"parentTimestamp" : "0x03a27aa856",
+		"parentDifficulty" : "0x0d8fb6a314affb46",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03a27aa87c",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x0d8c52b56beacf49"
+	},
+
+ "DifficultyTest1865" : {
+		"parentTimestamp" : "0x01a6bdcb15",
+		"parentDifficulty" : "0x61b51eb1aa44ae41",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01a6bdcb3b",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x619cb169fdda1d19"
+	},
+
+ "DifficultyTest1866" : {
+		"parentTimestamp" : "0x59ebcf13",
+		"parentDifficulty" : "0x61539538cf593512",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x59ebcf39",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x613b405381255eca"
+	},
+
+ "DifficultyTest1867" : {
+		"parentTimestamp" : "0x03d44fad21",
+		"parentDifficulty" : "0x3b53c84e2e0f2989",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03d44fad47",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x3b44f35c1a83a5c7"
+	},
+
+ "DifficultyTest1868" : {
+		"parentTimestamp" : "0x04a508d7a8",
+		"parentDifficulty" : "0x52b9cb24ae7c7d7b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04a508d7ce",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x52a51cb1e550de6d"
+	},
+
+ "DifficultyTest1869" : {
+		"parentTimestamp" : "0x079ba6d85e",
+		"parentDifficulty" : "0x222b63123c2959fd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x079ba6d884",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x2222d839779a4fc7"
+	},
+
+ "DifficultyTest1870" : {
+		"parentTimestamp" : "0x05d8e97171",
+		"parentDifficulty" : "0x5a017924dff139ef",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d8e97197",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x59eaf8c696b93de1"
+	},
+
+ "DifficultyTest1871" : {
+		"parentTimestamp" : "0x04012fb1d6",
+		"parentDifficulty" : "0x035358a802e5330b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04012fb1fc",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x035283d1d8e47a3f"
+	},
+
+ "DifficultyTest1872" : {
+		"parentTimestamp" : "0x02d2154cd3",
+		"parentDifficulty" : "0x07adb05782952345",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d2154cf9",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x07abc4eb6cb47efd"
+	},
+
+ "DifficultyTest1873" : {
+		"parentTimestamp" : "0x05130151e9",
+		"parentDifficulty" : "0x11c4b649e1f82328",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051301520f",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x11c0451c4f7fa720"
+	},
+
+ "DifficultyTest1874" : {
+		"parentTimestamp" : "0x06ec588990",
+		"parentDifficulty" : "0x7417c0f981f9bf5c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ec5889b6",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x73fabb09439944ee"
+	},
+
+ "DifficultyTest1875" : {
+		"parentTimestamp" : "0x04e1094ba2",
+		"parentDifficulty" : "0x6af8d29c1f574b07",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04e1094bc8",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x6ade1467784f7d35"
+	},
+
+ "DifficultyTest1876" : {
+		"parentTimestamp" : "0x06bd491ad3",
+		"parentDifficulty" : "0x5aa76e619b21cae7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06bd491af9",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x5a90c48602bb1275"
+	},
+
+ "DifficultyTest1877" : {
+		"parentTimestamp" : "0x065b9b42cb",
+		"parentDifficulty" : "0x053bd75880575fdc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x065b9b42f1",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x053a8862aa376a06"
+	},
+
+ "DifficultyTest1878" : {
+		"parentTimestamp" : "0x0733479037",
+		"parentDifficulty" : "0x35e8fc854d79fef2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x073347905d",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x35db82462c26e074"
+	},
+
+ "DifficultyTest1879" : {
+		"parentTimestamp" : "0x04fb0a2dbb",
+		"parentDifficulty" : "0x70029212aa89cea5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04fb0a2de1",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x6fd8911be389dafa"
+	},
+
+ "DifficultyTest1880" : {
+		"parentTimestamp" : "0x03aada2708",
+		"parentDifficulty" : "0x0f6f342448b41e2e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03aada272e",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x0f696a70bb18daa5"
+	},
+
+ "DifficultyTest1881" : {
+		"parentTimestamp" : "0x05c6add917",
+		"parentDifficulty" : "0x1c87f0b27909a967",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05c6add93d",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x1c7d3db8361c45c8"
+	},
+
+ "DifficultyTest1882" : {
+		"parentTimestamp" : "0x06425b6581",
+		"parentDifficulty" : "0x4be9d111225fabe7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06425b65a7",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x4bcd5962bbf2c808"
+	},
+
+ "DifficultyTest1883" : {
+		"parentTimestamp" : "0x042c9a4f46",
+		"parentDifficulty" : "0x50359d611e5108e9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x042c9a4f6c",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x5017894619e5aa86"
+	},
+
+ "DifficultyTest1884" : {
+		"parentTimestamp" : "0x075efc67d6",
+		"parentDifficulty" : "0x2354243c64982bab",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x075efc67fc",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x2346e4aecdf2729c"
+	},
+
+ "DifficultyTest1885" : {
+		"parentTimestamp" : "0x059908cc31",
+		"parentDifficulty" : "0x522676e303dd5cb4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x059908cc57",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x5207a8766ebbe9b3"
+	},
+
+ "DifficultyTest1886" : {
+		"parentTimestamp" : "0x0616438fc7",
+		"parentDifficulty" : "0x08c687aedcd84ca0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0616438fed",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x08c33d3bfb457b85"
+	},
+
+ "DifficultyTest1887" : {
+		"parentTimestamp" : "0x04aeca1362",
+		"parentDifficulty" : "0x18b1b0c0c2468f5b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04aeca1388",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x18a86e1e79fdb4e8"
+	},
+
+ "DifficultyTest1888" : {
+		"parentTimestamp" : "0x0596f073c0",
+		"parentDifficulty" : "0x2fde5de1306e38ad",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0596f073e6",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x2fcc6a7dfbfc0f58"
+	},
+
+ "DifficultyTest1889" : {
+		"parentTimestamp" : "0x041dcc3f04",
+		"parentDifficulty" : "0x1f94b5c4a435e0f7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x041dcc3f2a",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x1f88de007a784cc3"
+	},
+
+ "DifficultyTest1890" : {
+		"parentTimestamp" : "0x05583f872f",
+		"parentDifficulty" : "0x4ab1dd47f01d95d5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05583f8755",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x4a95da94f5238abf"
+	},
+
+ "DifficultyTest1891" : {
+		"parentTimestamp" : "0x07aa549b99",
+		"parentDifficulty" : "0x4db1c68ef8c01e8c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07aa549bbf",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x4d94a3e48322d683"
+	},
+
+ "DifficultyTest1892" : {
+		"parentTimestamp" : "0x0720959530",
+		"parentDifficulty" : "0x7e1455148fbbb770",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0720959556",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x7de50d74a805d10e"
+	},
+
+ "DifficultyTest1893" : {
+		"parentTimestamp" : "0x03b7c4df3c",
+		"parentDifficulty" : "0x2405c475cdb22a24",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03b7c4df62",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x23f8424c21850755"
+	},
+
+ "DifficultyTest1894" : {
+		"parentTimestamp" : "0x04d53aff63",
+		"parentDifficulty" : "0x3b1ce131a3d14ef5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04d53aff89",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x3b06b65d3133e07b"
+	},
+
+ "DifficultyTest1895" : {
+		"parentTimestamp" : "0x03236d9b06",
+		"parentDifficulty" : "0x77d7c324f72ab269",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03236d9b2c",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x77aad23bc94e0269"
+	},
+
+ "DifficultyTest1896" : {
+		"parentTimestamp" : "0x04c18f4071",
+		"parentDifficulty" : "0x31a274478f2bdda8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04c18f4097",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x318fd75bf4562d3b"
+	},
+
+ "DifficultyTest1897" : {
+		"parentTimestamp" : "0x06c3411ecf",
+		"parentDifficulty" : "0x107486e5bbc896d1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06c3411ef5",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x106e5b3325a22ba3"
+	},
+
+ "DifficultyTest1898" : {
+		"parentTimestamp" : "0x039832cd",
+		"parentDifficulty" : "0x783416010a21cd81",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x039832f3",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x78070278c9be00e6"
+	},
+
+ "DifficultyTest1899" : {
+		"parentTimestamp" : "0x06ae00381d",
+		"parentDifficulty" : "0x09a29497910706a1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06ae003843",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x099ef79fd830a421"
+	},
+
+ "DifficultyTest1900" : {
+		"parentTimestamp" : "0x060c066f32",
+		"parentDifficulty" : "0x2f82878870665693",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060c066f58",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2f70b6959d3c3075"
+	},
+
+ "DifficultyTest1901" : {
+		"parentTimestamp" : "0x01f21543e5",
+		"parentDifficulty" : "0x30c23a6329035d21",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f215440b",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x30aff18d43d3fc60"
+	},
+
+ "DifficultyTest1902" : {
+		"parentTimestamp" : "0x0757c70e37",
+		"parentDifficulty" : "0x5d55f82ed242580d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0757c70e5d",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x5d32f7f1c0b3802c"
+	},
+
+ "DifficultyTest1903" : {
+		"parentTimestamp" : "0x03cc8a1fe8",
+		"parentDifficulty" : "0x5d0c5c00dd558009",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03cc8a200e",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x5ce9775e5d0281f9"
+	},
+
+ "DifficultyTest1904" : {
+		"parentTimestamp" : "0x02d94dddcb",
+		"parentDifficulty" : "0x400dcecc08f29b9e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02d94dddf1",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x3ff5c99e7c6f44a5"
+	},
+
+ "DifficultyTest1905" : {
+		"parentTimestamp" : "0x04a328269a",
+		"parentDifficulty" : "0x68861e1fc9b6e4f3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04a32826c0",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x685eebd47dcb405f"
+	},
+
+ "DifficultyTest1906" : {
+		"parentTimestamp" : "0x058955ca8d",
+		"parentDifficulty" : "0x732e2406877fc57e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x058955cab3",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x7302f2b9050cf596"
+	},
+
+ "DifficultyTest1907" : {
+		"parentTimestamp" : "0x01854a6dd5",
+		"parentDifficulty" : "0x6965efbcaa5bb391",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01854a6dfb",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x693e6982c39bd12f"
+	},
+
+ "DifficultyTest1908" : {
+		"parentTimestamp" : "0x020b91d76c",
+		"parentDifficulty" : "0x5a1cb35aabc113f5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x020b91d792",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x59fae89769c0ab8f"
+	},
+
+ "DifficultyTest1909" : {
+		"parentTimestamp" : "0x503f6d96",
+		"parentDifficulty" : "0x654fb14296aaea16",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x503f6dbc",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x6529b3601db269ff"
+	},
+
+ "DifficultyTest1910" : {
+		"parentTimestamp" : "0x030052e4d2",
+		"parentDifficulty" : "0x4235688130261e72",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x030052e4f8",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x421c9479ffb41029"
+	},
+
+ "DifficultyTest1911" : {
+		"parentTimestamp" : "0x4a19054c",
+		"parentDifficulty" : "0x1b852f3ebb199fc0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x4a190572",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x1b7add4d03937627"
+	},
+
+ "DifficultyTest1912" : {
+		"parentTimestamp" : "0x060b933b4e",
+		"parentDifficulty" : "0x426f3d1da2751c23",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x060b933b74",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x425ea14e5b0c7edd"
+	},
+
+ "DifficultyTest1913" : {
+		"parentTimestamp" : "0x034fdd97b6",
+		"parentDifficulty" : "0x5749a5bb1f8e45a8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x034fdd97dc",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x5733d351b0c66219"
+	},
+
+ "DifficultyTest1914" : {
+		"parentTimestamp" : "0xd5783a44",
+		"parentDifficulty" : "0x7ddf4a8883a7d506",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xd5783a6a",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x7dbfd2b5e186eb14"
+	},
+
+ "DifficultyTest1915" : {
+		"parentTimestamp" : "0x0373f1be64",
+		"parentDifficulty" : "0x1f2880d3e1047b25",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0373f1be8a",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x1f20b6b3ac0c3a0b"
+	},
+
+ "DifficultyTest1916" : {
+		"parentTimestamp" : "0x04f86a4faf",
+		"parentDifficulty" : "0x5716ca53549fe131",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04f86a4fd5",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x570104a0bfcab941"
+	},
+
+ "DifficultyTest1917" : {
+		"parentTimestamp" : "0x0388d7fd58",
+		"parentDifficulty" : "0x4dcbaa98c65b2e03",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0388d7fd7e",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x4db837ae20299749"
+	},
+
+ "DifficultyTest1918" : {
+		"parentTimestamp" : "0x8e18c3e5",
+		"parentDifficulty" : "0x57b090c1ca7d68ea",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x8e18c40b",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x579aa49d9a0ac9b0"
+	},
+
+ "DifficultyTest1919" : {
+		"parentTimestamp" : "0x060e1727b5",
+		"parentDifficulty" : "0x44d29eff49f9dda1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x060e1727db",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x44c16a578a275f6b"
+	},
+
+ "DifficultyTest1920" : {
+		"parentTimestamp" : "0x0185285606",
+		"parentDifficulty" : "0x0f46c5e93fd67273",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x018528562c",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x0f42f437c5867d57"
+	},
+
+ "DifficultyTest1921" : {
+		"parentTimestamp" : "0x051f4762f1",
+		"parentDifficulty" : "0x5b984bae3e076387",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x051f476317",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x5b81659b5277e2af"
+	},
+
+ "DifficultyTest1922" : {
+		"parentTimestamp" : "0x022dafcc0a",
+		"parentDifficulty" : "0x743e1a6dad9da15e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x022dafcc30",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x74210ae712323bf6"
+	},
+
+ "DifficultyTest1923" : {
+		"parentTimestamp" : "0x042e9fe0bb",
+		"parentDifficulty" : "0x2a70046c89b0def7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x042e9fe0e1",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x2a65686b6e8e76c1"
+	},
+
+ "DifficultyTest1924" : {
+		"parentTimestamp" : "0x6d02fba3",
+		"parentDifficulty" : "0x48d63b6dcb0e9320",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x6d02fbc9",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x48c405deef9bd77c"
+	},
+
+ "DifficultyTest1925" : {
+		"parentTimestamp" : "0x06a9194171",
+		"parentDifficulty" : "0x0f08ff9fc4d8764c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06a9194197",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x0f053d5fdce75030"
+	},
+
+ "DifficultyTest1926" : {
+		"parentTimestamp" : "0x021d398232",
+		"parentDifficulty" : "0x42e89284e4e58847",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x021d398258",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x42d7d86043ac6ee5"
+	},
+
+ "DifficultyTest1927" : {
+		"parentTimestamp" : "0x011c6fd33f",
+		"parentDifficulty" : "0x43d88bae32db2a53",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x011c6fd365",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x43c7958b474eb389"
+	},
+
+ "DifficultyTest1928" : {
+		"parentTimestamp" : "0x01c0e01c6b",
+		"parentDifficulty" : "0x74b11f83c2a941dd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c0e01c91",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x7493f33be1b8978d"
+	},
+
+ "DifficultyTest1929" : {
+		"parentTimestamp" : "0x026e50d963",
+		"parentDifficulty" : "0x4953bb487ea44084",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x026e50d989",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x49416659ac849774"
+	},
+
+ "DifficultyTest1930" : {
+		"parentTimestamp" : "0x058142c53b",
+		"parentDifficulty" : "0x3d12a4e2b215ff0d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x058142c561",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x3d0360397969798f"
+	},
+
+ "DifficultyTest1931" : {
+		"parentTimestamp" : "0x93eedb4d",
+		"parentDifficulty" : "0x5417854542b08450",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x93eedb73",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x54027f63f15fd830"
+	},
+
+ "DifficultyTest1932" : {
+		"parentTimestamp" : "0x03a5dc801c",
+		"parentDifficulty" : "0x183d94ae6b286396",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03a5dc8042",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x183785493f8d997e"
+	},
+
+ "DifficultyTest1933" : {
+		"parentTimestamp" : "0x0640b14ba9",
+		"parentDifficulty" : "0x6f5b0256f36900f4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0640b14bcf",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x6f3f2b965dac26b4"
+	},
+
+ "DifficultyTest1934" : {
+		"parentTimestamp" : "0x0446100d5c",
+		"parentDifficulty" : "0x47f766218ecf170d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0446100d82",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x47e56848066b6349"
+	},
+
+ "DifficultyTest1935" : {
+		"parentTimestamp" : "0x07ae087656",
+		"parentDifficulty" : "0x7ccbc5b59dc3ec7b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07ae08767c",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x7cac92c4305c7b81"
+	},
+
+ "DifficultyTest1936" : {
+		"parentTimestamp" : "0x01b5413b88",
+		"parentDifficulty" : "0x2a5449c48e38f7c4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01b5413bae",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x2a49b4b21d156988"
+	},
+
+ "DifficultyTest1937" : {
+		"parentTimestamp" : "0x02c069d2ee",
+		"parentDifficulty" : "0x4ff70460f67490c5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02c069d314",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x4fe3069fde36f3a1"
+	},
+
+ "DifficultyTest1938" : {
+		"parentTimestamp" : "0x03ad2fabba",
+		"parentDifficulty" : "0x4505ca059799027a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ad2fabe0",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x44f4889316331c3a"
+	},
+
+ "DifficultyTest1939" : {
+		"parentTimestamp" : "0xb9e89232",
+		"parentDifficulty" : "0x1b9edd9c546cf882",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xb9e89258",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x1b97f5e4ed57dd44"
+	},
+
+ "DifficultyTest1940" : {
+		"parentTimestamp" : "0xce51e182",
+		"parentDifficulty" : "0x3b9c59988e2a3fda",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xce51e1a8",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x3b8d72822806b54c"
+	},
+
+ "DifficultyTest1941" : {
+		"parentTimestamp" : "0x024b681389",
+		"parentDifficulty" : "0x3a68e1f45ae01864",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x024b6813af",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x3a5a47bbddc9605e"
+	},
+
+ "DifficultyTest1942" : {
+		"parentTimestamp" : "0x05c4285538",
+		"parentDifficulty" : "0x6fd3ffe0eb977dd4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05c428555e",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x6fb80ae0f35c97f6"
+	},
+
+ "DifficultyTest1943" : {
+		"parentTimestamp" : "0x1ee35285",
+		"parentDifficulty" : "0x2eeaee1edd5c14a3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x1ee352ab",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x2edf336355a4bda0"
+	},
+
+ "DifficultyTest1944" : {
+		"parentTimestamp" : "0x0248125f44",
+		"parentDifficulty" : "0x430a9d1ef59ea95c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0248125f6a",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x42f9da77ade141b4"
+	},
+
+ "DifficultyTest1945" : {
+		"parentTimestamp" : "0x024c2da7e8",
+		"parentDifficulty" : "0x696df07e9e8bf493",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x024c2da80e",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x695395027ee4519b"
+	},
+
+ "DifficultyTest1946" : {
+		"parentTimestamp" : "0x07a6addc74",
+		"parentDifficulty" : "0x577acce1f0ccd5d7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07a6addc9a",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x5764ee2eb850a2ab"
+	},
+
+ "DifficultyTest1947" : {
+		"parentTimestamp" : "0x96d0feea",
+		"parentDifficulty" : "0x30d7f4d4ddab69cf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x96d0ff10",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x30cbbed7a873ff05"
+	},
+
+ "DifficultyTest1948" : {
+		"parentTimestamp" : "0x066c2c4b1a",
+		"parentDifficulty" : "0x74057ba2530c5faa",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x066c2c4b40",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x73e87a436a779cb4"
+	},
+
+ "DifficultyTest1949" : {
+		"parentTimestamp" : "0x046a90c210",
+		"parentDifficulty" : "0x375894ffcd41dde8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x046a90c236",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x374abeda8d4e8db2"
+	},
+
+ "DifficultyTest1950" : {
+		"parentTimestamp" : "0x039bcdda8c",
+		"parentDifficulty" : "0x6dd04bdeec8bba",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039bcddab2",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x6db4d7cbf4d118"
+	},
+
+ "DifficultyTest1951" : {
+		"parentTimestamp" : "0x013d77d3d2",
+		"parentDifficulty" : "0x13984d90efe7cc9f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013d77d3f8",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x1393677d8babd3ad"
+	},
+
+ "DifficultyTest1952" : {
+		"parentTimestamp" : "0x15e88358",
+		"parentDifficulty" : "0x565982d31347d27c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x15e8837e",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x5643ec725e830288"
+	},
+
+ "DifficultyTest1953" : {
+		"parentTimestamp" : "0x017852209d",
+		"parentDifficulty" : "0x45c7b1968543ef7f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01785220c3",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x45b63faa1fa2a285"
+	},
+
+ "DifficultyTest1954" : {
+		"parentTimestamp" : "0x0388450418",
+		"parentDifficulty" : "0x3e1500365b309bd7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x038845043e",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x3e057af64d99cfb1"
+	},
+
+ "DifficultyTest1955" : {
+		"parentTimestamp" : "0x05707d551e",
+		"parentDifficulty" : "0x7b4b2df5a95ae9ee",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05707d5544",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x7b2c5b2a2bf09334"
+	},
+
+ "DifficultyTest1956" : {
+		"parentTimestamp" : "0x4b23cbd6",
+		"parentDifficulty" : "0x7e3e77692ba91b26",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x4b23cbfc",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x7e1ee7cb515e30e0"
+	},
+
+ "DifficultyTest1957" : {
+		"parentTimestamp" : "0x052145e93b",
+		"parentDifficulty" : "0x3614672e04d2c2f6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x052145e961",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x3606e21439518e46"
+	},
+
+ "DifficultyTest1958" : {
+		"parentTimestamp" : "0x03c662a6af",
+		"parentDifficulty" : "0x534237ffa76cbdea",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03c662a6d5",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x532d6771a782e2bc"
+	},
+
+ "DifficultyTest1959" : {
+		"parentTimestamp" : "0xe6e80c99",
+		"parentDifficulty" : "0x5578a857d5b7169e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xe6e80cbf",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x55634a2dbfc1a8da"
+	},
+
+ "DifficultyTest1960" : {
+		"parentTimestamp" : "0x06bb86f58d",
+		"parentDifficulty" : "0x48f07c24bc3935",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06bb86f5b3",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x48de4005b30a27"
+	},
+
+ "DifficultyTest1961" : {
+		"parentTimestamp" : "0x0619be841e",
+		"parentDifficulty" : "0x384dde9b055ca291",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0619be8446",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x3838c1678b3a9fd5"
+	},
+
+ "DifficultyTest1962" : {
+		"parentTimestamp" : "0x04f72925f0",
+		"parentDifficulty" : "0x6cc53e96d1e16dc0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f7292618",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x6c9c749f5952b93a"
+	},
+
+ "DifficultyTest1963" : {
+		"parentTimestamp" : "0x05d1dc6989",
+		"parentDifficulty" : "0x68913e2151bc1bd0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05d1dc69b1",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x686a07aa053d7549"
+	},
+
+ "DifficultyTest1964" : {
+		"parentTimestamp" : "0x0756907b68",
+		"parentDifficulty" : "0x703552791431c19d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0756907b90",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x700b3e7a26ca2ef9"
+	},
+
+ "DifficultyTest1965" : {
+		"parentTimestamp" : "0x057bdaa9f9",
+		"parentDifficulty" : "0x673c467f3a55b834",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x057bdaaa21",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x67158fe4ca9fd817"
+	},
+
+ "DifficultyTest1966" : {
+		"parentTimestamp" : "0x0790ea7ab3",
+		"parentDifficulty" : "0x66168cb3a0da2192",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0790ea7adb",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x65f0443edd7dcfd6"
+	},
+
+ "DifficultyTest1967" : {
+		"parentTimestamp" : "0x045a8e8b37",
+		"parentDifficulty" : "0x0b01f01d6b872bb5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x045a8e8b5f",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x0afdcf63607ed926"
+	},
+
+ "DifficultyTest1968" : {
+		"parentTimestamp" : "0x028e197993",
+		"parentDifficulty" : "0x3d924930feae6d54",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x028e1979bb",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x3d7b32558c4eec2d"
+	},
+
+ "DifficultyTest1969" : {
+		"parentTimestamp" : "0x01c0e05d6a",
+		"parentDifficulty" : "0x44877d0ccb048129",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01c0e05d92",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x446dca3de6385ff9"
+	},
+
+ "DifficultyTest1970" : {
+		"parentTimestamp" : "0x0441ce991d",
+		"parentDifficulty" : "0x2a6f100be7c8c9b0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0441ce9945",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x2a5f2665e351df65"
+	},
+
+ "DifficultyTest1971" : {
+		"parentTimestamp" : "0x01507c78ae",
+		"parentDifficulty" : "0x5823470788c109ee",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01507c78d6",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x580239cce5edc38b"
+	},
+
+ "DifficultyTest1972" : {
+		"parentTimestamp" : "0x03e789de45",
+		"parentDifficulty" : "0x7d7e104c5255cd89",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e789de6d",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x7d4f010635b6f15e"
+	},
+
+ "DifficultyTest1973" : {
+		"parentTimestamp" : "0x05f0ce2b2b",
+		"parentDifficulty" : "0x25c70a037b6ac095",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f0ce2b53",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x25b8df5fba1c808d"
+	},
+
+ "DifficultyTest1974" : {
+		"parentTimestamp" : "0x046f5972e0",
+		"parentDifficulty" : "0x7d74d1564183934f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x046f597308",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x7d45c587c12b11f9"
+	},
+
+ "DifficultyTest1975" : {
+		"parentTimestamp" : "0x05c913cca3",
+		"parentDifficulty" : "0x0b45d6d346e03d3a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05c913cccb",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x0b419ca2b7a5c925"
+	},
+
+ "DifficultyTest1976" : {
+		"parentTimestamp" : "0xa5c90ef6",
+		"parentDifficulty" : "0x2ce0d218185d405e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa5c90f1e",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x2ccffdc94f545d66"
+	},
+
+ "DifficultyTest1977" : {
+		"parentTimestamp" : "0xb089e48a",
+		"parentDifficulty" : "0x7fb825e1cc7ddf07",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb089e4b2",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x7f8840d397d12fd6"
+	},
+
+ "DifficultyTest1978" : {
+		"parentTimestamp" : "0x019cb4a780",
+		"parentDifficulty" : "0x159018c80c0b4f42",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x019cb4a7a8",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x158802bec106cb07"
+	},
+
+ "DifficultyTest1979" : {
+		"parentTimestamp" : "0x593ddae5",
+		"parentDifficulty" : "0x57c2aae3f78741a1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x593ddb0d",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x57a1c1e3e20a6ee9"
+	},
+
+ "DifficultyTest1980" : {
+		"parentTimestamp" : "0xa3bba438",
+		"parentDifficulty" : "0x6459ac24ab9d1eb4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xa3bba460",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x64340a841ddcc3cb"
+	},
+
+ "DifficultyTest1981" : {
+		"parentTimestamp" : "0x05ccf6a2f1",
+		"parentDifficulty" : "0x52a02272a9ec8ef9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ccf6a319",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x52812665beecd646"
+	},
+
+ "DifficultyTest1982" : {
+		"parentTimestamp" : "0x02e0d6e580",
+		"parentDifficulty" : "0x0afbff2abc1688a4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e0d6e5a8",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x0af7e0ab0c100031"
+	},
+
+ "DifficultyTest1983" : {
+		"parentTimestamp" : "0xf0023428",
+		"parentDifficulty" : "0x010a3842839978d8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xf0023450",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x0109d46d6aa81f4b"
+	},
+
+ "DifficultyTest1984" : {
+		"parentTimestamp" : "0x069727f481",
+		"parentDifficulty" : "0x793fe3be347d0d93",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x069727f4a9",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x79126bc8cd295eb0"
+	},
+
+ "DifficultyTest1985" : {
+		"parentTimestamp" : "0x04230ab654",
+		"parentDifficulty" : "0x451d853264de8d82",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04230ab67c",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x45039a2071f8ba0f"
+	},
+
+ "DifficultyTest1986" : {
+		"parentTimestamp" : "0x04dd54027f",
+		"parentDifficulty" : "0x34ce3b054f4b1153",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04dd5402a7",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x34ba6daf2d4d552d"
+	},
+
+ "DifficultyTest1987" : {
+		"parentTimestamp" : "0x06fa5fafbd",
+		"parentDifficulty" : "0x27335afc4ed4d58a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06fa5fafe5",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x2724a7ba303745bc"
+	},
+
+ "DifficultyTest1988" : {
+		"parentTimestamp" : "0x023ff05fab",
+		"parentDifficulty" : "0x0b7f6e29647b6123",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x023ff05fd3",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x0b7b1e6014f5b2df"
+	},
+
+ "DifficultyTest1989" : {
+		"parentTimestamp" : "0x03578cb1fa",
+		"parentDifficulty" : "0x7f29cb839b7fb159",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03578cb222",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x7efa1bd74a256177"
+	},
+
+ "DifficultyTest1990" : {
+		"parentTimestamp" : "0xb236a640",
+		"parentDifficulty" : "0x78bd7113a6b45240",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb236a668",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x78902a093f55cea2"
+	},
+
+ "DifficultyTest1991" : {
+		"parentTimestamp" : "0x055502e25d",
+		"parentDifficulty" : "0x569e429b4888bc1a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x055502e285",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x567dc7424e4d88d5"
+	},
+
+ "DifficultyTest1992" : {
+		"parentTimestamp" : "0x019cc910ec",
+		"parentDifficulty" : "0x45d119c0ade2459b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x019cc91114",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x45b6eb5705a110c4"
+	},
+
+ "DifficultyTest1993" : {
+		"parentTimestamp" : "0x04281f2ee2",
+		"parentDifficulty" : "0x3ad064481b746355",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04281f2f0a",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x3aba5622806a17b3"
+	},
+
+ "DifficultyTest1994" : {
+		"parentTimestamp" : "0x0587c6233b",
+		"parentDifficulty" : "0x077f80ea38086cba",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0587c62363",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x077cb119e0336997"
+	},
+
+ "DifficultyTest1995" : {
+		"parentTimestamp" : "0x044a05e857",
+		"parentDifficulty" : "0x4936fbc9aab39590",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x044a05e87f",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x491b872b3f139242"
+	},
+
+ "DifficultyTest1996" : {
+		"parentTimestamp" : "0x07c0c45be0",
+		"parentDifficulty" : "0x2049d2c46e8f8214",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07c0c45c08",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x203db71564e60c54"
+	},
+
+ "DifficultyTest1997" : {
+		"parentTimestamp" : "0x8ca3dc25",
+		"parentDifficulty" : "0x141ffecdd8cb219b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x8ca3dc4d",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x141872ce4b99d58f"
+	},
+
+ "DifficultyTest1998" : {
+		"parentTimestamp" : "0x04afd0597b",
+		"parentDifficulty" : "0x7632bd61f5eb196f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04afd059a3",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x76066a5af12ee186"
+	},
+
+ "DifficultyTest1999" : {
+		"parentTimestamp" : "0x0568a81f39",
+		"parentDifficulty" : "0x5f6ba6d217a65014",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0568a81f61",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x5f47de7388dd7236"
+	},
+
+ "DifficultyTest2000" : {
+		"parentTimestamp" : "0x06a3d10ce4",
+		"parentDifficulty" : "0x2a19b9403d8ccbb7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06a3d10d0c",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x2a09ef9ac575b7ec"
+	},
+
+ "DifficultyTest2001" : {
+		"parentTimestamp" : "0x05f79e3b6b",
+		"parentDifficulty" : "0x62a77a23671b3ad2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05f79e3b93",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x62827b5599d4929d"
+	},
+
+ "DifficultyTest2002" : {
+		"parentTimestamp" : "0xbda7e3a1",
+		"parentDifficulty" : "0x7ef83ac969518040",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xbda7e3c9",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x7ec89db35dca05b0"
+	},
+
+ "DifficultyTest2003" : {
+		"parentTimestamp" : "0x01f91b9016",
+		"parentDifficulty" : "0x3f3a737d54b43122",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f91b903e",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x3f22bd9205b46d90"
+	},
+
+ "DifficultyTest2004" : {
+		"parentTimestamp" : "0x04088f6bce",
+		"parentDifficulty" : "0x1216a080696e17aa",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04088f6bf6",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x120fd80439468e64"
+	},
+
+ "DifficultyTest2005" : {
+		"parentTimestamp" : "0x04a063177d",
+		"parentDifficulty" : "0x6b5bed05d4775dcb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04a06317a5",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x6b33aa8cf247b10a"
+	},
+
+ "DifficultyTest2006" : {
+		"parentTimestamp" : "0x01733646fb",
+		"parentDifficulty" : "0x011a5231862e0b9d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0173364723",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x0119e852b39bba5a"
+	},
+
+ "DifficultyTest2007" : {
+		"parentTimestamp" : "0x03103de453",
+		"parentDifficulty" : "0x46f2b0c0922023a6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03103de47b",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x46d815be49e9579a"
+	},
+
+ "DifficultyTest2008" : {
+		"parentTimestamp" : "0x028dcc8046",
+		"parentDifficulty" : "0x325c44ac3f4cda8a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x028dcc806e",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x324962127eb51db9"
+	},
+
+ "DifficultyTest2009" : {
+		"parentTimestamp" : "0x05661fd1f9",
+		"parentDifficulty" : "0x0df4903afe3f83a8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05661fd221",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x0def5484e8202bd8"
+	},
+
+ "DifficultyTest2010" : {
+		"parentTimestamp" : "0x0112e59432",
+		"parentDifficulty" : "0x6311fcbf49ccce0f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0112e5945a",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x62ecd60082112144"
+	},
+
+ "DifficultyTest2011" : {
+		"parentTimestamp" : "0x13ecbb29",
+		"parentDifficulty" : "0x5850e439470df206",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x13ecbb51",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x582fc5e3b1934ccd"
+	},
+
+ "DifficultyTest2012" : {
+		"parentTimestamp" : "0x07b3eb4ca8",
+		"parentDifficulty" : "0x5077672a555ae18f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07b3eb4cd0",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x50593a63a57adf7d"
+	},
+
+ "DifficultyTest2013" : {
+		"parentTimestamp" : "0x0338aa4a84",
+		"parentDifficulty" : "0x30abff0af5273edf",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0338aa4aac",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x3099be8b510b502e"
+	},
+
+ "DifficultyTest2014" : {
+		"parentTimestamp" : "0x0636997e7a",
+		"parentDifficulty" : "0x32a11784c0c3fce3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0636997ea2",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x328e1b1beefbb36e"
+	},
+
+ "DifficultyTest2015" : {
+		"parentTimestamp" : "0x046a322e7d",
+		"parentDifficulty" : "0x2f41f62f57cb2073",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x046a322ea5",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x2f303d73060a3457"
+	},
+
+ "DifficultyTest2016" : {
+		"parentTimestamp" : "0x035255cf9c",
+		"parentDifficulty" : "0x4fb41437f4657569",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x035255cfc4",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x4f9630b05f69cf7f"
+	},
+
+ "DifficultyTest2017" : {
+		"parentTimestamp" : "0x01e6b04120",
+		"parentDifficulty" : "0x3ba84388675f0b18",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e6b04148",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x3b91e46f143847b5"
+	},
+
+ "DifficultyTest2018" : {
+		"parentTimestamp" : "0xae0df1b3",
+		"parentDifficulty" : "0x7734313a380f8646",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xae0df1db",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x77077da7c23a80f6"
+	},
+
+ "DifficultyTest2019" : {
+		"parentTimestamp" : "0x02705a3862",
+		"parentDifficulty" : "0x653c93965852880f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02705a388a",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x65169cdefff16a1c"
+	},
+
+ "DifficultyTest2020" : {
+		"parentTimestamp" : "0x0692cfc252",
+		"parentDifficulty" : "0x54e9235f3a217e29",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0692cfc27a",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x54c94bf1f66bb39c"
+	},
+
+ "DifficultyTest2021" : {
+		"parentTimestamp" : "0x03742dc335",
+		"parentDifficulty" : "0x0ed335d4cfcea5ca",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03742dc35d",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x0ecda6a0a000bc4e"
+	},
+
+ "DifficultyTest2022" : {
+		"parentTimestamp" : "0x02f8b5dea5",
+		"parentDifficulty" : "0x055d011b6bd3eedc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02f8b5decd",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x055afe3b018b8765"
+	},
+
+ "DifficultyTest2023" : {
+		"parentTimestamp" : "0x072b69370b",
+		"parentDifficulty" : "0x128832c08786cbc2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x072b693733",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x12813fad7f540937"
+	},
+
+ "DifficultyTest2024" : {
+		"parentTimestamp" : "0x05224b11fb",
+		"parentDifficulty" : "0x0df1898446720e7d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05224b1223",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x0dec4ef0b4d7c3ba"
+	},
+
+ "DifficultyTest2025" : {
+		"parentTimestamp" : "0x072b174d83",
+		"parentDifficulty" : "0x553c160c5047ea05",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x072b174dab",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x551c1f840baa0f0e"
+	},
+
+ "DifficultyTest2026" : {
+		"parentTimestamp" : "0x0658ed2c0c",
+		"parentDifficulty" : "0x03a788f4dc7a1640",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0658ed2c34",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x03a69f129f42f7bc"
+	},
+
+ "DifficultyTest2027" : {
+		"parentTimestamp" : "0x013e533622",
+		"parentDifficulty" : "0x4be3f71230f9b365",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x013e53364a",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x4bd0fe146c6d74f9"
+	},
+
+ "DifficultyTest2028" : {
+		"parentTimestamp" : "0x06b19c59ed",
+		"parentDifficulty" : "0x29f068270cf9eab4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06b19c5a15",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x29e5ec0d0336ac3a"
+	},
+
+ "DifficultyTest2029" : {
+		"parentTimestamp" : "0x06c0062aba",
+		"parentDifficulty" : "0x50658466dd0bebbc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c0062ae2",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x50516b05c354a8c2"
+	},
+
+ "DifficultyTest2030" : {
+		"parentTimestamp" : "0x01a913eb1b",
+		"parentDifficulty" : "0x52adef2d6c5bc4b4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01a913eb43",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x529943b1a100adc4"
+	},
+
+ "DifficultyTest2031" : {
+		"parentTimestamp" : "0x69597ed1",
+		"parentDifficulty" : "0x767506e99e9ef556",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x69597ef9",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x765769a7e4374d9a"
+	},
+
+ "DifficultyTest2032" : {
+		"parentTimestamp" : "0x058513a802",
+		"parentDifficulty" : "0x7893778465ea0804",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x058513a82a",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x787552a684d08d82"
+	},
+
+ "DifficultyTest2033" : {
+		"parentTimestamp" : "0x066e6e6817",
+		"parentDifficulty" : "0x186025991a794dbc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x066e6e683f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x185a0d8fb432af6a"
+	},
+
+ "DifficultyTest2034" : {
+		"parentTimestamp" : "0x8751ea98",
+		"parentDifficulty" : "0x3a70e6e3f8dfec6a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x8751eac0",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x3a624aaa3fe1b470"
+	},
+
+ "DifficultyTest2035" : {
+		"parentTimestamp" : "0x045ca87094",
+		"parentDifficulty" : "0x22efaf6da6fdc775",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045ca870bc",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x22e6f381cb940805"
+	},
+
+ "DifficultyTest2036" : {
+		"parentTimestamp" : "0x042f1a9a18",
+		"parentDifficulty" : "0x032e200e00a67ddb",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x042f1a9a40",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x032d5485fd26543d"
+	},
+
+ "DifficultyTest2037" : {
+		"parentTimestamp" : "0x02ba5edb3b",
+		"parentDifficulty" : "0x297b458fc59b3824",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ba5edb63",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x2970e6be61a9d156"
+	},
+
+ "DifficultyTest2038" : {
+		"parentTimestamp" : "0x017e7ef719",
+		"parentDifficulty" : "0x5c4f3280d45bea1f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x017e7ef741",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x5c381eb43426d325"
+	},
+
+ "DifficultyTest2039" : {
+		"parentTimestamp" : "0x0272b275d4",
+		"parentDifficulty" : "0x3eae4d42e916ab64",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0272b275fc",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x3e9ea1af985c65ba"
+	},
+
+ "DifficultyTest2040" : {
+		"parentTimestamp" : "0x0641ca7b9a",
+		"parentDifficulty" : "0x2c4665f2285bb6f6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0641ca7bc2",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x2c3b5458abd1a00a"
+	},
+
+ "DifficultyTest2041" : {
+		"parentTimestamp" : "0x04e09099a1",
+		"parentDifficulty" : "0x674666d599207594",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04e09099c9",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x672c953be3ba2d79"
+	},
+
+ "DifficultyTest2042" : {
+		"parentTimestamp" : "0x40a4b72c",
+		"parentDifficulty" : "0x265b15f27df3dc9a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x40a4b754",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x26517f2d01545fa6"
+	},
+
+ "DifficultyTest2043" : {
+		"parentTimestamp" : "0x115b4fad",
+		"parentDifficulty" : "0x4a21595af629c258",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x115b4fd5",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x4a0ed1049f6c37ec"
+	},
+
+ "DifficultyTest2044" : {
+		"parentTimestamp" : "0x062dc69045",
+		"parentDifficulty" : "0x7bee83f1a0f505c2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x062dc6906d",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x7bcf8850a48cc88a"
+	},
+
+ "DifficultyTest2045" : {
+		"parentTimestamp" : "0x043e20f07d",
+		"parentDifficulty" : "0x72d0a9cf9c739387",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x043e20f0a5",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x72b3f5a5288c76b3"
+	},
+
+ "DifficultyTest2046" : {
+		"parentTimestamp" : "0xef2edb05",
+		"parentDifficulty" : "0x4737224d452947c2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xef2edb2d",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x47255484b1d7fd92"
+	},
+
+ "DifficultyTest2047" : {
+		"parentTimestamp" : "0x593e21ad",
+		"parentDifficulty" : "0x2a7b64f69e08a4c8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x593e21d5",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2a70c61d606122e0"
+	},
+
+ "DifficultyTest2048" : {
+		"parentTimestamp" : "0x036325f413",
+		"parentDifficulty" : "0x135fcece4a35f35b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x036325f43b",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x135af6da96a3665f"
+	},
+
+ "DifficultyTest2049" : {
+		"parentTimestamp" : "0x03a4aafc8a",
+		"parentDifficulty" : "0x7db3a45bc7bade5a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03a4aafcb2",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x7d943772b0c8f0a4"
+	},
+
+ "DifficultyTest2050" : {
+		"parentTimestamp" : "0x046130ca4d",
+		"parentDifficulty" : "0x790ad31bc5201a82",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x046130ca75",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x78ec9066fe2ed47c"
+	},
+
+ "DifficultyTest2051" : {
+		"parentTimestamp" : "0x0793606bbf",
+		"parentDifficulty" : "0x172330f6b9ca3423",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0793606be7",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x171d682a7c1bc597"
+	},
+
+ "DifficultyTest2052" : {
+		"parentTimestamp" : "0x0146686f5a",
+		"parentDifficulty" : "0x242545a70c02b816",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0146686f82",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x241c3c55a23fb768"
+	},
+
+ "DifficultyTest2053" : {
+		"parentTimestamp" : "0x067be8ad5e",
+		"parentDifficulty" : "0x668482575d535188",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x067be8ad86",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x666ae136c77bfcb4"
+	},
+
+ "DifficultyTest2054" : {
+		"parentTimestamp" : "0x03f445ea08",
+		"parentDifficulty" : "0x75449ff7182d13dd",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03f445ea30",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x75274ecf1a670899"
+	},
+
+ "DifficultyTest2055" : {
+		"parentTimestamp" : "0x7879a4e3",
+		"parentDifficulty" : "0x123869ad0294a4e6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7879a50b",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x1233db929753ffbe"
+	},
+
+ "DifficultyTest2056" : {
+		"parentTimestamp" : "0x0261c9adb2",
+		"parentDifficulty" : "0x360cab3c418d59c1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0261c9adda",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x35ff2811727cf66b"
+	},
+
+ "DifficultyTest2057" : {
+		"parentTimestamp" : "0x04d8d41530",
+		"parentDifficulty" : "0x1894e9df33acd8b8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04d8d41558",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x188ec4a4bbdfed82"
+	},
+
+ "DifficultyTest2058" : {
+		"parentTimestamp" : "0xac1f1c6d",
+		"parentDifficulty" : "0x12ea274f7f52d3ae",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xac1f1c95",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x12e56cc5ab72fefa"
+	},
+
+ "DifficultyTest2059" : {
+		"parentTimestamp" : "0x040efef5a4",
+		"parentDifficulty" : "0x3d12c06157565dc5",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x040efef5ce",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x3cfbd95932d59d64"
+	},
+
+ "DifficultyTest2060" : {
+		"parentTimestamp" : "0xcfdcced1",
+		"parentDifficulty" : "0x7364d9b38ca080f0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xcfdccefb",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x733993e1e94bc4c1"
+	},
+
+ "DifficultyTest2061" : {
+		"parentTimestamp" : "0x2787e42d",
+		"parentDifficulty" : "0x482c642699d35f0a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2787e457",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x481153810b59afcb"
+	},
+
+ "DifficultyTest2062" : {
+		"parentTimestamp" : "0x570039d0",
+		"parentDifficulty" : "0x516d57c81f0fe0a2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x570039fa",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x514ecec734043ab2"
+	},
+
+ "DifficultyTest2063" : {
+		"parentTimestamp" : "0x056ad0d68c",
+		"parentDifficulty" : "0x3e820b4fcb9b10b0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x056ad0d6b6",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x3e6a9a8b8daeb692"
+	},
+
+ "DifficultyTest2064" : {
+		"parentTimestamp" : "0x0780e6f587",
+		"parentDifficulty" : "0x3632055e0b888586",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0780e6f5b1",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x361db29c08443266"
+	},
+
+ "DifficultyTest2065" : {
+		"parentTimestamp" : "0x0709c0e82a",
+		"parentDifficulty" : "0x53c0ea9f9ffbba18",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0709c0e854",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x53a18247a41fbbd3"
+	},
+
+ "DifficultyTest2066" : {
+		"parentTimestamp" : "0xb3b83d02",
+		"parentDifficulty" : "0x53c36fd5969f37ff",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xb3b83d2c",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x53a4068ba686bc8d"
+	},
+
+ "DifficultyTest2067" : {
+		"parentTimestamp" : "0x01411f3e09",
+		"parentDifficulty" : "0x5c00a9820180b446",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01411f3e33",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x5bde294270c02484"
+	},
+
+ "DifficultyTest2068" : {
+		"parentTimestamp" : "0x07dbfb5da4",
+		"parentDifficulty" : "0x519e06aa35c630c9",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07dbfb5dce",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x517f6b67b5f20777"
+	},
+
+ "DifficultyTest2069" : {
+		"parentTimestamp" : "0x05e1f50c45",
+		"parentDifficulty" : "0x4a5db6875f97096f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05e1f50c6f",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x4a41d362ecd332cc"
+	},
+
+ "DifficultyTest2070" : {
+		"parentTimestamp" : "0x02b79bd1d9",
+		"parentDifficulty" : "0x1fc20142414315d7",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02b79bd203",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x1fb61881c86aa0b1"
+	},
+
+ "DifficultyTest2071" : {
+		"parentTimestamp" : "0x051d735aa1",
+		"parentDifficulty" : "0x4064fc5c0734de88",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051d735acb",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x404cd67d64b232b7"
+	},
+
+ "DifficultyTest2072" : {
+		"parentTimestamp" : "0x03091ca7ac",
+		"parentDifficulty" : "0x77a94c04d5b30176",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03091ca7d6",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x777c6c8853e2ee56"
+	},
+
+ "DifficultyTest2073" : {
+		"parentTimestamp" : "0x013d2c503d",
+		"parentDifficulty" : "0x647eabf21fd3d197",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x013d2c5067",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x6458fc71a5080229"
+	},
+
+ "DifficultyTest2074" : {
+		"parentTimestamp" : "0xeee6697f",
+		"parentDifficulty" : "0x201e5bfeece91a1c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xeee669a9",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x2012509c6d5082b3"
+	},
+
+ "DifficultyTest2075" : {
+		"parentTimestamp" : "0x0705285bae",
+		"parentDifficulty" : "0x1e87d644452dd37c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0705285bd8",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x1e7c6353eb93e24e"
+	},
+
+ "DifficultyTest2076" : {
+		"parentTimestamp" : "0x060c61de61",
+		"parentDifficulty" : "0x12319ac78424d64a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060c61de8b",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x122ac82d7953487c"
+	},
+
+ "DifficultyTest2077" : {
+		"parentTimestamp" : "0x01e1a8d31d",
+		"parentDifficulty" : "0x3a5ed1ae72faa4cd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01e1a8d347",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x3a48ee1fd18f86d1"
+	},
+
+ "DifficultyTest2078" : {
+		"parentTimestamp" : "0x035512a585",
+		"parentDifficulty" : "0x5b5ed3440d58e92b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x035512a5af",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x5b3c8fb4d3d3e7d4"
+	},
+
+ "DifficultyTest2079" : {
+		"parentTimestamp" : "0x01e59dcc08",
+		"parentDifficulty" : "0x1cbd45ab88ce29f4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01e59dcc32",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x1cb27eb1687adca5"
+	},
+
+ "DifficultyTest2080" : {
+		"parentTimestamp" : "0x022cf836fb",
+		"parentDifficulty" : "0x3307fc340b977f47",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x022cf83725",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x32f4d9357813267a"
+	},
+
+ "DifficultyTest2081" : {
+		"parentTimestamp" : "0x0161cfcb2d",
+		"parentDifficulty" : "0x3d93a3e223d503d4",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0161cfcb57",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x3d7c8c84af0793f4"
+	},
+
+ "DifficultyTest2082" : {
+		"parentTimestamp" : "0x060bf713c9",
+		"parentDifficulty" : "0x0577673acd8794d3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060bf713f3",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x05755a74177a81fd"
+	},
+
+ "DifficultyTest2083" : {
+		"parentTimestamp" : "0x060051b8c0",
+		"parentDifficulty" : "0x1942167bc0abd95d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x060051b8ea",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x19389db3524398ec"
+	},
+
+ "DifficultyTest2084" : {
+		"parentTimestamp" : "0x05541fae61",
+		"parentDifficulty" : "0x10aa524b007081c6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05541fae8b",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x10a4126c24505796"
+	},
+
+ "DifficultyTest2085" : {
+		"parentTimestamp" : "0x045009e916",
+		"parentDifficulty" : "0x6c678ea4490b8144",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x045009e940",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x6c3ee7cecb701cf4"
+	},
+
+ "DifficultyTest2086" : {
+		"parentTimestamp" : "0x01c3eae81a",
+		"parentDifficulty" : "0x32d7597fd5c074f3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01c3eae844",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x32c448be45d04cc9"
+	},
+
+ "DifficultyTest2087" : {
+		"parentTimestamp" : "0x06c5b14620",
+		"parentDifficulty" : "0x74da21c31489a75e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x06c5b1464a",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x74ae4ff66b61f3c2"
+	},
+
+ "DifficultyTest2088" : {
+		"parentTimestamp" : "0x048b84bca8",
+		"parentDifficulty" : "0x7c47c15edac1615c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x048b84bcd2",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x7c192676572f58d8"
+	},
+
+ "DifficultyTest2089" : {
+		"parentTimestamp" : "0x02f1702d24",
+		"parentDifficulty" : "0x4675d9598a946ed1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02f1702d4e",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x465b6d280900772a"
+	},
+
+ "DifficultyTest2090" : {
+		"parentTimestamp" : "0x05dc7fadb7",
+		"parentDifficulty" : "0x3ecb6ad2924ebfda",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05dc7fade1",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x3eb3de8a8357e256"
+	},
+
+ "DifficultyTest2091" : {
+		"parentTimestamp" : "0x048c9e839e",
+		"parentDifficulty" : "0x160a4fd34a670bdc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x048c9e83c8",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x16020bf55b2b253b"
+	},
+
+ "DifficultyTest2092" : {
+		"parentTimestamp" : "0x0699efc575",
+		"parentDifficulty" : "0x2fe407e1cdc55a69",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0699efc59f",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x2fd2125ed918306c"
+	},
+
+ "DifficultyTest2093" : {
+		"parentTimestamp" : "0x03ba9b3957",
+		"parentDifficulty" : "0x03e08228f2b325e2",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03ba9b3981",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x03df0df8235822be"
+	},
+
+ "DifficultyTest2094" : {
+		"parentTimestamp" : "0x028b23e826",
+		"parentDifficulty" : "0x69630be7bcb70204",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x028b23e850",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x693b86c345d03d74"
+	},
+
+ "DifficultyTest2095" : {
+		"parentTimestamp" : "0x030cd79f4c",
+		"parentDifficulty" : "0x083d5ed777a18720",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x030cd79f76",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x083a47d3e6d4aab0"
+	},
+
+ "DifficultyTest2096" : {
+		"parentTimestamp" : "0x041ad2565d",
+		"parentDifficulty" : "0x61712b07fc226265",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x041ad25687",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x614ca097d923d5c1"
+	},
+
+ "DifficultyTest2097" : {
+		"parentTimestamp" : "0x049fec6514",
+		"parentDifficulty" : "0x558527cf0412fb74",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x049fec653e",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x556515e0167174d7"
+	},
+
+ "DifficultyTest2098" : {
+		"parentTimestamp" : "0x0676c24dde",
+		"parentDifficulty" : "0x33c880887a53f1ff",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0676c24e08",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x33b5155847261385"
+	},
+
+ "DifficultyTest2099" : {
+		"parentTimestamp" : "0x0682cca587",
+		"parentDifficulty" : "0x7d7e845569276998",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0682cca5b1",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x7d4f74e3c91ffcd1"
+	},
+
+ "DifficultyTest2100" : {
+		"parentTimestamp" : "0x01fc28942b",
+		"parentDifficulty" : "0x72770577fbabbfea",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01fc289455",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x724c18d5eead6385"
+	},
+
+ "DifficultyTest2101" : {
+		"parentTimestamp" : "0x01ad0ec214",
+		"parentDifficulty" : "0x7b0576e49a79f33b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01ad0ec23e",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x7ad754d804c00581"
+	},
+
+ "DifficultyTest2102" : {
+		"parentTimestamp" : "0x05270b6c6d",
+		"parentDifficulty" : "0x52d9f671dc839646",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05270b6c97",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x52bae4b571d0e4f0"
+	},
+
+ "DifficultyTest2103" : {
+		"parentTimestamp" : "0x07bc221245",
+		"parentDifficulty" : "0x061ed4291cd02f94",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07bc22126f",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x061c88998d656185"
+	},
+
+ "DifficultyTest2104" : {
+		"parentTimestamp" : "0x05ec17a8a8",
+		"parentDifficulty" : "0x1f594ec90ec73f3c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05ec17a8d2",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x1f4d8d4b8361b487"
+	},
+
+ "DifficultyTest2105" : {
+		"parentTimestamp" : "0x03393e3019",
+		"parentDifficulty" : "0x7c6950809a40e632",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03393e3043",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x7c3aa9026a070dde"
+	},
+
+ "DifficultyTest2106" : {
+		"parentTimestamp" : "0x063ca91225",
+		"parentDifficulty" : "0x4fdcb3921f87bdb3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x063ca9124f",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x4fbec0cec8bbeace"
+	},
+
+ "DifficultyTest2107" : {
+		"parentTimestamp" : "0x0295fb8acf",
+		"parentDifficulty" : "0x0b43e759590109a6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0295fb8af9",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x0b3fade2977fa943"
+	},
+
+ "DifficultyTest2108" : {
+		"parentTimestamp" : "0x05a75442d9",
+		"parentDifficulty" : "0x4f0295a2232608a4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05a7544303",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x4ee4f4aa0658da61"
+	},
+
+ "DifficultyTest2109" : {
+		"parentTimestamp" : "0x68a54f59",
+		"parentDifficulty" : "0x18a783645d62de6b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x68a54f83",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x189e449317bfd95b"
+	},
+
+ "DifficultyTest2110" : {
+		"parentTimestamp" : "0xbf19e4a2",
+		"parentDifficulty" : "0x064b1d8ee53979e5",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xbf19e4cc",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x0648c163cfa3845a"
+	},
+
+ "DifficultyTest2111" : {
+		"parentTimestamp" : "0x078d05f5d9",
+		"parentDifficulty" : "0x78e29a043c67258d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x078d05f603",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x78b5450a7ad07ee5"
+	},
+
+ "DifficultyTest2112" : {
+		"parentTimestamp" : "0x05257b422e",
+		"parentDifficulty" : "0x62bd2021b6681c6a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05257b4258",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x62981935a9c3b569"
+	},
+
+ "DifficultyTest2113" : {
+		"parentTimestamp" : "0x02476bc1f6",
+		"parentDifficulty" : "0x57c08657ebf81856",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02476bc220",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x579f9e258aff9b5d"
+	},
+
+ "DifficultyTest2114" : {
+		"parentTimestamp" : "0x054b3ddc7b",
+		"parentDifficulty" : "0x38a2b04460f62bda",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x054b3ddca5",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x388d73424751cfab"
+	},
+
+ "DifficultyTest2115" : {
+		"parentTimestamp" : "0x06facb4859",
+		"parentDifficulty" : "0x3242ae4ef9e66dac",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06facb4883",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x322fd54d9c48b785"
+	},
+
+ "DifficultyTest2116" : {
+		"parentTimestamp" : "0x394a39bf",
+		"parentDifficulty" : "0x3343f551421cc492",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x394a39e9",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x3330bbd543a3fa4a"
+	},
+
+ "DifficultyTest2117" : {
+		"parentTimestamp" : "0x05596be73b",
+		"parentDifficulty" : "0x11e3ee544e74dd91",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05596be765",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x11dd38daeed772c0"
+	},
+
+ "DifficultyTest2118" : {
+		"parentTimestamp" : "0x0681e83c80",
+		"parentDifficulty" : "0x393d72d073b6c501",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0681e83caa",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x3927fbc5658b6279"
+	},
+
+ "DifficultyTest2119" : {
+		"parentTimestamp" : "0x9359e9d8",
+		"parentDifficulty" : "0x498736b999280fbe",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x9359ea02",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x496ba405138ea4bb"
+	},
+
+ "DifficultyTest2120" : {
+		"parentTimestamp" : "0x05c7c4d193",
+		"parentDifficulty" : "0x242570a9831ae432",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05c7c4d1bd",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x2417e29f4389c21e"
+	},
+
+ "DifficultyTest2121" : {
+		"parentTimestamp" : "0x05aa7ffc47",
+		"parentDifficulty" : "0x08500015b7fef162",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05aa7ffc71",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x084ce215afda01c8"
+	},
+
+ "DifficultyTest2122" : {
+		"parentTimestamp" : "0x06f06e26",
+		"parentDifficulty" : "0x58fd20f6536792d6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06f06e50",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x58dbc209f7086c00"
+	},
+
+ "DifficultyTest2123" : {
+		"parentTimestamp" : "0x03e0f15963",
+		"parentDifficulty" : "0x1c39fbd553835e8d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03e0f1598d",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x1c2f6616e3844d4c"
+	},
+
+ "DifficultyTest2124" : {
+		"parentTimestamp" : "0x06742a6bbd",
+		"parentDifficulty" : "0x4ee42a150e847b39",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06742a6be7",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x4ed0710a8940da1b"
+	},
+
+ "DifficultyTest2125" : {
+		"parentTimestamp" : "0x029538a3be",
+		"parentDifficulty" : "0x378171a60a603eed",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029538a3e8",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x37739149a0dda6df"
+	},
+
+ "DifficultyTest2126" : {
+		"parentTimestamp" : "0x03c1763f5a",
+		"parentDifficulty" : "0x08d7d93259ad0c05",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03c1763f84",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x08d5a33c0d16a0c3"
+	},
+
+ "DifficultyTest2127" : {
+		"parentTimestamp" : "0x054036db38",
+		"parentDifficulty" : "0x3b303682ffb7b3c6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x054036db62",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x3b216a755ef7c5da"
+	},
+
+ "DifficultyTest2128" : {
+		"parentTimestamp" : "0x076cd02171",
+		"parentDifficulty" : "0x1d94a07fc3f4c018",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x076cd0219b",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x1d8d3b57a403c2e8"
+	},
+
+ "DifficultyTest2129" : {
+		"parentTimestamp" : "0x0167b021e4",
+		"parentDifficulty" : "0x7e2da1e692936abc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0167b0220e",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x7e0e167e18eec5e2"
+	},
+
+ "DifficultyTest2130" : {
+		"parentTimestamp" : "0x4a9c047d",
+		"parentDifficulty" : "0x66c4b6b70e5384d3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x4a9c04a7",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x66ab0589608feff3"
+	},
+
+ "DifficultyTest2131" : {
+		"parentTimestamp" : "0x07eab261ac",
+		"parentDifficulty" : "0x358449c923f8a16d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07eab261d6",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x3576e8b6b1afa345"
+	},
+
+ "DifficultyTest2132" : {
+		"parentTimestamp" : "0x06c2169d1d",
+		"parentDifficulty" : "0x12aa6fa959c00d3a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c2169d47",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x12a5c50d6f699d38"
+	},
+
+ "DifficultyTest2133" : {
+		"parentTimestamp" : "0x01e516a7ac",
+		"parentDifficulty" : "0x323fe7ac4b22a7a9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01e516a7d6",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x323357b2600fdf01"
+	},
+
+ "DifficultyTest2134" : {
+		"parentTimestamp" : "0x06b220a45d",
+		"parentDifficulty" : "0x36a71c50119355e2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06b220a487",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x36997288fd8ef10e"
+	},
+
+ "DifficultyTest2135" : {
+		"parentTimestamp" : "0x04c1dded04",
+		"parentDifficulty" : "0x0662c6970590d000",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04c1dded2e",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x06612de55fcf6bcc"
+	},
+
+ "DifficultyTest2136" : {
+		"parentTimestamp" : "0x027c97bbc4",
+		"parentDifficulty" : "0x573614162b7c2c5f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x027c97bbee",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x5720469125f14d55"
+	},
+
+ "DifficultyTest2137" : {
+		"parentTimestamp" : "0x04130d6ba4",
+		"parentDifficulty" : "0x7434659e5b8be850",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04130d6bce",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x74175884f3f50556"
+	},
+
+ "DifficultyTest2138" : {
+		"parentTimestamp" : "0x0787487bd8",
+		"parentDifficulty" : "0x5f56acfd31fdca16",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0787487c02",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x5f3ed751f2b14aa4"
+	},
+
+ "DifficultyTest2139" : {
+		"parentTimestamp" : "0x02803b2e76",
+		"parentDifficulty" : "0x4bb151361973311b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02803b2ea0",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x4b9e64e1cbecd450"
+	},
+
+ "DifficultyTest2140" : {
+		"parentTimestamp" : "0x03b1458fcf",
+		"parentDifficulty" : "0x6ca153fa6856e034",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03b1458ff9",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x6c862ba569bcca7e"
+	},
+
+ "DifficultyTest2141" : {
+		"parentTimestamp" : "0x04fdd83a1e",
+		"parentDifficulty" : "0x2f638594915d3072",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04fdd83a48",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x2f57acb32c38d92a"
+	},
+
+ "DifficultyTest2142" : {
+		"parentTimestamp" : "0x05e06ec8b7",
+		"parentDifficulty" : "0x7c130d11cf895458",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05e06ec8e1",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x7bf4084e8b15720c"
+	},
+
+ "DifficultyTest2143" : {
+		"parentTimestamp" : "0x04b3ec7359",
+		"parentDifficulty" : "0x02f23356dfb19c72",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04b3ec7383",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x02f176ca09f9b01c"
+	},
+
+ "DifficultyTest2144" : {
+		"parentTimestamp" : "0x02ae7ab3b2",
+		"parentDifficulty" : "0x617b84d1b6202507",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02ae7ab3dc",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x616325f081b29d1f"
+	},
+
+ "DifficultyTest2145" : {
+		"parentTimestamp" : "0x0153cb956e",
+		"parentDifficulty" : "0x25634dd56b35929a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0153cb9598",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2559f501f5dac576"
+	},
+
+ "DifficultyTest2146" : {
+		"parentTimestamp" : "0x053fd96fe7",
+		"parentDifficulty" : "0x6fb13550c0d6b15b",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x053fd97011",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x6f9549036ca67c2f"
+	},
+
+ "DifficultyTest2147" : {
+		"parentTimestamp" : "0x04fffccb01",
+		"parentDifficulty" : "0x712ca8b031482bc3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04fffccb2b",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x71105d86053bdab9"
+	},
+
+ "DifficultyTest2148" : {
+		"parentTimestamp" : "0x0765cf4eec",
+		"parentDifficulty" : "0x4265bf1f5d2bad87",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0765cf4f16",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x425525af9554649d"
+	},
+
+ "DifficultyTest2149" : {
+		"parentTimestamp" : "0x039a8b4b51",
+		"parentDifficulty" : "0x36965b494eabaaac",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x039a8b4b7b",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x3688b5b27c5803c2"
+	},
+
+ "DifficultyTest2150" : {
+		"parentTimestamp" : "0x021faf8d2f",
+		"parentDifficulty" : "0x047a198802239697",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x021faf8d59",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x0478fb01a0230db3"
+	},
+
+ "DifficultyTest2151" : {
+		"parentTimestamp" : "0x061fa9731b",
+		"parentDifficulty" : "0x171332b0d9533143",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x061fa97345",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x170d6de42d1cdc77"
+	},
+
+ "DifficultyTest2152" : {
+		"parentTimestamp" : "0x01c5da28cf",
+		"parentDifficulty" : "0x65ed11b8443e9688",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01c5da28f9",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x65d39673d62d86e4"
+	},
+
+ "DifficultyTest2153" : {
+		"parentTimestamp" : "0x06a2a9a99b",
+		"parentDifficulty" : "0x48c2b17498de61",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06a2a9a9c5",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x48b080c83bb82b"
+	},
+
+ "DifficultyTest2154" : {
+		"parentTimestamp" : "0x076dd96cc7",
+		"parentDifficulty" : "0x309aba84245eff04",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x076dd96cf1",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x308e93d58355e746"
+	},
+
+ "DifficultyTest2155" : {
+		"parentTimestamp" : "0x075a9001d8",
+		"parentDifficulty" : "0x6f603ad802fafcc8",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x075a900202",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x6f4462c94cfa3e0a"
+	},
+
+ "DifficultyTest2156" : {
+		"parentTimestamp" : "0x03581ce765",
+		"parentDifficulty" : "0x210d403819c594a2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03581ce78f",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x2104fce80bbf233e"
+	},
+
+ "DifficultyTest2157" : {
+		"parentTimestamp" : "0xdff1b86c",
+		"parentDifficulty" : "0x640abfcf055cb3b1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0xdff1b898",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x63e53bc717bab0ef"
+	},
+
+ "DifficultyTest2158" : {
+		"parentTimestamp" : "0x03ae8dc0ae",
+		"parentDifficulty" : "0x396c03adb1a5ba4f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03ae8dc0da",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x39567b2c50831c2b"
+	},
+
+ "DifficultyTest2159" : {
+		"parentTimestamp" : "0x04f1bcea95",
+		"parentDifficulty" : "0x3ef9b58ec81f1edd",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04f1bceac1",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x3ee217eab2941336"
+	},
+
+ "DifficultyTest2160" : {
+		"parentTimestamp" : "0x02034825e5",
+		"parentDifficulty" : "0x22047ff2d12ad02c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0203482611",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x21f7be42d61c6022"
+	},
+
+ "DifficultyTest2161" : {
+		"parentTimestamp" : "0x05c035f908",
+		"parentDifficulty" : "0x08838f7d2cda81f0",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05c035f934",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x08805e275de9b008"
+	},
+
+ "DifficultyTest2162" : {
+		"parentTimestamp" : "0x0285a3a01d",
+		"parentDifficulty" : "0x16140957e26242c3",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0285a3a049",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x160bc1d4616d5dfb"
+	},
+
+ "DifficultyTest2163" : {
+		"parentTimestamp" : "0x0303a1a5aa",
+		"parentDifficulty" : "0x3047344119a64c23",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0303a1a5d6",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x3035198d813cade8"
+	},
+
+ "DifficultyTest2164" : {
+		"parentTimestamp" : "0x038275c8f3",
+		"parentDifficulty" : "0x3fbf6d1f99a3bac8",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x038275c91f",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0x3fa78556adca1da3"
+	},
+
+ "DifficultyTest2165" : {
+		"parentTimestamp" : "0x03a8f9c629",
+		"parentDifficulty" : "0x42a302eb7b70dedc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03a8f9c655",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x428a05ca6322950b"
+	},
+
+ "DifficultyTest2166" : {
+		"parentTimestamp" : "0x07ad408ace",
+		"parentDifficulty" : "0x7c5b4da369e476ff",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07ad408afa",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x7c2cab664c9cc255"
+	},
+
+ "DifficultyTest2167" : {
+		"parentTimestamp" : "0x0442fbabae",
+		"parentDifficulty" : "0x2b7d80536352417e",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0442fbabda",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x2b6d3143440d04a6"
+	},
+
+ "DifficultyTest2168" : {
+		"parentTimestamp" : "0x05267c7730",
+		"parentDifficulty" : "0x0caa797e275f99ed",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05267c775c",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x0ca5b9909810da14"
+	},
+
+ "DifficultyTest2169" : {
+		"parentTimestamp" : "0x02ca31fac5",
+		"parentDifficulty" : "0x1f014440903c3a3f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02ca31faf1",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x1ef5a3c6f8062baa"
+	},
+
+ "DifficultyTest2170" : {
+		"parentTimestamp" : "0x0499509811",
+		"parentDifficulty" : "0x50e3a24e16d39e6f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x049950983d",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x50c54cf1398b1f16"
+	},
+
+ "DifficultyTest2171" : {
+		"parentTimestamp" : "0x01da36b679",
+		"parentDifficulty" : "0x106f6dc7d84b5977",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01da36b6a5",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x106943fead5a5d36"
+	},
+
+ "DifficultyTest2172" : {
+		"parentTimestamp" : "0x07a5b5ae1b",
+		"parentDifficulty" : "0x2f7330af22e30370",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07a5b5ae47",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x2f61657ce1362e50"
+	},
+
+ "DifficultyTest2173" : {
+		"parentTimestamp" : "0x0179e8e48a",
+		"parentDifficulty" : "0x1e19e96ed97d8912",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0179e8e4b6",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x1e0e9fb74febf9ff"
+	},
+
+ "DifficultyTest2174" : {
+		"parentTimestamp" : "0x051c706702",
+		"parentDifficulty" : "0x2999ba13aff9a921",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x051c70672e",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x298a206de897ab82"
+	},
+
+ "DifficultyTest2175" : {
+		"parentTimestamp" : "0x0744d3f0ec",
+		"parentDifficulty" : "0x07c1af2205790005",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0744d3f118",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x07bec68058b6f2a5"
+	},
+
+ "DifficultyTest2176" : {
+		"parentTimestamp" : "0x2f079bd2",
+		"parentDifficulty" : "0x24c82f4db4fe108a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2f079bfe",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x24ba643bf7da3144"
+	},
+
+ "DifficultyTest2177" : {
+		"parentTimestamp" : "0x027bc91742",
+		"parentDifficulty" : "0x7a0c6b59e6d0f041",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x027bc9176e",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x79dea6b1a51a61e7"
+	},
+
+ "DifficultyTest2178" : {
+		"parentTimestamp" : "0x040642d659",
+		"parentDifficulty" : "0x26b60185d98ed30a",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x040642d685",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x26a77d45475d3d7c"
+	},
+
+ "DifficultyTest2179" : {
+		"parentTimestamp" : "0x04b27664e4",
+		"parentDifficulty" : "0x301e439f95f84f40",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04b2766510",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x300c38463a201225"
+	},
+
+ "DifficultyTest2180" : {
+		"parentTimestamp" : "0x0698c5e663",
+		"parentDifficulty" : "0x574c1a8adedc0fba",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0698c5e68f",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x572b5e00eac87d37"
+	},
+
+ "DifficultyTest2181" : {
+		"parentTimestamp" : "0x3a5efc3e",
+		"parentDifficulty" : "0x487d17f8dfd91905",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x3a5efc6a",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x4861e90fe285279c"
+	},
+
+ "DifficultyTest2182" : {
+		"parentTimestamp" : "0x062ad9b480",
+		"parentDifficulty" : "0x7c206e4c7cdee496",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x062ad9b4ac",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x7bf1e22320301102"
+	},
+
+ "DifficultyTest2183" : {
+		"parentTimestamp" : "0x04e1b50dca",
+		"parentDifficulty" : "0x3a28707b6259e659",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04e1b50df6",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x3a12a151341504a5"
+	},
+
+ "DifficultyTest2184" : {
+		"parentTimestamp" : "0x4320015e",
+		"parentDifficulty" : "0x71e3b22bb0b1fa3b",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x4320018a",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x71b8fcc8e04fb77e"
+	},
+
+ "DifficultyTest2185" : {
+		"parentTimestamp" : "0x7e80ff3d",
+		"parentDifficulty" : "0x37325953a32d56d1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x7e80ff69",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x371da67223d025d3"
+	},
+
+ "DifficultyTest2186" : {
+		"parentTimestamp" : "0x0341981f02",
+		"parentDifficulty" : "0x517219a7b181af49",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0341981f2e",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x51538ede129f1eaa"
+	},
+
+ "DifficultyTest2187" : {
+		"parentTimestamp" : "0x07568da9d0",
+		"parentDifficulty" : "0x3fcae1bf4e8cf9d6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x07568da9fc",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x3fb2f5aaa6cf84f9"
+	},
+
+ "DifficultyTest2188" : {
+		"parentTimestamp" : "0x027c48acdb",
+		"parentDifficulty" : "0x35b85efda9e05fbe",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x027c48ad07",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x35a439da0ac0ab9e"
+	},
+
+ "DifficultyTest2189" : {
+		"parentTimestamp" : "0x01f2ff4aba",
+		"parentDifficulty" : "0x7d267f1f7c28f184",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x01f2ff4ae6",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x7cf790afd05a622c"
+	},
+
+ "DifficultyTest2190" : {
+		"parentTimestamp" : "0x034c388390",
+		"parentDifficulty" : "0x56b789ceed4b9adb",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x034c3883bc",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x569704fb3fb29e86"
+	},
+
+ "DifficultyTest2191" : {
+		"parentTimestamp" : "0x02aba5c1cf",
+		"parentDifficulty" : "0x2b7360283c8140e6",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02aba5c1fb",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x2b6314e42d6a9076"
+	},
+
+ "DifficultyTest2192" : {
+		"parentTimestamp" : "0x03e5efad94",
+		"parentDifficulty" : "0x7c99f4f657a55107",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03e5efadc0",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x7c6b3b3a7b447319"
+	},
+
+ "DifficultyTest2193" : {
+		"parentTimestamp" : "0x02e1291afa",
+		"parentDifficulty" : "0x394feb888aa0db54",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x02e1291b26",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x393a6d90376cdf23"
+	},
+
+ "DifficultyTest2194" : {
+		"parentTimestamp" : "0x72c9f272",
+		"parentDifficulty" : "0x2ae64319c5dbf01f",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x72c9f29e",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0x2ad62cc09c31bde5"
+	},
+
+ "DifficultyTest2195" : {
+		"parentTimestamp" : "0x03290d83b6",
+		"parentDifficulty" : "0x5abd1261a569a4bc",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x03290d83e2",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x5a9b0b7ac0cb9da0"
+	},
+
+ "DifficultyTest2196" : {
+		"parentTimestamp" : "0x2cd6da18",
+		"parentDifficulty" : "0x26937e90358676ad",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x2cd6da44",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x26850740bf726543"
+	},
+
+ "DifficultyTest2197" : {
+		"parentTimestamp" : "0x05202aa1c2",
+		"parentDifficulty" : "0x0641678745305131",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x05202aa1ee",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x063f0f0072766113"
+	},
+
+ "DifficultyTest2198" : {
+		"parentTimestamp" : "0x026d6e028d",
+		"parentDifficulty" : "0x7ea397d521efa49d",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x026d6e02b9",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x7e741a7c3202eec1"
+	},
+
+ "DifficultyTest2199" : {
+		"parentTimestamp" : "0x04de783082",
+		"parentDifficulty" : "0x44732ee5d7a7317c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04de7830ae",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x445983b4417652ca"
+	},
+
+ "DifficultyTest2200" : {
+		"parentTimestamp" : "0x018762c5be",
+		"parentDifficulty" : "0x093003408c615f87",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x018762c5ea",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x092c913f542cbb06"
+	},
+
+ "DifficultyTest2201" : {
+		"parentTimestamp" : "0x6dc9026e",
+		"parentDifficulty" : "0x1e604e8a55497dc1",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x6dc9029a",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x1e54ea6ce1698234"
+	},
+
+ "DifficultyTest2202" : {
+		"parentTimestamp" : "0x0631e2bbd5",
+		"parentDifficulty" : "0x0d1e2de0b66b6890",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0631e2bc01",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x0d19428f82270049"
+	},
+
+ "DifficultyTest2203" : {
+		"parentTimestamp" : "0x04a65b23f9",
+		"parentDifficulty" : "0x683a02bdef28609c",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x04a65b2425",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x6812ecfce7eeb178"
+	},
+
+ "DifficultyTest2204" : {
+		"parentTimestamp" : "0x0163c05adb",
+		"parentDifficulty" : "0x2dee8b339587cb96",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x0163c05b07",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x2ddd51bf622fb8ab"
+	},
+
+ "DifficultyTest2205" : {
+		"parentTimestamp" : "0x5fab2b3e",
+		"parentDifficulty" : "0x21e06893cd078a71",
+		"parentUncles" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"currentTimestamp" : "0x5fab2b6a",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x21d3b46c959aa79e"
+	},
+
+ "DifficultyTest2206" : {
+		"parentTimestamp" : "0x7a57bc26",
+		"parentDifficulty" : "0x0ba834ab246c5cf0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x7a57bc52",
+		"currentBlockNumber" : "0x0186a0",
+		"currentDifficulty" : "0x0ba3d597643eb44f"
+	},
+
+ "DifficultyTest2207" : {
+		"parentTimestamp" : "0x0490a59994",
+		"parentDifficulty" : "0x5004b1f0c31f2aa1",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0490a599c0",
+		"currentBlockNumber" : "0x030d40",
+		"currentDifficulty" : "0x4fe6b02e08d5fef3"
+	},
+
+ "DifficultyTest2208" : {
+		"parentTimestamp" : "0x66741c22",
+		"parentDifficulty" : "0x63967beef79fb870",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x66741c4e",
+		"currentBlockNumber" : "0x0493e0",
+		"currentDifficulty" : "0x637123807e02dc8d"
+	},
+
+ "DifficultyTest2209" : {
+		"parentTimestamp" : "0xd0254d1b",
+		"parentDifficulty" : "0x481bf314364bad5e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xd0254d47",
+		"currentBlockNumber" : "0x061a80",
+		"currentDifficulty" : "0x4800e8990eb75103"
+	},
+
+ "DifficultyTest2210" : {
+		"parentTimestamp" : "0x04481a9cab",
+		"parentDifficulty" : "0x5c2ff4ee3420affc",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04481a9cd7",
+		"currentBlockNumber" : "0x07a120",
+		"currentDifficulty" : "0x5c0d62f25acd23c5"
+	},
+
+ "DifficultyTest2211" : {
+		"parentTimestamp" : "0x045c8af3ae",
+		"parentDifficulty" : "0x5e61d32701071f9e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045c8af3da",
+		"currentBlockNumber" : "0x0927c0",
+		"currentDifficulty" : "0x5e3e6e77d266bd05"
+	},
+
+ "DifficultyTest2212" : {
+		"parentTimestamp" : "0x065bda8e8c",
+		"parentDifficulty" : "0x2cb31190b15c12a0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x065bda8eb8",
+		"currentBlockNumber" : "0x0aae60",
+		"currentDifficulty" : "0x2ca24e6a1b19903a"
+	},
+
+ "DifficultyTest2213" : {
+		"parentTimestamp" : "0x055524f9e5",
+		"parentDifficulty" : "0xce10999b3566f9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x055524fa11",
+		"currentBlockNumber" : "0x0c3500",
+		"currentDifficulty" : "0xcdc353619b3335"
+	},
+
+ "DifficultyTest2214" : {
+		"parentTimestamp" : "0xcf7ebea2",
+		"parentDifficulty" : "0x6307bd720c5d3a82",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xcf7ebece",
+		"currentBlockNumber" : "0x0dbba0",
+		"currentDifficulty" : "0x62e29a8b0198980d"
+	},
+
+ "DifficultyTest2215" : {
+		"parentTimestamp" : "0x063d0e2af3",
+		"parentDifficulty" : "0x3833f61100bf9297",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x063d0e2b1f",
+		"currentBlockNumber" : "0x0f4240",
+		"currentDifficulty" : "0x381ee294ba5f4bc1"
+	},
+
+ "DifficultyTest2216" : {
+		"parentTimestamp" : "0x060e787733",
+		"parentDifficulty" : "0x52908b5c19741771",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x060e78775f",
+		"currentBlockNumber" : "0x10c8e0",
+		"currentDifficulty" : "0x52719527d6ea8deb"
+	},
+
+ "DifficultyTest2217" : {
+		"parentTimestamp" : "0x02d1ebba86",
+		"parentDifficulty" : "0x4ed1b13af8d5f561",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02d1ebbab2",
+		"currentBlockNumber" : "0x124f80",
+		"currentDifficulty" : "0x4eb4229882b8a927"
+	},
+
+ "DifficultyTest2218" : {
+		"parentTimestamp" : "0x363a2fe7",
+		"parentDifficulty" : "0x6f3f95b8a7e9dd60",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x363a3013",
+		"currentBlockNumber" : "0x13d620",
+		"currentDifficulty" : "0x6f15dde082aaedaf"
+	},
+
+ "DifficultyTest2219" : {
+		"parentTimestamp" : "0x03266ae42c",
+		"parentDifficulty" : "0x714ea0c115b7a58e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03266ae458",
+		"currentBlockNumber" : "0x155cc0",
+		"currentDifficulty" : "0x71242344cd4f90b2"
+	},
+
+ "DifficultyTest2220" : {
+		"parentTimestamp" : "0x03ffd2a079",
+		"parentDifficulty" : "0x6587a748bb7dea7e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03ffd2a0a5",
+		"currentBlockNumber" : "0x16e360",
+		"currentDifficulty" : "0x6561946a0037bb47"
+	},
+
+ "DifficultyTest2221" : {
+		"parentTimestamp" : "0x029343f600",
+		"parentDifficulty" : "0x0283f5878261dcfe",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x029343f62c",
+		"currentBlockNumber" : "0x186a00",
+		"currentDifficulty" : "0x0283040b6f91384d"
+	},
+
+ "DifficultyTest2222" : {
+		"parentTimestamp" : "0x510c0325",
+		"parentDifficulty" : "0x4a599e9d1604e2d7",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x510c0351",
+		"currentBlockNumber" : "0x19f0a0",
+		"currentDifficulty" : "0x4a4708356ebf619f"
+	},
+
+ "DifficultyTest2223" : {
+		"parentTimestamp" : "0x010fe3c227",
+		"parentDifficulty" : "0x47737048fd8d0b07",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x010fe3c253",
+		"currentBlockNumber" : "0x1b7740",
+		"currentDifficulty" : "0x4761936ceb4da7c5"
+	},
+
+ "DifficultyTest2224" : {
+		"parentTimestamp" : "0x02cc4bab87",
+		"parentDifficulty" : "0x487a6225ac5cba86",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02cc4babb3",
+		"currentBlockNumber" : "0x1cfde0",
+		"currentDifficulty" : "0x4868438d22f1a358"
+	},
+
+ "DifficultyTest2225" : {
+		"parentTimestamp" : "0x011ced0fb4",
+		"parentDifficulty" : "0x187b4871c0a1424e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x011ced0fe0",
+		"currentBlockNumber" : "0x1e8480",
+		"currentDifficulty" : "0x1875299fa43119fe"
+	},
+
+ "DifficultyTest2226" : {
+		"parentTimestamp" : "0xcdf98c42",
+		"parentDifficulty" : "0x1980abe5b20d3e0f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xcdf98c6e",
+		"currentBlockNumber" : "0x200b20",
+		"currentDifficulty" : "0x197a4bbab8a0bac1"
+	},
+
+ "DifficultyTest2227" : {
+		"parentTimestamp" : "0x04c58b3083",
+		"parentDifficulty" : "0x33a76c628e5d260a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x04c58b30af",
+		"currentBlockNumber" : "0x2191c0",
+		"currentDifficulty" : "0x339a828775b98ec2"
+	},
+
+ "DifficultyTest2228" : {
+		"parentTimestamp" : "0x06061ce7d4",
+		"parentDifficulty" : "0x2f6676ddd71260a2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06061ce800",
+		"currentBlockNumber" : "0x231860",
+		"currentDifficulty" : "0x2f5a9d401f9c9c0a"
+	},
+
+ "DifficultyTest2229" : {
+		"parentTimestamp" : "0x03688f3e0d",
+		"parentDifficulty" : "0x3a29ab0fb6593471",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03688f3e39",
+		"currentBlockNumber" : "0x249f00",
+		"currentDifficulty" : "0x3a1b20a4f26b9e25"
+	},
+
+ "DifficultyTest2230" : {
+		"parentTimestamp" : "0x01b4dbe052",
+		"parentDifficulty" : "0x02de36db6489cf5c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01b4dbe07e",
+		"currentBlockNumber" : "0x2625a0",
+		"currentDifficulty" : "0x02dd7f4dadb0acea"
+	},
+
+ "DifficultyTest2231" : {
+		"parentTimestamp" : "0x05499cd83c",
+		"parentDifficulty" : "0x013878f2f26e9bca",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05499cd868",
+		"currentBlockNumber" : "0x27ac40",
+		"currentDifficulty" : "0x01382ad4b5b20024"
+	},
+
+ "DifficultyTest2232" : {
+		"parentTimestamp" : "0x010709472f",
+		"parentDifficulty" : "0x3cbf04e21e249a0d",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x010709475b",
+		"currentBlockNumber" : "0x2932e0",
+		"currentDifficulty" : "0x3cafd520e59d10e7"
+	},
+
+ "DifficultyTest2233" : {
+		"parentTimestamp" : "0x06d43c006c",
+		"parentDifficulty" : "0x111a1242fec0d4f3",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06d43c0098",
+		"currentBlockNumber" : "0x2ab980",
+		"currentDifficulty" : "0x1115cbbe6e0124bf"
+	},
+
+ "DifficultyTest2234" : {
+		"parentTimestamp" : "0x06f43b909d",
+		"parentDifficulty" : "0x620e626b0b6daff6",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06f43b90c9",
+		"currentBlockNumber" : "0x2c4020",
+		"currentDifficulty" : "0x61f5ded270aad48c"
+	},
+
+ "DifficultyTest2235" : {
+		"parentTimestamp" : "0x2de1c56b",
+		"parentDifficulty" : "0x4ca9dd0e860155ab",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x2de1c597",
+		"currentBlockNumber" : "0x2dc6c0",
+		"currentDifficulty" : "0x4c96b297425fd557"
+	},
+
+ "DifficultyTest2236" : {
+		"parentTimestamp" : "0x0764b45a30",
+		"parentDifficulty" : "0x26cc3b99685f6f43",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0764b45a5c",
+		"currentBlockNumber" : "0x2f4d60",
+		"currentDifficulty" : "0x26c2888a82055769"
+	},
+
+ "DifficultyTest2237" : {
+		"parentTimestamp" : "0x0173ee548a",
+		"parentDifficulty" : "0x340ef7756546d476",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0173ee54b6",
+		"currentBlockNumber" : "0x30d400",
+		"currentDifficulty" : "0x3401f3b787ed82c3"
+	},
+
+ "DifficultyTest2238" : {
+		"parentTimestamp" : "0x06c530ae22",
+		"parentDifficulty" : "0x6c36a2ab198c7113",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x06c530ae4e",
+		"currentBlockNumber" : "0x325aa0",
+		"currentDifficulty" : "0x6c1b95026ec60df9"
+	},
+
+ "DifficultyTest2239" : {
+		"parentTimestamp" : "0x045bf98f95",
+		"parentDifficulty" : "0x7c0ce8ddb3510981",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x045bf98fc1",
+		"currentBlockNumber" : "0x33e140",
+		"currentDifficulty" : "0x7bede5a37be43543"
+	},
+
+ "DifficultyTest2240" : {
+		"parentTimestamp" : "0x076b695e11",
+		"parentDifficulty" : "0x72fedb8f372b0802",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x076b695e3d",
+		"currentBlockNumber" : "0x3567e0",
+		"currentDifficulty" : "0x72e21bd8535d3d48"
+	},
+
+ "DifficultyTest2241" : {
+		"parentTimestamp" : "0x03766a40c4",
+		"parentDifficulty" : "0x2a6d5dae733a4311",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03766a40f0",
+		"currentBlockNumber" : "0x36ee80",
+		"currentDifficulty" : "0x2a62c257079d7491"
+	},
+
+ "DifficultyTest2242" : {
+		"parentTimestamp" : "0x040984d8e2",
+		"parentDifficulty" : "0x56e3e345cbb1278a",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x040984d90e",
+		"currentBlockNumber" : "0x387520",
+		"currentDifficulty" : "0x56ce2a4cfa3e3b62"
+	},
+
+ "DifficultyTest2243" : {
+		"parentTimestamp" : "0x03608e9506",
+		"parentDifficulty" : "0xbb6482c0b8b266",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03608e9532",
+		"currentBlockNumber" : "0x39fbc0",
+		"currentDifficulty" : "0xbb35a9a008847a"
+	},
+
+ "DifficultyTest2244" : {
+		"parentTimestamp" : "0x02b845589f",
+		"parentDifficulty" : "0x339112f882397d8c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x02b84558cb",
+		"currentBlockNumber" : "0x3b8260",
+		"currentDifficulty" : "0x33842eb3c418efae"
+	},
+
+ "DifficultyTest2245" : {
+		"parentTimestamp" : "0x03f6b64940",
+		"parentDifficulty" : "0x4c47908f810512f9",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x03f6b6496c",
+		"currentBlockNumber" : "0x3d0900",
+		"currentDifficulty" : "0x4c347eab5d24d2b5"
+	},
+
+ "DifficultyTest2246" : {
+		"parentTimestamp" : "0x05dfcc563e",
+		"parentDifficulty" : "0x0bea0a7a239f1f55",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x05dfcc566a",
+		"currentBlockNumber" : "0x3e8fa0",
+		"currentDifficulty" : "0x0be70ff78516398f"
+	},
+
+ "DifficultyTest2247" : {
+		"parentTimestamp" : "0x028ca690ed",
+		"parentDifficulty" : "0x0e873547bcf8a0",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x028ca69119",
+		"currentBlockNumber" : "0x401640",
+		"currentDifficulty" : "0x0e83937a6b0d62"
+	},
+
+ "DifficultyTest2248" : {
+		"parentTimestamp" : "0x10c5150d",
+		"parentDifficulty" : "0x528aa79da3f3f82e",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x10c51539",
+		"currentBlockNumber" : "0x419ce0",
+		"currentDifficulty" : "0x527604f3bc8afb30"
+	},
+
+ "DifficultyTest2249" : {
+		"parentTimestamp" : "0x01ec922769",
+		"parentDifficulty" : "0x65612d63b3cf15d2",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01ec922795",
+		"currentBlockNumber" : "0x432380",
+		"currentDifficulty" : "0x6547d5185ae2220e"
+	},
+
+ "DifficultyTest2250" : {
+		"parentTimestamp" : "0x07657f95e9",
+		"parentDifficulty" : "0x67cf43ab4546a505",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x07657f9615",
+		"currentBlockNumber" : "0x44aa20",
+		"currentDifficulty" : "0x67b54fda5a75535d"
+	},
+
+ "DifficultyTest2251" : {
+		"parentTimestamp" : "0xa29249b5",
+		"parentDifficulty" : "0x34e1fe0c33d6024c",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xa29249e1",
+		"currentBlockNumber" : "0x4630c0",
+		"currentDifficulty" : "0x34d4c58cb0c90ccc"
+	},
+
+ "DifficultyTest2252" : {
+		"parentTimestamp" : "0xc78b0d16",
+		"parentDifficulty" : "0x5be8ce8c5482f50f",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0xc78b0d42",
+		"currentBlockNumber" : "0x47b760",
+		"currentDifficulty" : "0x5bd1d458b16dd453"
+	},
+
+ "DifficultyTest2253" : {
+		"parentTimestamp" : "0x01a021670d",
+		"parentDifficulty" : "0x06846c4b794c2fee",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x01a0216739",
+		"currentBlockNumber" : "0x493e00",
+		"currentDifficulty" : "0x0682cb30666ddce4"
+	},
+
+ "DifficultyTest2254" : {
+		"parentTimestamp" : "0x0448f7f82c",
+		"parentDifficulty" : "0x654e07e951479ee4",
+		"parentUncles" : "0xb474a45ef82026d18138c2f23fee5586c9c7449f33f865e8838572ae06ffc7e9",
+		"currentTimestamp" : "0x0448f7f858",
+		"currentBlockNumber" : "0x4ac4a0",
+		"currentDifficulty" : "0x6534b46756f34cfe"
+	}
+
+}

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -2,7 +2,7 @@ import
   macrocache, strutils, unittest2,
   stew/byteutils, chronicles, stew/ranges, eth/common,
   ../nimbus/vm/interpreter/opcode_values,
-  stew/shims/macros
+  stew/shims/macros, ../nimbus/config
 
 import
   options, json, os, eth/trie/[db, hexary],
@@ -201,7 +201,7 @@ proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, 
     if forkOverride.isSome:
       forkOverride.get
     else:
-      vmState.blockNumber.toFork
+      vmState.chainDB.config.toFork(vmState.blockNumber)
 
   let gasUsed = 0 #tx.payload.intrinsicGas.GasInt + gasFees[fork][GasTXCreate]
 
@@ -225,7 +225,7 @@ proc initComputation(vmState: BaseVMState, tx: Transaction, sender: EthAddress, 
 
   vmState.mutateStateDb:
     db.setCode(contractAddress, tx.payload.toRange)
-    
+
   newComputation(vmState, msg)
 
 proc initDatabase*(): (Uint256, BaseChainDB) =

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -16,7 +16,8 @@ import
   ../nimbus/[vm_state, utils, vm_types, errors, transaction, constants],
   ../nimbus/db/[db_chain, state_db],
   ../nimbus/utils/header,
-  ../nimbus/p2p/executor
+  ../nimbus/p2p/[executor, dao],
+  ../nimbus/config
 
 type
   SealEngine = enum
@@ -51,6 +52,7 @@ type
     trace: bool
     vmState: BaseVMState
     debugData: JsonNode
+    network: string
 
   MiningHeader* = object
     parentHash*:    Hash256
@@ -187,21 +189,65 @@ proc parseBlocks(blocks: JsonNode, testStatusIMPL: var TestStatus): seq[TesterBl
 
     result.add t
 
-func vmConfiguration(network: string): VMConfig =
+func vmConfiguration(network: string, c: var ChainConfig): VMConfig =
+
+  c.homesteadBlock = high(BlockNumber)
+  c.daoForkBlock = high(BlockNumber)
+  c.daoForkSupport = false
+  c.eip150Block = high(BlockNumber)
+  c.eip158Block = high(BlockNumber)
+  c.byzantiumBlock = high(BlockNumber)
+  c.constantinopleBlock = high(BlockNumber)
+  c.petersburgBlock = high(BlockNumber)
+  c.istanbulBlock = high(BlockNumber)
+  c.muirGlacierBlock = high(BlockNumber)
+
   case network
-  of "EIP150": result = [(0, FkTangerine), (0, FkTangerine)]
-  of "ConstantinopleFix": result = [(0, FkPetersburg), (0, FkPetersburg)]
-  of "Homestead": result = [(0, FkHomestead), (0, FkHomestead)]
-  of "Frontier": result = [(0, FkFrontier), (0, FkFrontier)]
-  of "Byzantium": result = [(0, FkByzantium), (0, FkByzantium)]
-  of "EIP158ToByzantiumAt5": result = [(0, FkSpurious), (5, FkByzantium)]
-  of "EIP158": result = [(0, FkSpurious), (0, FkSpurious)]
-  of "HomesteadToDaoAt5": result = [(0, FkHomestead), (5, FkHomestead)]
-  of "Constantinople": result = [(0, FkConstantinople), (0, FkConstantinople)]
-  of "HomesteadToEIP150At5": result = [(0, FkHomestead), (5, FkTangerine)]
-  of "FrontierToHomesteadAt5": result = [(0, FkFrontier), (5, FkHomestead)]
-  of "ByzantiumToConstantinopleFixAt5": result = [(0, FkByzantium), (5, FkPetersburg)]
-  of "Istanbul": result = [(0, FkIstanbul), (0, FkIstanbul)]
+  of "EIP150":
+    result = [(0, FkTangerine), (0, FkTangerine)]
+    c.eip150Block = 0.toBlockNumber
+  of "ConstantinopleFix":
+    result = [(0, FkPetersburg), (0, FkPetersburg)]
+    c.petersburgBlock = 0.toBlockNumber
+  of "Homestead":
+    result = [(0, FkHomestead), (0, FkHomestead)]
+    c.homesteadBlock = 0.toBlockNumber
+  of "Frontier":
+    result = [(0, FkFrontier), (0, FkFrontier)]
+    #c.frontierBlock = 0.toBlockNumber
+  of "Byzantium":
+    result = [(0, FkByzantium), (0, FkByzantium)]
+    c.byzantiumBlock = 0.toBlockNumber
+  of "EIP158ToByzantiumAt5":
+    result = [(0, FkSpurious), (5, FkByzantium)]
+    c.eip158Block = 0.toBlockNumber
+    c.byzantiumBlock = 5.toBlockNumber
+  of "EIP158":
+    result = [(0, FkSpurious), (0, FkSpurious)]
+    c.eip158Block = 0.toBlockNumber
+  of "HomesteadToDaoAt5":
+    result = [(0, FkHomestead), (5, FkHomestead)]
+    c.homesteadBlock = 0.toBlockNumber
+    c.daoForkBlock = 5.toBlockNumber
+    c.daoForkSupport = true
+  of "Constantinople":
+    result = [(0, FkConstantinople), (0, FkConstantinople)]
+    c.constantinopleBlock = 0.toBlockNumber
+  of "HomesteadToEIP150At5":
+    result = [(0, FkHomestead), (5, FkTangerine)]
+    c.homesteadBlock = 0.toBlockNumber
+    c.eip150Block = 5.toBlockNumber
+  of "FrontierToHomesteadAt5":
+    result = [(0, FkFrontier), (5, FkHomestead)]
+    #c.frontierBlock = 0.toBlockNumber
+    c.homesteadBlock = 5.toBlockNumber
+  of "ByzantiumToConstantinopleFixAt5":
+    result = [(0, FkByzantium), (5, FkPetersburg)]
+    c.byzantiumBlock = 0.toBlockNumber
+    c.petersburgBlock = 5.toBlockNumber
+  of "Istanbul":
+    result = [(0, FkIstanbul), (0, FkIstanbul)]
+    c.istanbulBlock = 0.toBlockNumber
   else:
     raise newException(ValueError, "unsupported network")
 
@@ -223,8 +269,7 @@ proc parseTester(fixture: JsonNode, testStatusIMPL: var TestStatus): Tester =
 
   if "sealEngine" in fixture:
     result.sealEngine = some(parseEnum[SealEngine](fixture["sealEngine"].getStr))
-  let network = fixture["network"].getStr
-  result.vmConfig = vmConfiguration(network)
+  result.network = fixture["network"].getStr
 
   try:
     result.blocks = parseBlocks(fixture["blocks"], testStatusIMPL)
@@ -232,8 +277,8 @@ proc parseTester(fixture: JsonNode, testStatusIMPL: var TestStatus): Tester =
     result.good = false
 
   # TODO: implement missing VM
-  if network in ["HomesteadToDaoAt5"]:
-    result.good = false
+  #if result.network in ["HomesteadToDaoAt5"]:
+    #result.good = false
 
 proc assignBlockRewards(minedBlock: PlainBlock, vmState: BaseVMState, fork: Fork, chainDB: BaseChainDB) =
   let blockReward = blockRewards[fork]
@@ -274,6 +319,10 @@ proc assignBlockRewards(minedBlock: PlainBlock, vmState: BaseVMState, fork: Fork
 proc processBlock(chainDB: BaseChainDB, vmState: BaseVMState, minedBlock: PlainBlock, fork: Fork) =
   var dbTx = chainDB.db.beginTransaction()
   defer: dbTx.dispose()
+
+  if chainDB.config.daoForkSupport and minedBlock.header.blockNumber == chainDB.config.daoForkBlock:
+    vmState.mutateStateDB:
+      db.applyDAOHardFork()
 
   vmState.receipts = newSeq[Receipt](minedBlock.transactions.len)
   vmState.cumulativeGasUsed = 0
@@ -511,7 +560,7 @@ proc importBlock(tester: var Tester, chainDB: BaseChainDB,
   let parentHeader = chainDB.getBlockHeader(preminedBlock.header.parentHash)
   let baseHeaderForImport = generateHeaderFromParentHeader(chainDB.config,
       parentHeader,
-      preminedBlock.header.coinbase,  
+      preminedBlock.header.coinbase,
       some(preminedBlock.header.timestamp),
       some(preminedBlock.header.gasLimit),
       @[]
@@ -537,6 +586,10 @@ proc importBlock(tester: var Tester, chainDB: BaseChainDB,
 
 proc applyFixtureBlockToChain(tester: var Tester, tb: TesterBlock,
   chainDB: BaseChainDB, checkSeal, validation = true): (PlainBlock, PlainBlock, Blob) =
+
+  # we hack the ChainConfig here and let it works with calcDifficulty
+  tester.vmConfig = vmConfiguration(tester.network, chainDB.config)
+
   var
     preminedBlock = rlp.decode(tb.headerRLP, PlainBlock)
     fork = vmConfigToFork(tester.vmConfig, preminedBlock.header.blockNumber)
@@ -625,7 +678,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus, debugMode = fal
   #     - mine block
   # 3 - diff resulting state with expected state
   # 4 - check that all previous blocks were valid
-  let specifyIndex = getConfiguration().index
+  let specifyIndex = test_config.getConfiguration().index
   var fixtureIndex = 0
   var fixtureTested = false
 
@@ -635,7 +688,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus, debugMode = fal
       continue
 
     var tester = parseTester(fixture, testStatusIMPL)
-    var chainDB = newBaseChainDB(newMemoryDb(), pruneTrie = getConfiguration().pruning)
+    var chainDB = newBaseChainDB(newMemoryDb(), pruneTrie = test_config.getConfiguration().pruning)
 
     echo "TESTING: ", fixtureName
     if not tester.good: continue
@@ -670,7 +723,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus, debugMode = fal
     check success == true
 
   if not fixtureTested:
-    echo getConfiguration().testSubject, " not tested at all, wrong index?"
+    echo test_config.getConfiguration().testSubject, " not tested at all, wrong index?"
     if specifyIndex <= 0 or specifyIndex > node.len:
       echo "Maximum subtest available: ", node.len
 
@@ -683,7 +736,7 @@ proc blockchainJsonMain*(debugMode = false) =
       jsonTest("newBlockChainTests", testFixture, skipNewBCTests)
   else:
     # execute single test in debug mode
-    let config = getConfiguration()
+    let config = test_config.getConfiguration()
     if config.testSubject.len == 0:
       echo "missing test subject"
       quit(QuitFailure)
@@ -698,7 +751,7 @@ when isMainModule:
   var message: string
 
   ## Processing command line arguments
-  if processArguments(message) != Success:
+  if test_config.processArguments(message) != test_config.Success:
     echo message
     quit(QuitFailure)
   else:

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -509,9 +509,9 @@ proc importBlock(tester: var Tester, chainDB: BaseChainDB,
   preminedBlock: PlainBlock, fork: Fork, checkSeal, validation = true): PlainBlock =
 
   let parentHeader = chainDB.getBlockHeader(preminedBlock.header.parentHash)
-  let baseHeaderForImport = generateHeaderFromParentHeader(parentHeader,
-      preminedBlock.header.coinbase,
-      fork,
+  let baseHeaderForImport = generateHeaderFromParentHeader(chainDB.config,
+      parentHeader,
+      preminedBlock.header.coinbase,  
       some(preminedBlock.header.timestamp),
       some(preminedBlock.header.gasLimit),
       @[]

--- a/tests/test_difficulty.nim
+++ b/tests/test_difficulty.nim
@@ -70,9 +70,9 @@ proc difficultyMain*() =
     ropstenConfig.calcDifficulty(timeStamp, parent)
 
   suite "DifficultyTest":
-    runTests("EIP2384_random_to20M", true, calcDifficultyGlacierMuir)
-    runTests("EIP2384_random", true, calcDifficultyGlacierMuir)
-    runTests("EIP2384", true, calcDifficultyGlacierMuir)
+    runTests("EIP2384_random_to20M", true, calcDifficultyMuirGlacier)
+    runTests("EIP2384_random", true, calcDifficultyMuirGlacier)
+    runTests("EIP2384", true, calcDifficultyMuirGlacier)
     runTests("Byzantium", true, calcDifficultyByzantium)
     runTests("Constantinople", true, calcDifficultyConstantinople)
     runTests("Homestead", true, calcDifficultyHomestead)

--- a/tests/test_difficulty.nim
+++ b/tests/test_difficulty.nim
@@ -1,7 +1,8 @@
 import unittest2, strutils, tables, os, json,
   ../nimbus/utils/difficulty, stint, times,
   eth/common, test_helpers, stew/byteutils,
-  ../nimbus/constants, ../nimbus/vm/interpreter/vm_forks
+  ../nimbus/constants, ../nimbus/vm/interpreter/vm_forks,
+  ../nimbus/config
 
 type
   Tester = object
@@ -59,10 +60,11 @@ template runTests(name: string, hex: bool, calculator: typed) =
       let diff = calculator(times.fromUnix(t.currentTimeStamp), p)
       check diff == t.currentDifficulty
 
-func calcDifficultyMainNetWork(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
-  calcDifficulty(timeStamp, parent, parent.blockNumber.toFork)
-  
 proc difficultyMain*() =
+  let mainnetConfig = publicChainConfig(MainNet)
+  func calcDifficultyMainNetWork(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
+    mainnetConfig.calcDifficulty(timeStamp, parent)
+
   suite "DifficultyTest":
     runTests("EIP2384_random_to20M", true, calcDifficultyGlacierMuir)
     runTests("EIP2384_random", true, calcDifficultyGlacierMuir)
@@ -72,7 +74,7 @@ proc difficultyMain*() =
     runTests("Homestead", true, calcDifficultyHomestead)
     runTests("MainNetwork", true, calcDifficultyMainNetwork)
     runTests("Frontier", true, calcDifficultyFrontier)
-    runTests("", false, calcDifficulty)
+    runTests("", false, calcDifficultyMainNetWork)
 
 when isMainModule:
   difficultyMain()

--- a/tests/test_difficulty.nim
+++ b/tests/test_difficulty.nim
@@ -65,6 +65,10 @@ proc difficultyMain*() =
   func calcDifficultyMainNetWork(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
     mainnetConfig.calcDifficulty(timeStamp, parent)
 
+  let ropstenConfig = publicChainConfig(RopstenNet)
+  func calcDifficultyRopsten(timeStamp: EthTime, parent: BlockHeader): DifficultyInt =
+    ropstenConfig.calcDifficulty(timeStamp, parent)
+
   suite "DifficultyTest":
     runTests("EIP2384_random_to20M", true, calcDifficultyGlacierMuir)
     runTests("EIP2384_random", true, calcDifficultyGlacierMuir)
@@ -75,6 +79,7 @@ proc difficultyMain*() =
     runTests("MainNetwork", true, calcDifficultyMainNetwork)
     runTests("Frontier", true, calcDifficultyFrontier)
     runTests("", false, calcDifficultyMainNetWork)
+    runTests("Ropsten", true, calcDifficultyRopsten)
 
 when isMainModule:
   difficultyMain()


### PR DESCRIPTION
summary of this PR:
- allow nimbus to sync using testnet configuration
- use one `calcDifficulty` implementation instead of two different implementation
- allow blockchain test to enable DAO fork test
- add ropsten difficulty test
- eliminate `nimbus evm fork` vs `evmc revision` conflict