### PR TITLE
stateless client experiment: switch `state_db` to `accounts_cache`

### DIFF
--- a/nimbus/db/accounts_cache.nim
+++ b/nimbus/db/accounts_cache.nim
@@ -145,13 +145,8 @@ proc isEmpty(acc: RefAccount): bool =
     acc.account.balance.isZero and
     acc.account.nonce == 0
 
-proc exists(acc: RefAccount): bool =
-  if IsAlive notin acc.flags:
-    return false
-  if IsClone in acc.flags:
-    result = true
-  else:
-    result = IsNew notin acc.flags
+template exists(acc: RefAccount): bool =
+  IsAlive in acc.flags
 
 template createTrieKeyFromSlot(slot: UInt256): auto =
   # XXX: This is too expensive. Similar to `createRangeFromAddress`

--- a/nimbus/p2p/dao.nim
+++ b/nimbus/p2p/dao.nim
@@ -1,4 +1,4 @@
-import eth/common, stew/byteutils, ../db/state_db
+import eth/common, stew/byteutils, ../db/accounts_cache
 
 const
   # DAOForkBlockExtra is the block header extra-data field to set for the DAO fork
@@ -135,7 +135,7 @@ const
 # ApplyDAOHardFork modifies the state database according to the DAO hard-fork
 # rules, transferring all balances of a set of DAO accounts to a single refund
 # contract.
-proc applyDAOHardFork*(statedb: var AccountStateDB) =
+proc applyDAOHardFork*(statedb: var AccountsCache) =
   const zero = 0.u256
   # Move every DAO account and extra-balance account funds into the refund contract
   for address in DAODrainList:

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -1,6 +1,6 @@
 import options, sets,
   eth/[common, bloom, trie/db], chronicles, nimcrypto,
-  ../db/[db_chain, state_db],
+  ../db/[db_chain, accounts_cache],
   ../utils, ../constants, ../transaction,
   ../vm_state, ../vm_types, ../vm_state_transactions,
   ../vm/[computation, message],
@@ -42,7 +42,8 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
           debug "state clearing", account
           db.deleteAccount(account)
 
-  vmState.accountDb.updateOriginalRoot()
+  #vmState.accountDb.updateOriginalRoot()
+  vmState.accountDb.persist()
 
 type
   # TODO: these types need to be removed

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -143,6 +143,7 @@ proc processBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, v
   # Reward beneficiary
   vmState.mutateStateDB:
     db.addBalance(header.coinbase, mainReward)
+    db.persist()
 
   let stateDb = vmState.accountDb
   if header.stateRoot != stateDb.rootHash:

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -13,7 +13,7 @@ import
   eth/[common, keys, rlp, p2p], nimcrypto,
   ../transaction, ../config, ../vm_state, ../constants, ../vm_types,
   ../vm_state_transactions, ../utils,
-  ../db/[db_chain, state_db],
+  ../db/[db_chain, accounts_cache],
   rpc_types, rpc_utils, ../vm/[message, computation],
   ../vm/interpreter/vm_forks
 
@@ -166,9 +166,7 @@ proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
     let
       accountDb = accountDbFromTag(quantityTag)
       addrBytes = data.toAddress
-      storage = accountDb.getStorage(addrBytes, quantity.u256)
-    if storage[1]:
-      result = storage[0]
+    result = accountDb.getStorage(addrBytes, quantity.u256)
 
   rpcsrv.rpc("eth_getTransactionCount") do(data: EthAddressStr, quantityTag: string) -> AccountNonce:
     ## Returns the number of transactions sent from an address.

--- a/nimbus/vm/interpreter/opcodes_impl.nim
+++ b/nimbus/vm/interpreter/opcodes_impl.nim
@@ -12,7 +12,7 @@ import
   ./gas_meter, ./gas_costs, ./opcode_values, ./vm_forks,
   ../memory, ../stack, ../code_stream, ../computation,
   ../../vm_state, ../../errors, ../../constants, ../../vm_types,
-  ../../db/[db_chain, state_db]
+  ../../db/[db_chain, accounts_cache]
 
 when defined(evmc_enabled):
   import  ../evmc_api, ../evmc_helpers, evmc/evmc

