### PR TITLE
write `Fork` enum in a "modern way"

### DIFF
--- a/nimbus/vm/interpreter/vm_forks.nim
+++ b/nimbus/vm/interpreter/vm_forks.nim
@@ -9,22 +9,11 @@ import stint, eth/common/eth_types
 
 type
   Fork* = enum
-    FkFrontier,
-    FkHomestead,
-    FkTangerine,
-    FkSpurious,
-    FkByzantium,
-    FkConstantinople,
-    FkPetersburg,
-    FkIstanbul
-
-proc `$`*(fork: Fork): string =
-  case fork
-  of FkFrontier: result = "Frontier"
-  of FkHomestead: result = "Homestead"
-  of FkTangerine: result = "Tangerine Whistle"
-  of FkSpurious: result = "Spurious Dragon"
-  of FkByzantium: result = "Byzantium"
-  of FkConstantinople: result = "Constantinople"
-  of FkPetersburg: result = "Petersburg"
-  of FkIstanbul: result = "Istanbul"
+    FkFrontier = "frontier"
+    FkHomestead = "homestead"
+    FkTangerine = "tangerine whistle"
+    FkSpurious = "spurious dragon"
+    FkByzantium = "byzantium"
+    FkConstantinople = "constantinople"
+    FkPetersburg = "petersburg"
+    FkIstanbul = "istanbul"


### PR DESCRIPTION
This provides the same functionality as `$` proc, but it keeps working
with Nim 1.3+, where `parseEnum` implementation has been changed to be
able to work with enums with holes (after a bugfix for them).

Note that the first character is case-sensitive and "Constantinople" !=
"constantinople".
Since the tests (`test_op_arith` and `test_op_bit`) use lower-case first
letter, the string representation is also changed to the lower-case.