### PR TITLE
Waku: Style: Fix {. .} syntax in objects

### DIFF
--- a/waku/start_network.nim
+++ b/waku/start_network.nim
@@ -22,17 +22,17 @@ type
     topology* {.
       desc: "Set the network topology."
       defaultValue: Star
-      name: "topology" }: Topology
+      name: "topology" .}: Topology
 
     amount* {.
       desc: "Amount of full nodes to be started."
       defaultValue: 4
-      name: "amount" }: int
+      name: "amount" .}: int
 
     testNodePeers* {.
       desc: "Amount of peers a test node should connect to."
       defaultValue: 1
-      name: "test-node-peers" }: int
+      name: "test-node-peers" .}: int
 
   NodeInfo* = object
     cmd: string


### PR DESCRIPTION
"Pragma syntax" for objects are now enclosed in {. .}, which means syntax
highlighting in e.g. NeoVim nim.nvim works.