--- a/nimbus/vm/transaction_tracer.nim
+++ b/nimbus/vm/transaction_tracer.nim
@@ -1,7 +1,7 @@
 import
   json, strutils, sets, hashes,
   chronicles, nimcrypto, eth/common, stint,
-  ../vm_types, memory, stack, ../db/state_db,
+  ../vm_types, memory, stack, ../db/accounts_cache,
   eth/trie/hexary,
   ./interpreter/opcode_values
 
@@ -100,7 +100,7 @@ proc traceOpCodeEnded*(tracer: var TransactionTracer, c: Computation, op: Op, la
     if c.msg.depth < tracer.storageKeys.len:
       var stateDB = c.vmState.accountDb
       for key in tracer.storage(c.msg.depth):
-        let (value, _) = stateDB.getStorage(c.msg.contractAddress, key)
+        let value = stateDB.getStorage(c.msg.contractAddress, key)
         storage[key.dumpHex] = %(value.dumpHex)
       j["storage"] = storage
 

--- a/nimbus/vm_state.nim
+++ b/nimbus/vm_state.nim
@@ -9,7 +9,7 @@ import
   macros, strformat, tables, sets, options,
   eth/common,
   vm/interpreter/[vm_forks, gas_costs],
-  ./constants, ./db/[db_chain, state_db],
+  ./constants, ./db/[db_chain, accounts_cache],
   ./utils, json, vm_types, vm/transaction_tracer,
   ./config
 
@@ -36,7 +36,7 @@ proc init*(self: BaseVMState, prevStateRoot: Hash256, header: BlockHeader,
   self.tracer.initTracer(tracerFlags)
   self.tracingEnabled = TracerFlags.EnableTracing in tracerFlags
   self.logEntries = @[]
-  self.accountDb = newAccountStateDB(chainDB.db, prevStateRoot, chainDB.pruneTrie)
+  self.accountDb = AccountsCache.init(chainDB.db, prevStateRoot, chainDB.pruneTrie)
   self.touchedAccounts = initHashSet[EthAddress]()
 
 proc newBaseVMState*(prevStateRoot: Hash256, header: BlockHeader,

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -10,7 +10,7 @@ import
   options, json, sets,
   ./vm/[memory, stack, code_stream],
   ./vm/interpreter/[gas_costs, opcode_values, vm_forks], # TODO - will be hidden at a lower layer
-  ./db/[db_chain, state_db]
+  ./db/[db_chain, accounts_cache]
 
 when defined(evmc_enabled):
   import ./vm/evmc_api
@@ -26,7 +26,7 @@ type
     tracer*        : TransactionTracer
     logEntries*    : seq[Log]
     receipts*      : seq[Receipt]
-    accountDb*     : AccountStateDB
+    accountDb*     : AccountsCache
     cumulativeGasUsed*: GasInt
     touchedAccounts*: HashSet[EthAddress]
     suicides*      : HashSet[EthAddress]
@@ -55,10 +55,6 @@ type
     accounts*: HashSet[EthAddress]
     storageKeys*: seq[HashSet[Uint256]]
 
-  Snapshot* = object
-    transaction*: DbTransaction
-    intermediateRoot*: Hash256
-
   Computation* = ref object
     # The execution computation
     vmState*:               BaseVMState
@@ -75,7 +71,7 @@ type
     touchedAccounts*:       HashSet[EthAddress]
     suicides*:              HashSet[EthAddress]
     logEntries*:            seq[Log]
-    dbsnapshot*:            Snapshot
+    savePoint*:             SavePoint
     instr*:                 Op
     opIndex*:               int
 

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -301,8 +301,10 @@ proc runVM*(blockNumber: Uint256, chainDB: BaseChainDB, boa: Assembler): bool =
       error "different memory value", idx=i, expected=mem, actual=actual
       return false
 
+  var stateDB = computation.vmState.accountDb
+  stateDB.persist()
+
   var
-    stateDB = computation.vmState.accountDb
     storageRoot = stateDB.getStorageRoot(computation.msg.contractAddress)
     trie = initSecureHexaryTrie(chainDB.db, storageRoot)
 

--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -7,7 +7,7 @@ import
 import
   options, json, os, eth/trie/[db, hexary],
   ../nimbus/[vm_state, vm_types, transaction, utils],
-  ../nimbus/db/[db_chain, state_db],
+  ../nimbus/db/[db_chain, accounts_cache],
   ../nimbus/vm_state_transactions,
   ../nimbus/vm/interpreter/vm_forks,
   ../nimbus/vm/[message, computation, memory]
@@ -303,8 +303,8 @@ proc runVM*(blockNumber: Uint256, chainDB: BaseChainDB, boa: Assembler): bool =
 
   var
     stateDB = computation.vmState.accountDb
-    account = stateDB.getAccount(computation.msg.contractAddress)
-    trie = initSecureHexaryTrie(chainDB.db, account.storageRoot)
+    storageRoot = stateDB.getStorageRoot(computation.msg.contractAddress)
+    trie = initSecureHexaryTrie(chainDB.db, storageRoot)
 
   for kv in boa.storage:
     let key = kv[0].toHex()

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -14,7 +14,7 @@ import
   ../premix/parser, test_config,
   ../nimbus/vm/interpreter/vm_forks,
   ../nimbus/[vm_state, utils, vm_types, errors, transaction, constants],
-  ../nimbus/db/[db_chain, state_db],
+  ../nimbus/db/[db_chain, accounts_cache],
   ../nimbus/utils/header,
   ../nimbus/p2p/[executor, dao],
   ../nimbus/config
@@ -299,6 +299,7 @@ proc assignBlockRewards(minedBlock: PlainBlock, vmState: BaseVMState, fork: Fork
   # Reward beneficiary
   vmState.mutateStateDB:
     db.addBalance(minedBlock.header.coinbase, mainReward)
+    db.persist()
 
   let stateDb = vmState.accountDb
   if minedBlock.header.stateRoot != stateDb.rootHash:
@@ -698,6 +699,7 @@ proc testFixture(node: JsonNode, testStatusIMPL: var TestStatus, debugMode = fal
 
     vmState.mutateStateDB:
       setupStateDB(fixture["pre"], db)
+      db.persist()
 
     let obtainedHash = $(vmState.readOnlyStateDB.rootHash)
     check obtainedHash == $(tester.genesisBlockHeader.stateRoot)

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -96,7 +96,10 @@ proc testFixtureIndexes(tester: Tester, testStatusIMPL: var TestStatus) =
   vmState.mutateStateDB:
     setupStateDB(tester.pre, db)
 
-  #vmState.accountDB.updateOriginalRoot()
+    # this is an important step when using accounts_cache
+    # it will affect the account storage's location
+    # during the next call to `getComittedStorage`
+    db.persist()
 
   defer:
     let obtainedHash = "0x" & `$`(vmState.readOnlyStateDB.rootHash).toLowerAscii
@@ -127,6 +130,12 @@ proc testFixtureIndexes(tester: Tester, testStatusIMPL: var TestStatus) =
       if tester.fork >= FkSpurious:
         if db.isEmptyAccount(miner):
           db.deleteAccount(miner)
+
+      # this is an important step when using accounts_cache
+      # it will affect the account storage's location
+      # during the next call to `getComittedStorage`
+      # and the result of rootHash
+      db.persist()
 
 proc testFixture(fixtures: JsonNode, testStatusIMPL: var TestStatus,
                  trace = false, debugMode = false, supportedForks: set[Fork] = supportedForks) =

--- a/tests/test_generalstate_json.nim
+++ b/tests/test_generalstate_json.nim
@@ -14,7 +14,7 @@ import
   ../nimbus/transaction,
   ../nimbus/[vm_state, vm_types, utils],
   ../nimbus/vm/interpreter,
-  ../nimbus/db/[db_chain, state_db]
+  ../nimbus/db/[db_chain, accounts_cache]
 
 type
   Tester = object
@@ -96,7 +96,7 @@ proc testFixtureIndexes(tester: Tester, testStatusIMPL: var TestStatus) =
   vmState.mutateStateDB:
     setupStateDB(tester.pre, db)
 
-  vmState.accountDB.updateOriginalRoot()
+  #vmState.accountDB.updateOriginalRoot()
 
   defer:
     let obtainedHash = "0x" & `$`(vmState.readOnlyStateDB.rootHash).toLowerAscii

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -149,6 +149,11 @@ proc setupStateDB*(wantedState: JsonNode, stateDB: var AccountsCache) =
     stateDB.setCode(account, code)
     stateDB.setBalance(account, balance)
 
+  # this is an important step when using accounts_cache
+  # it will affect the account storage's location
+  # during the next call to `getComittedStorage`
+  stateDB.persist()
+
 proc verifyStateDB*(wantedState: JsonNode, stateDB: ReadOnlyStateDB) =
   for ac, accountData in wantedState:
     let account = ethAddressFromHex(ac)

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -11,7 +11,7 @@ import
   testutils/markdown_reports,
   ../nimbus/[config, transaction, utils, errors],
   ../nimbus/vm/interpreter/vm_forks,
-  ../nimbus/db/state_db
+  ../nimbus/db/accounts_cache
 
 func revmap(x: Table[Fork, string]): Table[string, Fork] =
   result = initTable[string, Fork]()
@@ -135,7 +135,7 @@ func getHexadecimalInt*(j: JsonNode): int64 =
   data = fromHex(StUInt[64], j.getStr)
   result = cast[int64](data)
 
-proc setupStateDB*(wantedState: JsonNode, stateDB: var AccountStateDB) =
+proc setupStateDB*(wantedState: JsonNode, stateDB: var AccountsCache) =
   for ac, accountData in wantedState:
     let account = ethAddressFromHex(ac)
     for slot, value in accountData{"storage"}:
@@ -157,9 +157,9 @@ proc verifyStateDB*(wantedState: JsonNode, stateDB: ReadOnlyStateDB) =
         slotId = UInt256.fromHex slot
         wantedValue = UInt256.fromHex value.getStr
 
-      let (actualValue, found) = stateDB.getStorage(account, slotId)
-      if not found:
-        raise newException(ValidationError, "account not found:  " & ac)
+      let actualValue = stateDB.getStorage(account, slotId)
+      #if not found:
+      #  raise newException(ValidationError, "account not found:  " & ac)
       if actualValue != wantedValue:
         raise newException(ValidationError, &"{ac} storageDiff: [{slot}] {actualValue.toHex} != {wantedValue.toHex}")
 

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -149,11 +149,6 @@ proc setupStateDB*(wantedState: JsonNode, stateDB: var AccountsCache) =
     stateDB.setCode(account, code)
     stateDB.setBalance(account, balance)
 
-  # this is an important step when using accounts_cache
-  # it will affect the account storage's location
-  # during the next call to `getComittedStorage`
-  stateDB.persist()
-
 proc verifyStateDB*(wantedState: JsonNode, stateDB: ReadOnlyStateDB) =
   for ac, accountData in wantedState:
     let account = ethAddressFromHex(ac)

--- a/tests/test_op_memory.nim
+++ b/tests/test_op_memory.nim
@@ -840,3 +840,6 @@ proc opMemoryMain*() =
         "0x00"
         "0x00"
         "0x0000000000000000000000000000002000000000000000000000000000000000"
+
+when isMainModule:
+  opMemoryMain()

--- a/tests/test_rpc.nim
+++ b/tests/test_rpc.nim
@@ -11,7 +11,7 @@ import
   eth/[rlp, keys], eth/trie/db, eth/p2p/rlpx_protocols/eth_protocol,
   ../nimbus/rpc/[common, p2p, hexstrings, rpc_types],
   ../nimbus/[constants, vm_state, config, genesis],
-  ../nimbus/db/[state_db, db_chain, storage_types],
+  ../nimbus/db/[accounts_cache, db_chain, storage_types],
   ../nimbus/p2p/chain,
   ./rpcclient/test_hexstrings, ./test_helpers
 


### PR DESCRIPTION
unlike state_db, there is no aleth/geth/parity compatibility mode in `accounts_cache`. the compatibility mode works out of the box with `accounts_cache` storage algorithm.

see `state_db.nim` comments for detailed explanation about previously used compatibility mode.

replace the `state_db` with `accounts_cache` is an important step to achieve stateless client. using `accounts_cache` will allow us to easily integrate `multiproof` block witness creation.

`multiproof` block witness will require the contract code `touched state` and also it will pull every addresses involved in a transaction/block. this requirements are provided almost at free cost by `accounts_cache`. the old `state_db` provide nothing for this requirements.