### PR TITLE
syncing with PoA chain

### DIFF
--- a/nimbus/db/geth_db.nim
+++ b/nimbus/db/geth_db.nim
@@ -1,0 +1,35 @@
+import eth/[rlp, common], db_chain, eth/trie/db
+
+const
+  headerPrefix     = 'h'.byte # headerPrefix + num (uint64 big endian) + hash -> header
+  headerHashSuffix = 'n'.byte # headerPrefix + num (uint64 big endian) + headerHashSuffix -> hash
+  blockBodyPrefix  = 'b'.byte # blockBodyPrefix + num (uint64 big endian) + hash -> block body
+
+proc headerHash*(db: BaseChainDB, number: uint64): Hash256 =
+  var key: array[10, byte]
+  key[0] = headerPrefix
+  key[1..8] = toBytesBE(number)[0..^1]
+  key[^1] = headerHashSuffix
+  let res = db.db.get(key)
+  doAssert(res.len == 32)
+  result.data[0..31] = res[0..31]
+
+proc blockHeader*(db: BaseChainDB, hash: Hash256, number: uint64): BlockHeader =
+  var key: array[41, byte]
+  key[0] = headerPrefix
+  key[1..8] = toBytesBE(number)[0..^1]
+  key[9..40] = hash.data[0..^1]
+  let res = db.db.get(key)
+  result = rlp.decode(res, BlockHeader)
+
+proc blockHeader*(db: BaseChainDB, number: uint64): BlockHeader =
+  let hash = db.headerHash(number)
+  db.blockHeader(hash, number)
+
+proc blockBody*(db: BaseChainDB, hash: Hash256, number: uint64): BlockBody =
+  var key: array[41, byte]
+  key[0] = blockBodyPrefix
+  key[1..8] = toBytesBE(number)[0..^1]
+  key[9..40] = hash.data[0..^1]
+  let res = db.db.get(key)
+  result = rlp.decode(res, BlockBody)

