### PR TITLE
make it compatible with Nim devel and future Nim 1.4

### DIFF
--- a/tests/macro_assembler.nim
+++ b/tests/macro_assembler.nim
@@ -170,7 +170,10 @@ proc parseCode(codes: NimNode): seq[byte] =
 
 proc parseFork(fork: NimNode): Fork =
   fork[0].expectKind({nnkIdent, nnkStrLit})
-  parseEnum[Fork](strip(fork[0].strVal))
+  when (NimMajor, NimMinor) < (1, 3):
+    parseEnum[Fork](strip(fork[0].strVal))
+  else:
+    parseEnum[Fork](strip("Fk" & fork[0].strVal))
 
 proc generateVMProxy(boa: Assembler): NimNode =
   let


### PR DESCRIPTION
Based on my testing with `make USE_SYSTEM_NIM=1 test`, this is the only change required for `nimbus` to work with both the current stable version of Nim (1.2.x) and the latest devel version of Nim (1.3.x) which will become next stable version (1.4.x) at some point.