### PR TITLE
bump vendor/nimbus-build-system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ endif
 #- deletes and recreates "nimbus.nims" which on Windows is a copy instead of a proper symlink
 update: | update-common
 	rm -rf nimbus.nims && \
-		$(MAKE) nimbus.nims
+		$(MAKE) nimbus.nims $(HANDLE_OUTPUT)
 
 # builds the tools, wherever they are
 $(TOOLS): | build deps
@@ -126,7 +126,7 @@ libnimbus.so: | build deps
 
 # libraries for dynamic linking of non-Nim objects
 EXTRA_LIBS_DYNAMIC := -L"$(CURDIR)/build" -lnimbus -lm
-wrappers: | build deps libnimbus.so go-checks
+wrappers: | build deps libnimbus.so
 	echo -e $(BUILD_MSG) "build/C_wrapper_example" && \
 		$(CC) wrappers/wrapper_example.c -Wl,-rpath,'$$ORIGIN' $(EXTRA_LIBS_DYNAMIC) -g -o build/C_wrapper_example
 	echo -e $(BUILD_MSG) "build/go_wrapper_example" && \
@@ -152,7 +152,7 @@ endif # Windows
 ifeq ($(USE_VENDORED_LIBUNWIND), 1)
 EXTRA_LIBS_STATIC := $(EXTRA_LIBS_STATIC) -lunwind
 endif # USE_VENDORED_LIBUNWIND
-wrappers-static: | build deps libnimbus.a go-checks
+wrappers-static: | build deps libnimbus.a
 	echo -e $(BUILD_MSG) "build/C_wrapper_example_static" && \
 		$(CC) wrappers/wrapper_example.c -static -pthread $(EXTRA_LIBS_STATIC) -g -o build/C_wrapper_example_static
 	echo -e $(BUILD_MSG) "build/go_wrapper_example_static" && \

--- a/config.nims
+++ b/config.nims
@@ -35,11 +35,10 @@ else:
 if not defined(macosx):
   # add debugging symbols and original files and line numbers
   --debugger:native
-  if not (defined(windows) and defined(i386)):
+  if not (defined(windows) and defined(i386)) and not defined(disable_libbacktrace):
     # light-weight stack traces using libbacktrace and libunwind
     --define:nimStackTraceOverride
-    # "--import:libbacktrace" is added to NIM_PARAMS inside the Makefile,
-    # because it doesn't work in here ("Error: undeclared identifier: 'copyMem'", like it kicks in in some other NimScript file)
+    switch("import", "libbacktrace")
 
 --define:nimOldCaseObjects # https://github.com/status-im/nim-confutils/issues/9
 # libnimbus.so needs position-independent code

--- a/nimbus/config.nim
+++ b/nimbus/config.nim
@@ -33,12 +33,14 @@ const
   NimbusIdent* = "$1/$2 ($3/$4)" % [NimbusName, NimbusVersion, hostCPU, hostOS]
   ## project ident name for networking services
 
-  gitRevision = staticExec("git rev-parse --short HEAD")
+  GitRevision = staticExec("git rev-parse --short HEAD")
+
+  NimVersion = staticExec("nim --version")
 
 let
   NimbusCopyright* = "Copyright (c) 2018-" & $(now().utc.year) & " Status Research & Development GmbH"
-  NimbusHeader* = "$# Version $# [$#: $#, $#, $#]\p$#" %
-    [NimbusName, NimbusVersion, hostOS, hostCPU, nimbus_db_backend, gitRevision, NimbusCopyright]
+  NimbusHeader* = "$# Version $# [$#: $#, $#, $#]\p$#\p\p$#\p" %
+    [NimbusName, NimbusVersion, hostOS, hostCPU, nimbus_db_backend, GitRevision, NimbusCopyright, NimVersion]
 
 type
   ConfigStatus* = enum


### PR DESCRIPTION
- add the Nim compiler header to the Nimbus header
- also support the USE_LIBBACKTRACE env var