--- a/nimbus/p2p/chain.nim
+++ b/nimbus/p2p/chain.nim
@@ -36,7 +36,7 @@ method getAncestorHeader*(c: Chain, h: BlockHeader, output: var BlockHeader, ski
 method getBlockBody*(c: Chain, blockHash: KeccakHash): BlockBodyRef =
   result = nil
 
-method persistBlocks*(c: Chain, headers: openarray[BlockHeader], bodies: openarray[BlockBody]): ValidationResult =
+method persistBlocks*(c: Chain, headers: openarray[BlockHeader], bodies: openarray[BlockBody]): ValidationResult {.gcsafe.} =
   # Run the VM here
   if headers.len != bodies.len:
     debug "Number of headers not matching number of bodies"

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -44,7 +44,7 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
 
   if vmState.generateWitness:
     vmState.accountDb.collectWitnessData()
-  vmState.accountDb.persist()
+  vmState.accountDb.persist(clearCache = false)
 
 type
   # TODO: these types need to be removed
@@ -146,7 +146,7 @@ proc processBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, v
     db.addBalance(header.coinbase, mainReward)
     if vmState.generateWitness:
       db.collectWitnessData()
-    db.persist()
+    db.persist(ClearCache in vmState.flags)
 
   let stateDb = vmState.accountDb
   if header.stateRoot != stateDb.rootHash:

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -26,7 +26,7 @@ proc processTransaction*(tx: Transaction, sender: EthAddress, vmState: BaseVMSta
 
   vmState.cumulativeGasUsed += result
 
-  let miner = vmState.getMinerAddress()
+  let miner = vmState.coinbase()
 
   vmState.mutateStateDB:
     # miner fee

--- a/nimbus/p2p/executor.nim
+++ b/nimbus/p2p/executor.nim
@@ -150,7 +150,10 @@ proc processBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, v
 
   let stateDb = vmState.accountDb
   if header.stateRoot != stateDb.rootHash:
-    error "Wrong state root in block", blockNumber=header.blockNumber, expected=header.stateRoot, actual=stateDb.rootHash, arrivedFrom=chainDB.getCanonicalHead().stateRoot
+    when defined(geth):
+      error "Wrong state root in block", blockNumber=header.blockNumber, expected=header.stateRoot, actual=stateDb.rootHash
+    else:
+      error "Wrong state root in block", blockNumber=header.blockNumber, expected=header.stateRoot, actual=stateDb.rootHash, arrivedFrom=chainDB.getCanonicalHead().stateRoot
     # this one is a show stopper until we are confident in our VM's
     # compatibility with the main chain
     return ValidationResult.Error

--- a/nimbus/rpc/p2p.nim
+++ b/nimbus/rpc/p2p.nim
@@ -86,11 +86,10 @@ proc binarySearchGas(vmState: var BaseVMState, transaction: Transaction, sender:
 
 proc setupEthRpc*(node: EthereumNode, chain: BaseChainDB, rpcsrv: RpcServer) =
 
-  func getAccountDb(header: BlockHeader): ReadOnlyStateDB =
+  proc getAccountDb(header: BlockHeader): ReadOnlyStateDB =
     ## Retrieves the account db from canonical head
-    # TODO: header.stateRoot to prevStateRoot
-    let vmState = newBaseVMState(header.stateRoot, header, chain)
-    result = vmState.readOnlyStateDB()
+    let ac = AccountsCache.init(chain.db, header.stateRoot, chain.pruneTrie)
+    result = ReadOnlyStateDB(ac)
 
   proc accountDbFromTag(tag: string, readOnly = true): ReadOnlyStateDB =
     result = getAccountDb(chain.headerFromTag(tag))

--- a/nimbus/tracer.nim
+++ b/nimbus/tracer.nim
@@ -5,8 +5,15 @@ import
   chronicles, rpc/hexstrings, launcher,
   vm/interpreter/vm_forks, ./config
 
-proc getParentHeader(self: BaseChainDB, header: BlockHeader): BlockHeader =
-  self.getBlockHeader(header.parentHash)
+when defined(geth):
+  import db/geth_db
+
+  proc getParentHeader(db: BaseChainDB, header: BlockHeader): BlockHeader =
+    db.blockHeader(header.blockNumber.truncate(uint64) - 1)
+
+else:
+  proc getParentHeader(self: BaseChainDB, header: BlockHeader): BlockHeader =
+    self.getBlockHeader(header.parentHash)
 
 proc `%`(x: openArray[byte]): JsonNode =
   result = %toHex(x, false)

--- a/nimbus/tracer.nim
+++ b/nimbus/tracer.nim
@@ -87,7 +87,7 @@ proc traceTransaction*(chainDB: BaseChainDB, header: BlockHeader,
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(chainDB.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false) # prune or not prune?
+    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(chainDB.config.chainId)) # prune or not prune?
     vmState = newBaseVMState(parent.stateRoot, header, captureChainDB, tracerFlags + {EnableAccount})
 
   var stateDb = vmState.accountDb
@@ -153,7 +153,7 @@ proc dumpBlockState*(db: BaseChainDB, header: BlockHeader, body: BlockBody, dump
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(db.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false)
+    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(db.config.chainId))
     # we only need stack dump if we want to scan for internal transaction address
     vmState = newBaseVMState(parent.stateRoot, header, captureChainDB, {EnableTracing, DisableMemory, DisableStorage, EnableAccount})
 
@@ -209,7 +209,7 @@ proc traceBlock*(chainDB: BaseChainDB, header: BlockHeader, body: BlockBody, tra
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(chainDB.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false)
+    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(chainDB.config.chainId))
     vmState = newBaseVMState(parent.stateRoot, header, captureChainDB, tracerFlags + {EnableTracing})
 
   if header.txRoot == BLANK_ROOT_HASH: return newJNull()
@@ -243,7 +243,7 @@ proc dumpDebuggingMetaData*(chainDB: BaseChainDB, header: BlockHeader,
     memoryDB = newMemoryDB()
     captureDB = newCaptureDB(chainDB.db, memoryDB)
     captureTrieDB = trieDB captureDB
-    captureChainDB = newBaseChainDB(captureTrieDB, false)
+    captureChainDB = newBaseChainDB(captureTrieDB, false, PublicNetWork(chainDB.config.chainId))
     bloom = createBloom(vmState.receipts)
 
   let blockSummary = %{

--- a/nimbus/vm_state.nim
+++ b/nimbus/vm_state.nim
@@ -75,6 +75,9 @@ method difficulty*(vmState: BaseVMState): UInt256 {.base, gcsafe.} =
 method gasLimit*(vmState: BaseVMState): GasInt {.base, gcsafe.} =
   vmState.blockHeader.gasLimit
 
+when defined(geth):
+  import db/geth_db
+
 method getAncestorHash*(vmState: BaseVMState, blockNumber: BlockNumber): Hash256 {.base, gcsafe.} =
   var ancestorDepth = vmState.blockHeader.blockNumber - blockNumber - 1
   if ancestorDepth >= constants.MAX_PREV_HEADER_DEPTH:
@@ -82,7 +85,10 @@ method getAncestorHash*(vmState: BaseVMState, blockNumber: BlockNumber): Hash256
   if blockNumber >= vmState.blockHeader.blockNumber:
     return
 
-  result = vmState.chainDB.getBlockHash(blockNumber)
+  when defined(geth):
+    result = vmState.chainDB.headerHash(blockNumber.truncate(uint64))
+  else:
+    result = vmState.chainDB.getBlockHash(blockNumber)
   #TODO: should we use deque here?
   # someday we may revive this code when
   # we already have working miner

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -39,6 +39,7 @@ type
     txGasPrice*    : GasInt
     gasCosts*      : GasCosts
     fork*          : Fork
+    minerAddress*  : EthAddress
 
   AccessLogs* = ref object
     reads*: Table[string, string]

--- a/nimbus/vm_types.nim
+++ b/nimbus/vm_types.nim
@@ -19,6 +19,7 @@ type
   VMFlag* = enum
     ExecutionOK
     GenerateWitness
+    ClearCache
 
   BaseVMState* = ref object of RootObj
     prevHeaders*   : seq[BlockHeader]

--- a/premix/persist.nim
+++ b/premix/persist.nim
@@ -3,7 +3,7 @@
 import
   eth/[common, rlp], stint,
   chronicles, downloader, configuration,
-  ../nimbus/errors
+  ../nimbus/[errors, config]
 
 import
   eth/trie/[hexary, db],
@@ -34,10 +34,10 @@ proc main() =
   # 52029 first block with receipts logs
   # 66407 failed transaction
 
-  let conf = getConfiguration()
+  let conf = configuration.getConfiguration()
   let db = newChainDb(conf.dataDir)
   let trieDB = trieDB db
-  let chainDB = newBaseChainDB(trieDB, false)
+  let chainDB = newBaseChainDB(trieDB, false, conf.netId)
 
   # move head to block number ...
   if conf.head != 0.u256:
@@ -93,7 +93,7 @@ when isMainModule:
   var message: string
 
   ## Processing command line arguments
-  if processArguments(message) != Success:
+  if configuration.processArguments(message) != Success:
     echo message
     quit(QuitFailure)
   else:

--- a/tests/test_blockchain_json.nim
+++ b/tests/test_blockchain_json.nim
@@ -18,7 +18,7 @@ import
   ../nimbus/utils/header,
   ../nimbus/p2p/[executor, dao],
   ../nimbus/config,
-  ../stateless/[multi_keys, tree_from_witness, witness_from_tree, witness_types]
+  ../stateless/[tree_from_witness, witness_types]
 
 type
   SealEngine = enum
@@ -283,12 +283,8 @@ proc parseTester(fixture: JsonNode, testStatusIMPL: var TestStatus): Tester =
 
 proc blockWitness(vmState: BaseVMState, fork: Fork, chainDB: BaseChainDB) =
   let rootHash = vmState.accountDb.rootHash
-  let mkeys = vmState.accountDb.makeMultiKeys()
+  let witness = vmState.buildWitness()
   let flags = if fork >= FKSpurious: {wfEIP170} else: {}
-
-  # build witness from tree
-  var wb = initWitnessBuilder(chainDB.db, rootHash, flags)
-  let witness = wb.buildWitness(mkeys)
 
   # build tree from witness
   var db = newMemoryDB()


### PR DESCRIPTION
Because Nimbus has difficulty(slow) syncing with MainNet, I switch to Goerli Testnet and use it's data to extract block witness for stateless client experiment.
This PR allow Nimbus to sync with PoA testnet such as Goerli and Rinkeby.